### PR TITLE
feat: add Dispute Origin

### DIFF
--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -144,4 +144,16 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabl
     function querySlashingOrigin(uint64 serviceId) public view virtual override returns (address slashingOrigin) {
         return address(this);
     }
+
+    /**
+     * @dev Query the dispute origin for a service. This mainly used by the runtime to determine the allowed account
+     * that can dispute an unapplied slash and remove it. by default, the service manager is the only account that can dispute a
+     * service. override this
+     * function to allow other accounts to dispute a service.
+     * @param serviceId The ID of the service.
+     * @return disputeOrigin The account that can dispute the unapplied slash for that service
+     */
+    function queryDisputeOrigin(uint64 serviceId) public view virtual override returns (address disputeOrigin) {
+        return address(this);
+    }
 }

--- a/src/IBlueprintServiceManager.sol
+++ b/src/IBlueprintServiceManager.sol
@@ -78,7 +78,17 @@ interface IBlueprintServiceManager {
      * that can slash a service. by default, the service manager is the only account that can slash a service. override this
      * function to allow other accounts to slash a service.
      * @param serviceId The ID of the service.
-     * @return slashingOrigin The list of accounts that can slash the service.
+     * @return slashingOrigin The account that can slash the offender.
      */
     function querySlashingOrigin(uint64 serviceId) external view returns (address slashingOrigin);
+
+    /**
+     * @dev Query the dispute origin for a service. This mainly used by the runtime to determine the allowed account
+     * that can dispute an unapplied slash and remove it. by default, the service manager is the only account that can dispute a
+     * service. override this
+     * function to allow other accounts to dispute a service.
+     * @param serviceId The ID of the service.
+     * @return disputeOrigin The account that can dispute the unapplied slash for that service
+     */
+    function queryDisputeOrigin(uint64 serviceId) external view returns (address disputeOrigin);
 }


### PR DESCRIPTION
This pull request introduces a new function to query the dispute origin for a service in the `BlueprintServiceManager` contract. The most important changes include adding the `queryDisputeOrigin` function to both the `BlueprintServiceManagerBase` contract and the `IBlueprintServiceManager` interface.

### Additions:

* [`src/BlueprintServiceManagerBase.sol`](diffhunk://#diff-6fe79b83efb9fdfb7f295ea335ff1232519b7ed772eec108195efd47df7bef91R147-R158): Added the `queryDisputeOrigin` function to allow querying the account that can dispute an unapplied slash for a service.
* [`src/IBlueprintServiceManager.sol`](diffhunk://#diff-d5a72da0582dfb5e9d96eddf40c940f7a3d90018136cfefd3139bb388dde2ec4L81-R93): Added the `queryDisputeOrigin` function to the interface to define the contract's external view.