### PR TITLE
feat: add MBSM deployment script

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -72,7 +72,7 @@ jobs:
         id: coverage
 
       - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v3
+        uses: zgosalvez/github-actions-report-lcov@v4
         with:
           coverage-files: lcov.info
           minimum-coverage: 85

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@ libs = ["dependencies"]
 optimizer_runs = 200
 fs_permissions = [{ access = "read-write", path = "./" }]
 solc = "0.8.20"
+evm_version = "shanghai"
 
 [profile.ci]
 verbosity = 4
@@ -34,6 +35,15 @@ depth = 120
 arbitrum_goerli = "${ARBITRUM_GOERLI_RPC}"
 arbitrum = "${ARBITRUM_RPC}"
 mainnet = "${MAINNET_RPC}"
+tangle_local = "${TANGLE_LOCAL_RPC}"
+tangle_testnet = "${TANGLE_TESTNET_RPC}"
+tangle_mainnet = "${TANGLE_MAINNET_RPC}"
+
+[etherscan]
+sepolia = { key = "${SEPOLIA_KEY}" }
+base-sepolia = { key = "${BASE_SEPOLIA_KEY}" }
+tangle_testnet = { key = "${TANGLE_TESTNET_KEY}", url = "https://testnet-explorer.tangle.tools" }
+tangle_mainnet = { key = "${TANGLE_MAINNET_KEY}", url = "https://explorer.tangle.tools" }
 
 [dependencies]
 forge-std = "1.9.4"

--- a/scripts/MBSMDeployer.s.sol
+++ b/scripts/MBSMDeployer.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+import {Script} from "forge-std/Script.sol";
+
+import "../src/MasterBlueprintServiceManager.sol";
+
+// Here is how you can run this script:
+// forge script scripts/MBSMDeployer.s.sol -vvvv --broadcast --evm-version london --legacy --private-key $(subkey inspect //Alice --scheme Ecdsa --output-type json | jq -r .secretSeed)
+
+contract MBSMDeployerScript is Script {
+    function run() public {
+        vm.createSelectFork("tangle_local");
+        vm.startBroadcast();
+        // TODO: Change this to the actual protocol fees receiver address
+        address payable protocolFeesReceiver = payable(address(0x0));
+        new MasterBlueprintServiceManager(protocolFeesReceiver);
+        vm.stopBroadcast();
+
+        // vm.createSelectFork("base-sepolia");
+        // vm.startBroadcast();
+        // new Counter();
+        // vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
Adds a simple deployment script to deploy MBSM to different chains:

```
forge script scripts/MBSMDeployer.s.sol -vvvv --broadcast --evm-version london --legacy --private-key $(subkey inspect //Alice --scheme Ecdsa --output-type json | jq -r .secretSeed)
```