### PR TITLE
feat: Slashing hooks

### DIFF
--- a/examples/IncredibleSquaringBlueprint.sol
+++ b/examples/IncredibleSquaringBlueprint.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-import "core/BlueprintServiceManager.sol";
+import "core/BlueprintServiceManagerBase.sol";
 
 /**
  * @title IncredibleSquaringBlueprint
@@ -9,13 +9,13 @@ import "core/BlueprintServiceManager.sol";
  * service to square a number. It demonstrates the lifecycle hooks that can be
  * implemented in a service blueprint.
  */
-
-contract IncredibleSquaringBlueprint is BlueprintServiceManager {
+contract IncredibleSquaringBlueprint is BlueprintServiceManagerBase {
     /**
      * @dev A mapping of all service operators registered with the blueprint.
      * The key is the operator's address and the value is the operator's details.
      */
     mapping(address => bytes) public operators;
+
     /**
      * @dev A mapping of all service instances requested from the blueprint.
      * The key is the service ID and the value is the service operator's address.
@@ -52,47 +52,49 @@ contract IncredibleSquaringBlueprint is BlueprintServiceManager {
     ) public payable override onlyFromRootChain {
         // store the service instance request
         for (uint i = 0; i < operators.length; i++) {
-            address operatorAddress = operatorAddressFromPublicKey(operators[i]);
+            address operatorAddress = operatorAddressFromPublicKey(
+                operators[i]
+            );
             serviceInstances[serviceId].push(operatorAddress);
         }
     }
 
     /**
-     * @dev Hook for handling job call results. Called when operators send the result
+     * @dev Hook for job calls on the service. Called when a job is called within
+     * the service context.
+     * @param serviceId The ID of the service where the job is called.
+     * @param job The job identifier.
+     * @param jobCallId A unique ID for the job call.
+     * @param inputs Inputs required for the job execution in bytes format.
+     */
+    function onJobCall(
+        uint64 serviceId,
+        uint8 job,
+        uint64 jobCallId,
+        bytes calldata inputs
+    ) public payable override onlyFromRootChain {
+        // Implement job call logic here
+    }
+
+    /**
+     * @dev Hook for handling job result. Called when operators send the result
      * of a job execution.
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
-     * @param _jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) sending the result.
-     * @param _inputs Inputs used for the job execution.
-     * @param _outputs Outputs resulting from the job execution.
+     * @param jobCallId The unique ID for the job call.
+     * @param operator The operator (operator) sending the result in bytes format.
+     * @param inputs Inputs used for the job execution in bytes format.
+     * @param outputs Outputs resulting from the job execution in bytes format.
      */
-    function onJobCallResult(
+    function onJobResult(
         uint64 serviceId,
         uint8 job,
-        uint64 _jobCallId,
-        bytes calldata participant,
-        bytes calldata _inputs,
-        bytes calldata _outputs
+        uint64 jobCallId,
+        bytes calldata operator,
+        bytes calldata inputs,
+        bytes calldata outputs
     ) public virtual override onlyFromRootChain {
-        // check that we have this service instance
-        require(
-            serviceInstances[serviceId].length > 0,
-            "Service instance not found"
-        );
-        // check if job is zero.
-        require(job == 0, "Job not found");
-        // Check if the participant is a registered operator
-        address operatorAddress = address(bytes20(keccak256(participant)));
-        require(
-            operators[operatorAddress].length > 0,
-            "Operator not registered"
-        );
-        // Check if operator is part of the service instance
-        require(
-            isOperatorInServiceInstance(serviceId, operatorAddress),
-            "Operator not part of service instance"
-        );
+        // Do something with the job result
     }
 
     /**
@@ -101,28 +103,28 @@ contract IncredibleSquaringBlueprint is BlueprintServiceManager {
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
      * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) whose result is being verified.
+     * @param operator The operator (operator) whose result is being verified.
      * @param inputs Inputs used for the job execution.
      * @param outputs Outputs resulting from the job execution.
      * @return bool Returns true if the job call result is verified successfully,
      * otherwise false.
      */
-    function verifyJobCallResult(
+    function verifyResult(
         uint64 serviceId,
         uint8 job,
         uint64 jobCallId,
-        bytes calldata participant,
+        bytes calldata operator,
         bytes calldata inputs,
         bytes calldata outputs
-    ) public view virtual override onlyFromRootChain returns (bool) {
+    ) public view returns (bool) {
         // Someone requested to verify the result of a job call.
         // We need to check if the output is the square of the input.
 
         // check if job is zero.
         require(job == 0, "Job not found");
-        // Check if the participant is a registered operator, so we can slash
+        // Check if the operator is a registered operator, so we can slash
         // their stake if they are cheating.
-        address operatorAddress = operatorAddressFromPublicKey(participant);
+        address operatorAddress = operatorAddressFromPublicKey(operator);
         require(
             operators[operatorAddress].length > 0,
             "Operator not registered"
@@ -139,7 +141,9 @@ contract IncredibleSquaringBlueprint is BlueprintServiceManager {
         bool isValid = output == input * input;
         if (!isValid) {
             // Slash the operator's stake if the result is invalid
-            // slashStake(operatorAddress);
+            // Using ServicesPrecompile to slash the operator's stake
+            // slashPercent = 10; // 10% slash
+            // ServicesPrecompile.slash(serviceId, operator, slashPercent);
         }
 
         return isValid;
@@ -157,12 +161,9 @@ contract IncredibleSquaringBlueprint is BlueprintServiceManager {
         return false;
     }
 
-
-    function operatorAddressFromPublicKey(bytes calldata publicKey)
-        public
-        pure
-        returns (address)
-    {
+    function operatorAddressFromPublicKey(
+        bytes calldata publicKey
+    ) public pure returns (address) {
         return address(uint160(uint256(keccak256(publicKey))));
     }
 }

--- a/examples/IncredibleSquaringBlueprint.sol
+++ b/examples/IncredibleSquaringBlueprint.sol
@@ -93,7 +93,7 @@ contract IncredibleSquaringBlueprint is BlueprintServiceManagerBase {
         bytes calldata operator,
         bytes calldata inputs,
         bytes calldata outputs
-    ) public virtual override onlyFromRootChain {
+    ) public payable virtual override onlyFromRootChain {
         // Do something with the job result
     }
 

--- a/src/BlueprintServiceManager.sol
+++ b/src/BlueprintServiceManager.sol
@@ -16,8 +16,8 @@ contract BlueprintServiceManager is RootChainEnabled {
     /**
      * @dev Hook for service operator registration. Called when a service operator
      * attempts to register with the blueprint.
-     * @param operator The operator's details.
-     * @param registrationInputs Inputs required for registration.
+     * @param operator The operator's details in bytes format.
+     * @param registrationInputs Inputs required for registration in bytes format.
      */
     function onRegister(bytes calldata operator, bytes calldata registrationInputs) public payable virtual onlyFromRootChain { }
 
@@ -25,8 +25,8 @@ contract BlueprintServiceManager is RootChainEnabled {
      * @dev Hook for service instance requests. Called when a user requests a service
      * instance from the blueprint.
      * @param serviceId The ID of the requested service.
-     * @param operators The operators involved in the service.
-     * @param requestInputs Inputs required for the service request.
+     * @param operators The operators involved in the service in bytes array format.
+     * @param requestInputs Inputs required for the service request in bytes format.
      */
     function onRequest(
         uint64 serviceId,
@@ -45,7 +45,7 @@ contract BlueprintServiceManager is RootChainEnabled {
      * @param serviceId The ID of the service where the job is called.
      * @param job The job identifier.
      * @param jobCallId A unique ID for the job call.
-     * @param inputs Inputs required for the job execution.
+     * @param inputs Inputs required for the job execution in bytes format.
      */
     function onJobCall(
         uint64 serviceId,
@@ -65,9 +65,9 @@ contract BlueprintServiceManager is RootChainEnabled {
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
      * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) sending the result.
-     * @param inputs Inputs used for the job execution.
-     * @param outputs Outputs resulting from the job execution.
+     * @param participant The participant (operator) sending the result in bytes format.
+     * @param inputs Inputs used for the job execution in bytes format.
+     * @param outputs Outputs resulting from the job execution in bytes format.
      */
     function onJobCallResult(
         uint64 serviceId,
@@ -88,9 +88,9 @@ contract BlueprintServiceManager is RootChainEnabled {
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
      * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) whose result is being verified.
-     * @param inputs Inputs used for the job execution.
-     * @param outputs Outputs resulting from the job execution.
+     * @param participant The participant (operator) whose result is being verified in bytes format.
+     * @param inputs Inputs used for the job execution in bytes format.
+     * @param outputs Outputs resulting from the job execution in bytes format.
      * @return bool Returns true if the job call result is verified successfully,
      * otherwise false.
      */
@@ -107,5 +107,41 @@ contract BlueprintServiceManager is RootChainEnabled {
         virtual
         onlyFromRootChain
         returns (bool)
+    { }
+
+    /**
+     * @dev Hook for handling unapplied slashes. Called when a slash is queued and still not yet applied to an offender.
+     * @param serviceId The ID of the service related to the slash.
+     * @param offender The offender's details in bytes format.
+     * @param slashPercent The percentage of the slash.
+     * @param totalPayout The total payout amount in wei.
+     */
+    function onUnappliedSlash(
+        uint64 serviceId,
+        bytes calldata offender,
+        uint8 slashPercent,
+        uint256 totalPayout
+    )
+        public
+        virtual
+        onlyFromRootChain
+    { }
+
+    /**
+     * @dev Hook for handling applied slashes. Called when a slash is applied to an offender.
+     * @param serviceId The ID of the service related to the slash.
+     * @param offender The offender's details in bytes format.
+     * @param slashPercent The percentage of the slash.
+     * @param totalPayout The total payout amount in wei.
+     */
+    function onSlash(
+        uint64 serviceId,
+        bytes calldata offender,
+        uint8 slashPercent,
+        uint256 totalPayout
+    )
+        public
+        virtual
+        onlyFromRootChain
     { }
 }

--- a/src/BlueprintServiceManager.sol
+++ b/src/BlueprintServiceManager.sol
@@ -144,4 +144,19 @@ contract BlueprintServiceManager is RootChainEnabled {
         virtual
         onlyFromRootChain
     { }
+
+    /**
+     * @dev Query the slashing origins for a service. This mainly used by the runtime to determine the allowed list of accounts
+     * that can slash a service. by default, the service manager is the only account that can slash a service. override this
+     * function
+     * to allow other accounts to slash a service.
+     * @param serviceId The ID of the service.
+     * @return slashingOrigins The list of accounts that can slash the service.
+     */
+    function querySlashingOrigins(uint64 serviceId) public view virtual returns (address[] memory slashingOrigins) {
+        slashingOrigins = new address[](1);
+        slashingOrigins[0] = address(this);
+
+        return slashingOrigins;
+    }
 }

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.19;
 
 import "core/Permissions.sol";
+import "core/IBlueprintServiceManager.sol";
 
 /**
- * @title BlueprintServiceManager
+ * @title BlueprintServiceManagerBase
  * @dev This contract acts as a manager for the lifecycle of a Blueprint Instance,
  * facilitating various stages such as registration, service requests, job execution,
  * and job result handling. It is designed to be used by the service blueprint designer
@@ -12,14 +13,23 @@ import "core/Permissions.sol";
  * Each function serves as a hook for different lifecycle events, and reverting any
  * of these functions interrupts the process flow.
  */
-contract BlueprintServiceManager is RootChainEnabled {
+contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabled {
     /**
      * @dev Hook for service operator registration. Called when a service operator
      * attempts to register with the blueprint.
      * @param operator The operator's details in bytes format.
      * @param registrationInputs Inputs required for registration in bytes format.
      */
-    function onRegister(bytes calldata operator, bytes calldata registrationInputs) public payable virtual onlyFromRootChain { }
+    function onRegister(
+        bytes calldata operator,
+        bytes calldata registrationInputs
+    )
+        public
+        payable
+        virtual
+        override
+        onlyFromRootChain
+    { }
 
     /**
      * @dev Hook for service instance requests. Called when a user requests a service
@@ -36,11 +46,12 @@ contract BlueprintServiceManager is RootChainEnabled {
         public
         payable
         virtual
+        override
         onlyFromRootChain
     { }
 
     /**
-     * @dev Hook for job calls on the service. Called when a job is executed within
+     * @dev Hook for job calls on the service. Called when a job is called within
      * the service context.
      * @param serviceId The ID of the service where the job is called.
      * @param job The job identifier.
@@ -56,11 +67,12 @@ contract BlueprintServiceManager is RootChainEnabled {
         public
         payable
         virtual
+        override
         onlyFromRootChain
     { }
 
     /**
-     * @dev Hook for handling job call results. Called when operators send the result
+     * @dev Hook for handling job result. Called when operators send the result
      * of a job execution.
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
@@ -69,7 +81,7 @@ contract BlueprintServiceManager is RootChainEnabled {
      * @param inputs Inputs used for the job execution in bytes format.
      * @param outputs Outputs resulting from the job execution in bytes format.
      */
-    function onJobCallResult(
+    function onJobResult(
         uint64 serviceId,
         uint8 job,
         uint64 jobCallId,
@@ -79,34 +91,8 @@ contract BlueprintServiceManager is RootChainEnabled {
     )
         public
         virtual
+        override
         onlyFromRootChain
-    { }
-
-    /**
-     * @dev Verifies the result of a job call. This function is used to validate the
-     * outputs of a job execution against the expected results.
-     * @param serviceId The ID of the service related to the job.
-     * @param job The job identifier.
-     * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) whose result is being verified in bytes format.
-     * @param inputs Inputs used for the job execution in bytes format.
-     * @param outputs Outputs resulting from the job execution in bytes format.
-     * @return bool Returns true if the job call result is verified successfully,
-     * otherwise false.
-     */
-    function verifyJobCallResult(
-        uint64 serviceId,
-        uint8 job,
-        uint64 jobCallId,
-        bytes calldata participant,
-        bytes calldata inputs,
-        bytes calldata outputs
-    )
-        public
-        view
-        virtual
-        onlyFromRootChain
-        returns (bool)
     { }
 
     /**
@@ -124,6 +110,7 @@ contract BlueprintServiceManager is RootChainEnabled {
     )
         public
         virtual
+        override
         onlyFromRootChain
     { }
 
@@ -142,21 +129,18 @@ contract BlueprintServiceManager is RootChainEnabled {
     )
         public
         virtual
+        override
         onlyFromRootChain
     { }
 
     /**
-     * @dev Query the slashing origins for a service. This mainly used by the runtime to determine the allowed list of accounts
+     * @dev Query the slashing origin for a service. This mainly used by the runtime to determine the allowed account
      * that can slash a service. by default, the service manager is the only account that can slash a service. override this
-     * function
-     * to allow other accounts to slash a service.
+     * function to allow other accounts to slash a service.
      * @param serviceId The ID of the service.
-     * @return slashingOrigins The list of accounts that can slash the service.
+     * @return slashingOrigin The list of accounts that can slash the service.
      */
-    function querySlashingOrigins(uint64 serviceId) public view virtual returns (address[] memory slashingOrigins) {
-        slashingOrigins = new address[](1);
-        slashingOrigins[0] = address(this);
-
-        return slashingOrigins;
+    function querySlashingOrigin(uint64 serviceId) public view virtual override returns (address slashingOrigin) {
+        return address(this);
     }
 }

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -90,6 +90,7 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabl
         bytes calldata outputs
     )
         public
+        payable
         virtual
         override
         onlyFromRootChain

--- a/src/IBlueprintServiceManager.sol
+++ b/src/IBlueprintServiceManager.sol
@@ -52,7 +52,8 @@ interface IBlueprintServiceManager {
         bytes calldata inputs,
         bytes calldata outputs
     )
-        external;
+        external
+        payable;
 
     /**
      * @dev Hook for handling unapplied slashes. Called when a slash is queued and still not yet applied to an offender.

--- a/src/IBlueprintServiceManager.sol
+++ b/src/IBlueprintServiceManager.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+/**
+ * @title IBlueprintServiceManager
+ * @dev Interface for the BlueprintServiceManager contract, which acts as a manager for the lifecycle of a Blueprint Instance,
+ * facilitating various stages such as registration, service requests, job execution, and job result handling.
+ */
+interface IBlueprintServiceManager {
+    /**
+     * @dev Hook for service operator registration. Called when a service operator
+     * attempts to register with the blueprint.
+     * @param operator The operator's details in bytes format.
+     * @param registrationInputs Inputs required for registration in bytes format.
+     */
+    function onRegister(bytes calldata operator, bytes calldata registrationInputs) external payable;
+
+    /**
+     * @dev Hook for service instance requests. Called when a user requests a service
+     * instance from the blueprint.
+     * @param serviceId The ID of the requested service.
+     * @param operators The operators involved in the service in bytes array format.
+     * @param requestInputs Inputs required for the service request in bytes format.
+     */
+    function onRequest(uint64 serviceId, bytes[] calldata operators, bytes calldata requestInputs) external payable;
+
+    /**
+     * @dev Hook for job calls on the service. Called when a job is called within
+     * the service context.
+     * @param serviceId The ID of the service where the job is called.
+     * @param job The job identifier.
+     * @param jobCallId A unique ID for the job call.
+     * @param inputs Inputs required for the job execution in bytes format.
+     */
+    function onJobCall(uint64 serviceId, uint8 job, uint64 jobCallId, bytes calldata inputs) external payable;
+
+    /**
+     * @dev Hook for handling job result. Called when operators send the result
+     * of a job execution.
+     * @param serviceId The ID of the service related to the job.
+     * @param job The job identifier.
+     * @param jobCallId The unique ID for the job call.
+     * @param participant The participant (operator) sending the result in bytes format.
+     * @param inputs Inputs used for the job execution in bytes format.
+     * @param outputs Outputs resulting from the job execution in bytes format.
+     */
+    function onJobResult(
+        uint64 serviceId,
+        uint8 job,
+        uint64 jobCallId,
+        bytes calldata participant,
+        bytes calldata inputs,
+        bytes calldata outputs
+    )
+        external;
+
+    /**
+     * @dev Hook for handling unapplied slashes. Called when a slash is queued and still not yet applied to an offender.
+     * @param serviceId The ID of the service related to the slash.
+     * @param offender The offender's details in bytes format.
+     * @param slashPercent The percentage of the slash.
+     * @param totalPayout The total payout amount in wei.
+     */
+    function onUnappliedSlash(uint64 serviceId, bytes calldata offender, uint8 slashPercent, uint256 totalPayout) external;
+
+    /**
+     * @dev Hook for handling applied slashes. Called when a slash is applied to an offender.
+     * @param serviceId The ID of the service related to the slash.
+     * @param offender The offender's details in bytes format.
+     * @param slashPercent The percentage of the slash.
+     * @param totalPayout The total payout amount in wei.
+     */
+    function onSlash(uint64 serviceId, bytes calldata offender, uint8 slashPercent, uint256 totalPayout) external;
+
+    /**
+     * @dev Query the slashing origin for a service. This mainly used by the runtime to determine the allowed account
+     * that can slash a service. by default, the service manager is the only account that can slash a service. override this
+     * function to allow other accounts to slash a service.
+     * @param serviceId The ID of the service.
+     * @return slashingOrigin The list of accounts that can slash the service.
+     */
+    function querySlashingOrigin(uint64 serviceId) external view returns (address slashingOrigin);
+}


### PR DESCRIPTION
This pull request refactors the `IncredibleSquaringBlueprint` contract by replacing `BlueprintServiceManager` with `BlueprintServiceManagerBase` and introduces an interface for the blueprint service manager. The most important changes include updating the contract inheritance, modifying function names and parameters, and adding new hooks for job calls and results.

### Refactoring and Code Simplification:

* [`examples/IncredibleSquaringBlueprint.sol`](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L4-R18): Updated the contract to inherit from `BlueprintServiceManagerBase` instead of `BlueprintServiceManager`. This change includes renaming functions and adjusting their parameters to use bytes format for inputs and outputs. [[1]](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L4-R18) [[2]](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L55-R97) [[3]](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L104-R127) [[4]](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L142-R146) [[5]](diffhunk://#diff-20f8b4fc97347460989c3c04ed844c50fbffe4c4765481426abcd2eb74a294a1L160-R166)

### Removal of Old Manager Contract:

* [`src/BlueprintServiceManager.sol`](diffhunk://#diff-08c09a4fb860c77cd4467165b47b475fcc2045ab0c2522acb4c1cb189b6ff6c1L1-L111): Removed the old `BlueprintServiceManager` contract, which included lifecycle hooks for service operator registration, service instance requests, job execution, and job result handling.

### Introduction of New Manager Base Contract:

* [`src/BlueprintServiceManagerBase.sol`](diffhunk://#diff-6fe79b83efb9fdfb7f295ea335ff1232519b7ed772eec108195efd47df7bef91R1-R146): Added a new base contract `BlueprintServiceManagerBase` that implements the `IBlueprintServiceManager` interface. This contract includes hooks for service operator registration, service instance requests, job calls, job results, and slashing operations.

### Addition of Interface for Blueprint Service Manager:

* [`src/IBlueprintServiceManager.sol`](diffhunk://#diff-d5a72da0582dfb5e9d96eddf40c940f7a3d90018136cfefd3139bb388dde2ec4R1-R83): Introduced an interface `IBlueprintServiceManager` to define the hooks for managing the lifecycle of a Blueprint Instance, including registration, service requests, job execution, job results, and slashing operations.