### PR TITLE
chore: bump bytecode crate to 0.6.0

### DIFF
--- a/bytecode/Cargo.lock
+++ b/bytecode/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bytecode"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
 ]

--- a/bytecode/Cargo.toml
+++ b/bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tnt-core-bytecode"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Bytecode exports for TNT Core Solidity contracts"
 license = "MIT"


### PR DESCRIPTION
# Overview

Bumps bytecode crate's version for next release