### PR TITLE
feat!: Add More Hooks to the blueprint service manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722676286,
-        "narHash": "sha256-wEDJdvwRZF2ErQ33nQ0Lqn/48XrPbaadv56/bM2MSZU=",
+        "lastModified": 1730625090,
+        "narHash": "sha256-lWfkkj+GEUM0UqYLD2Rx3zzILTL3xdmGJKGR4fwONpA=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "d84c83b1c1722c8742b3d2d84c9386814d75384e",
+        "rev": "1c6a742bcbfd55a80de0e1f967a60174716a1560",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723703277,
-        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -6,6 +6,7 @@ import "src/IBlueprintServiceManager.sol";
 
 /**
  * @title BlueprintServiceManagerBase
+ * @author Tangle Network Team
  * @dev This contract acts as a manager for the lifecycle of a Blueprint Instance,
  * facilitating various stages such as registration, service requests, job execution,
  * and job result handling. It is designed to be used by the service blueprint designer
@@ -14,73 +15,80 @@ import "src/IBlueprintServiceManager.sol";
  * of these functions interrupts the process flow.
  */
 contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabled {
-    /**
-     * @dev Hook for service operator registration. Called when a service operator
-     * attempts to register with the blueprint.
-     * @param operator The operator's details in bytes format.
-     * @param registrationInputs Inputs required for registration in bytes format.
-     */
+    /// @inheritdoc IBlueprintServiceManager
     function onRegister(
-        bytes calldata operator,
+        OperatorPreferences calldata operator,
         bytes calldata registrationInputs
     )
-        public
+        external
         payable
-        virtual
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Hook for service instance requests. Called when a user requests a service
-     * instance from the blueprint.
-     * @param serviceId The ID of the requested service.
-     * @param operators The operators involved in the service in bytes array format.
-     * @param requestInputs Inputs required for the service request in bytes format.
-     */
+    /// @inheritdoc IBlueprintServiceManager
+    function onUnregister(OperatorPreferences calldata operator) external override onlyFromRootChain { }
+
+    /// @inheritdoc IBlueprintServiceManager
+    function onUpdatePriceTargets(OperatorPreferences calldata operator) external payable override onlyFromRootChain { }
+
+    /// @inheritdoc IBlueprintServiceManager
     function onRequest(
-        uint64 serviceId,
-        bytes[] calldata operators,
-        bytes calldata requestInputs
+        uint64 requestId,
+        address requester,
+        OperatorPreferences[] calldata operators,
+        bytes calldata requestInputs,
+        address[] calldata permittedCallers,
+        uint64 ttl
     )
-        public
+        external
         payable
-        virtual
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Hook for job calls on the service. Called when a job is called within
-     * the service context.
-     * @param serviceId The ID of the service where the job is called.
-     * @param job The job identifier.
-     * @param jobCallId A unique ID for the job call.
-     * @param inputs Inputs required for the job execution in bytes format.
-     */
+    /// @inheritdoc IBlueprintServiceManager
+    function onApprove(
+        OperatorPreferences calldata operator,
+        uint64 requestId,
+        uint8 restakingPercent
+    )
+        external
+        payable
+        override
+        onlyFromRootChain
+    { }
+
+    /// @inheritdoc IBlueprintServiceManager
+    function onReject(OperatorPreferences calldata operator, uint64 requestId) external override onlyFromRootChain { }
+
+    /// @inheritdoc IBlueprintServiceManager
+    function onServiceInitialized(
+        uint64 requestId,
+        uint64 serviceId,
+        address owner,
+        address[] calldata permittedCallers,
+        uint64 ttl
+    )
+        external
+        override
+        onlyFromRootChain
+    { }
+
+    /// @inheritdoc IBlueprintServiceManager
     function onJobCall(
         uint64 serviceId,
         uint8 job,
         uint64 jobCallId,
         bytes calldata inputs
     )
-        public
+        external
         payable
-        virtual
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Hook for handling job result. Called when operators send the result
-     * of a job execution.
-     * @param serviceId The ID of the service related to the job.
-     * @param job The job identifier.
-     * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) sending the result in bytes format.
-     * @param inputs Inputs used for the job execution in bytes format.
-     * @param outputs Outputs resulting from the job execution in bytes format.
-     */
+    /// @inheritdoc IBlueprintServiceManager
     function onJobResult(
         uint64 serviceId,
         uint8 job,
@@ -89,71 +97,46 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabl
         bytes calldata inputs,
         bytes calldata outputs
     )
-        public
+        external
         payable
-        virtual
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Hook for handling unapplied slashes. Called when a slash is queued and still not yet applied to an offender.
-     * @param serviceId The ID of the service related to the slash.
-     * @param offender The offender's details in bytes format.
-     * @param slashPercent The percentage of the slash.
-     * @param totalPayout The total payout amount in wei.
-     */
+    /// @inheritdoc IBlueprintServiceManager
+    function onServiceTermination(uint64 serviceId, address owner) external override onlyFromRootChain { }
+
+    /// @inheritdoc IBlueprintServiceManager
     function onUnappliedSlash(
         uint64 serviceId,
         bytes calldata offender,
         uint8 slashPercent,
         uint256 totalPayout
     )
-        public
-        virtual
+        external
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Hook for handling applied slashes. Called when a slash is applied to an offender.
-     * @param serviceId The ID of the service related to the slash.
-     * @param offender The offender's details in bytes format.
-     * @param slashPercent The percentage of the slash.
-     * @param totalPayout The total payout amount in wei.
-     */
+    /// @inheritdoc IBlueprintServiceManager
     function onSlash(
         uint64 serviceId,
         bytes calldata offender,
         uint8 slashPercent,
         uint256 totalPayout
     )
-        public
-        virtual
+        external
         override
         onlyFromRootChain
     { }
 
-    /**
-     * @dev Query the slashing origin for a service. This mainly used by the runtime to determine the allowed account
-     * that can slash a service. by default, the service manager is the only account that can slash a service. override this
-     * function to allow other accounts to slash a service.
-     * @param serviceId The ID of the service.
-     * @return slashingOrigin The list of accounts that can slash the service.
-     */
-    function querySlashingOrigin(uint64 serviceId) public view virtual override returns (address slashingOrigin) {
+    /// @inheritdoc IBlueprintServiceManager
+    function querySlashingOrigin(uint64) external view override returns (address slashingOrigin) {
         return address(this);
     }
 
-    /**
-     * @dev Query the dispute origin for a service. This mainly used by the runtime to determine the allowed account
-     * that can dispute an unapplied slash and remove it. by default, the service manager is the only account that can dispute a
-     * service. override this
-     * function to allow other accounts to dispute a service.
-     * @param serviceId The ID of the service.
-     * @return disputeOrigin The account that can dispute the unapplied slash for that service
-     */
-    function queryDisputeOrigin(uint64 serviceId) public view virtual override returns (address disputeOrigin) {
+    /// @inheritdoc IBlueprintServiceManager
+    function queryDisputeOrigin(uint64) external view override returns (address disputeOrigin) {
         return address(this);
     }
 }

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -93,7 +93,7 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager, RootChainEnabl
         uint64 serviceId,
         uint8 job,
         uint64 jobCallId,
-        bytes calldata participant,
+        OperatorPreferences calldata operator,
         bytes calldata inputs,
         bytes calldata outputs
     )

--- a/src/IBlueprintServiceManager.sol
+++ b/src/IBlueprintServiceManager.sol
@@ -130,7 +130,7 @@ interface IBlueprintServiceManager {
      * @param serviceId The ID of the service related to the job.
      * @param job The job identifier.
      * @param jobCallId The unique ID for the job call.
-     * @param participant The participant (operator) sending the result in bytes format.
+     * @param operator The operator sending the result in bytes format.
      * @param inputs Inputs used for the job execution in bytes format.
      * @param outputs Outputs resulting from the job execution in bytes format.
      */
@@ -138,7 +138,7 @@ interface IBlueprintServiceManager {
         uint64 serviceId,
         uint8 job,
         uint64 jobCallId,
-        bytes calldata participant,
+        OperatorPreferences calldata operator,
         bytes calldata inputs,
         bytes calldata outputs
     )

--- a/src/Permissions.sol
+++ b/src/Permissions.sol
@@ -1,22 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
-contract PermittedCaller {
-    address public permitted;
-
-    constructor() {
-        permitted = msg.sender;
-    }
-
-    modifier onlyPermittedCaller() {
-        require(msg.sender == permitted, "Only permitted caller can call this function");
-        _;
-    }
-}
-
+/// @title Root Chain Enabled
+/// @dev This contract defines the root chain address and provides a modifier to restrict access to the root chain
+/// @notice This contract is used to restrict access of certain functions to the root chain only.
 contract RootChainEnabled {
-    /// @dev address(keccak256(pallet_services::Config::PalletId::to_account_id())[0:20])
-    address public constant ROOT_CHAIN = 0x6d6f646c70792F73727663730000000000000000;
+    /// @notice The address of the root chain
+    address public constant ROOT_CHAIN = 0x1111111111111111111111111111111111111111;
+
+    /// @dev Get the root chain address
+    /// @return rootChainAddress The address of the root chain
+    function rootChain() external pure returns (address rootChainAddress) {
+        return ROOT_CHAIN;
+    }
 
     /// @dev Only root chain can call this function
     /// @notice This function can only be called by the root chain

--- a/src/Permissions.sol
+++ b/src/Permissions.sol
@@ -8,6 +8,8 @@ contract RootChainEnabled {
     /// @notice The address of the root chain
     address public constant ROOT_CHAIN = 0x1111111111111111111111111111111111111111;
 
+    error OnlyRootChainAllowed(address caller, address rootChain);
+
     /// @dev Get the root chain address
     /// @return rootChainAddress The address of the root chain
     function rootChain() external pure returns (address rootChainAddress) {
@@ -17,7 +19,9 @@ contract RootChainEnabled {
     /// @dev Only root chain can call this function
     /// @notice This function can only be called by the root chain
     modifier onlyFromRootChain() {
-        require(msg.sender == ROOT_CHAIN, "RootChain: Only root chain can call this function");
+        if (msg.sender != ROOT_CHAIN) {
+            revert OnlyRootChainAllowed(msg.sender, ROOT_CHAIN);
+        }
         _;
     }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `BlueprintServiceManagerBase` and `IBlueprintServiceManager` contracts, as well as the addition of a new `RootChainEnabled` contract. The changes focus on enhancing the structure and functionality of service management and operator preferences.

Enhancements to `BlueprintServiceManagerBase` and `IBlueprintServiceManager`:

* [`src/BlueprintServiceManagerBase.sol`](diffhunk://#diff-6fe79b83efb9fdfb7f295ea335ff1232519b7ed772eec108195efd47df7bef91L17-R139): Added `@inheritdoc IBlueprintServiceManager` to multiple functions to inherit documentation and updated function parameters to use the new `OperatorPreferences` struct.
* [`src/IBlueprintServiceManager.sol`](diffhunk://#diff-d5a72da0582dfb5e9d96eddf40c940f7a3d90018136cfefd3139bb388dde2ec4R10-R115): Introduced `OperatorPreferences` and `PriceTargets` structs to encapsulate operator details and pricing targets. Updated function signatures to use these structs. [[1]](diffhunk://#diff-d5a72da0582dfb5e9d96eddf40c940f7a3d90018136cfefd3139bb388dde2ec4R10-R115) [[2]](diffhunk://#diff-d5a72da0582dfb5e9d96eddf40c940f7a3d90018136cfefd3139bb388dde2ec4L43-R154)

Introduction of `RootChainEnabled` contract:

* [`src/Permissions.sol`](diffhunk://#diff-64c9b48d95aa1ab3429dc512bd9e4ce8073d257b8315ca7ae21936affe218b4cL4-R24): Added the `RootChainEnabled` contract to define the root chain address and provide a modifier to restrict access to the root chain. This includes a new error type `OnlyRootChainAllowed` for better error handling.