### PR TITLE
feat(schema): add TLV v2 format with field names

### DIFF
--- a/script/v2/CreateServiceForTLV2Test.s.sol
+++ b/script/v2/CreateServiceForTLV2Test.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Script, console2 } from "forge-std/Script.sol";
+import { ITangleFull } from "../../src/v2/interfaces/ITangle.sol";
+
+/// @title CreateServiceForTLV2Test
+/// @notice Create a service for the TLV v2 test blueprint
+contract CreateServiceForTLV2Test is Script {
+    uint256 constant DEPLOYER_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+    uint256 constant OPERATOR1_KEY = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    address constant TANGLE = 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9;
+    address constant OPERATOR1 = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
+    
+    function run() external {
+        ITangleFull tangle = ITangleFull(payable(TANGLE));
+        
+        // 1. Register operator1 for blueprint 1
+        console2.log("Registering operator for blueprint 1...");
+        vm.startBroadcast(OPERATOR1_KEY);
+        bytes memory operator1Key = hex"040102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40";
+        tangle.registerOperator(1, operator1Key, "http://operator1.local:8545");
+        vm.stopBroadcast();
+        console2.log("Operator registered");
+        
+        // 2. Request service for blueprint 1 with operator1
+        console2.log("Requesting service for blueprint 1...");
+        vm.startBroadcast(DEPLOYER_KEY);
+        
+        address[] memory operators = new address[](1);
+        operators[0] = OPERATOR1;
+        address[] memory permittedCallers = new address[](0); // Anyone can call
+        
+        uint64 serviceId = tangle.requestService(
+            1,                      // blueprintId
+            operators,              // operators 
+            "",                     // config
+            permittedCallers,       // permittedCallers
+            uint64(7 days),         // ttl
+            address(0),             // paymentToken (native)
+            0                       // paymentAmount
+        );
+        console2.log("Service requested with ID:", serviceId);
+        vm.stopBroadcast();
+        
+        // 3. Approve service as operator1
+        console2.log("Approving service as operator1...");
+        vm.startBroadcast(OPERATOR1_KEY);
+        tangle.approveService(serviceId, 100); // 100% restaking
+        vm.stopBroadcast();
+        console2.log("Service approved and active");
+        
+        console2.log("Done! Service ID:", serviceId);
+    }
+}

--- a/script/v2/CreateTestBlueprintTLV2.s.sol
+++ b/script/v2/CreateTestBlueprintTLV2.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Script, console2 } from "forge-std/Script.sol";
+import { Types } from "../../src/v2/libraries/Types.sol";
+import { SchemaLib } from "../../src/v2/libraries/SchemaLib.sol";
+import { ITangleFull } from "../../src/v2/interfaces/ITangle.sol";
+import { BlueprintDefinitionHelper } from "../../test/support/BlueprintDefinitionHelper.sol";
+
+/// @title CreateTestBlueprintTLV2
+/// @notice Deploy a blueprint with TLV v2 schemas that include field names
+contract CreateTestBlueprintTLV2 is Script, BlueprintDefinitionHelper {
+    uint256 constant DEPLOYER_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+    address constant TANGLE = 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9;
+    
+    function run() external {
+        vm.startBroadcast(DEPLOYER_KEY);
+        
+        // Create blueprint with TLV v2 schemas
+        Types.BlueprintDefinition memory def = _blueprintDefinition("http://localhost/test", address(0));
+        def.config.membership = Types.MembershipModel.Dynamic;
+        def.config.minOperators = 1;
+        def.config.maxOperators = 0;
+        def.metadata.name = "TLV v2 Test Blueprint";
+        def.metadata.description = "Blueprint with named parameters for TLV v2 testing";
+        
+        // Add jobs with proper schemas that have field names
+        Types.JobDefinition[] memory jobs = new Types.JobDefinition[](2);
+        
+        // Job 0: hello with "name" param (string)
+        jobs[0].name = "hello";
+        jobs[0].description = "Greets with a personalized message";
+        jobs[0].paramsSchema = _stringSchema("name");
+        jobs[0].resultSchema = _stringSchema("greeting");
+        
+        // Job 1: multiplyNumbers with "a" and "b" params
+        jobs[1].name = "multiplyNumbers";
+        jobs[1].description = "Multiplies two numbers";
+        jobs[1].paramsSchema = _twoUint256Schema("a", "b");
+        jobs[1].resultSchema = _uint256Schema("product");
+        
+        def.jobs = jobs;
+        
+        ITangleFull tangle = ITangleFull(payable(TANGLE));
+        uint64 blueprintId = tangle.createBlueprint(def);
+        console2.log("Blueprint created with ID:", blueprintId);
+        
+        vm.stopBroadcast();
+    }
+    
+    function _stringSchema(string memory fieldName) internal pure returns (bytes memory) {
+        Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
+        fields[0].kind = Types.BlueprintFieldKind.String;
+        fields[0].arrayLength = 0;
+        fields[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].name = fieldName;
+        return SchemaLib.encodeSchema(fields);
+    }
+    
+    function _uint256Schema(string memory fieldName) internal pure returns (bytes memory) {
+        Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
+        fields[0].kind = Types.BlueprintFieldKind.Uint256;
+        fields[0].arrayLength = 0;
+        fields[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].name = fieldName;
+        return SchemaLib.encodeSchema(fields);
+    }
+    
+    function _twoUint256Schema(string memory name1, string memory name2) internal pure returns (bytes memory) {
+        Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](2);
+        fields[0].kind = Types.BlueprintFieldKind.Uint256;
+        fields[0].arrayLength = 0;
+        fields[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].name = name1;
+        fields[1].kind = Types.BlueprintFieldKind.Uint256;
+        fields[1].arrayLength = 0;
+        fields[1].children = new Types.BlueprintFieldType[](0);
+        fields[1].name = name2;
+        return SchemaLib.encodeSchema(fields);
+    }
+}

--- a/src/v2/libraries/Errors.sol
+++ b/src/v2/libraries/Errors.sol
@@ -40,6 +40,9 @@ library Errors {
     /// @notice Schema field kind is not supported
     error UnsupportedFieldKind(uint8 kind);
 
+    /// @notice Schema version byte is not the expected version
+    error InvalidSchemaVersion(uint8 expected, uint8 actual);
+
     // ═══════════════════════════════════════════════════════════════════════════
     // BLUEPRINT
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/v2/libraries/Types.sol
+++ b/src/v2/libraries/Types.sol
@@ -199,6 +199,7 @@ library Types {
         BlueprintFieldKind kind;
         uint16 arrayLength;
         BlueprintFieldType[] children;
+        string name;
     }
 
     /// @notice Primitive kinds supported within blueprint schemas

--- a/test/support/BlueprintDefinitionHelper.sol
+++ b/test/support/BlueprintDefinitionHelper.sol
@@ -78,6 +78,7 @@ abstract contract BlueprintDefinitionHelper {
         fields[0].kind = Types.BlueprintFieldKind.Bool;
         fields[0].arrayLength = 0;
         fields[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].name = "flag";
         return SchemaLib.encodeSchema(fields);
     }
 
@@ -86,9 +87,12 @@ abstract contract BlueprintDefinitionHelper {
         for (uint256 i = 0; i < fields.length; ++i) {
             fields[i].arrayLength = 0;
             fields[i].children = new Types.BlueprintFieldType[](0);
+            fields[i].name = "";
         }
         fields[0].kind = Types.BlueprintFieldKind.Bool;
+        fields[0].name = "flag";
         fields[1].kind = Types.BlueprintFieldKind.Uint32;
+        fields[1].name = "value";
         return SchemaLib.encodeSchema(fields);
     }
 
@@ -96,11 +100,14 @@ abstract contract BlueprintDefinitionHelper {
     function _requestStructBoolUint16Schema() internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Struct;
+        fields[0].name = "data";
         fields[0].children = new Types.BlueprintFieldType[](2);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].children[0].name = "flag";
         fields[0].children[1].kind = Types.BlueprintFieldKind.Uint16;
         fields[0].children[1].children = new Types.BlueprintFieldType[](0);
+        fields[0].children[1].name = "value";
         return SchemaLib.encodeSchema(fields);
     }
 
@@ -108,9 +115,11 @@ abstract contract BlueprintDefinitionHelper {
     function _requestListOfBoolSchema() internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.List;
+        fields[0].name = "flags";
         fields[0].children = new Types.BlueprintFieldType[](1);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].children[0].name = "";
         return SchemaLib.encodeSchema(fields);
     }
 
@@ -119,9 +128,11 @@ abstract contract BlueprintDefinitionHelper {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Array;
         fields[0].arrayLength = length;
+        fields[0].name = "bools";
         fields[0].children = new Types.BlueprintFieldType[](1);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].children[0].name = "";
         return SchemaLib.encodeSchema(fields);
     }
 
@@ -129,9 +140,11 @@ abstract contract BlueprintDefinitionHelper {
     function _optionalBoolFieldSchema() internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Optional;
+        fields[0].name = "optionalFlag";
         fields[0].children = new Types.BlueprintFieldType[](1);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
+        fields[0].children[0].name = "";
         return SchemaLib.encodeSchema(fields);
     }
 

--- a/test/support/SchemaTestUtils.sol
+++ b/test/support/SchemaTestUtils.sol
@@ -80,6 +80,7 @@ library SchemaTestUtils {
             field.kind = Types.BlueprintFieldKind.FixedBytes;
             field.arrayLength = uint16((nextSeed & 0x1F) + 1);
             field.children = new Types.BlueprintFieldType[](0);
+            field.name = "";
             nextSeed = _nextSeed(nextSeed);
         } else if (variant == 5) {
             field = _scalarField(Types.BlueprintFieldKind.Address);
@@ -89,16 +90,19 @@ library SchemaTestUtils {
             field.kind = Types.BlueprintFieldKind.Optional;
             field.children = new Types.BlueprintFieldType[](1);
             field.children[0] = child;
+            field.name = "";
         } else if (variant == 7) {
             Types.BlueprintFieldType memory child;
             (child, nextSeed) = _buildFieldDefinition(nextSeed, depth + 1);
             field.kind = Types.BlueprintFieldKind.List;
             field.children = new Types.BlueprintFieldType[](1);
             field.children[0] = child;
+            field.name = "";
         } else if (variant == 8) {
             uint8 childCount = uint8((nextSeed & 0x03) + 2);
             field.kind = Types.BlueprintFieldKind.Struct;
             field.children = new Types.BlueprintFieldType[](childCount);
+            field.name = "";
             nextSeed = _nextSeed(nextSeed);
             for (uint8 i = 0; i < childCount; ++i) {
                 Types.BlueprintFieldType memory child;
@@ -112,6 +116,7 @@ library SchemaTestUtils {
             field.arrayLength = uint16((nextSeed & 0x03) + 1);
             field.children = new Types.BlueprintFieldType[](1);
             field.children[0] = child;
+            field.name = "";
             nextSeed = _nextSeed(nextSeed);
         } else if (variant == 10) {
             field = _scalarField(Types.BlueprintFieldKind.Bytes32);
@@ -297,6 +302,7 @@ library SchemaTestUtils {
         field.kind = kind;
         field.arrayLength = 0;
         field.children = new Types.BlueprintFieldType[](0);
+        field.name = "";
     }
 
     function _randomBytes(uint256 length, uint256 seed) private pure returns (bytes memory data) {

--- a/test/v2/libraries/SchemaLibFuzz.t.sol
+++ b/test/v2/libraries/SchemaLibFuzz.t.sol
@@ -215,6 +215,7 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
         fields[0].kind = Types.BlueprintFieldKind.String;
         fields[0].children = new Types.BlueprintFieldType[](0);
         fields[0].arrayLength = 0;
+        fields[0].name = "text";
 
         bytes memory schema = SchemaLib.encodeSchema(fields);
         harness.setRegistrationSchema(schema);
@@ -318,9 +319,12 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Struct;
         fields[0].arrayLength = 0;
+        fields[0].name = "data";
         fields[0].children = new Types.BlueprintFieldType[](2);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
+        fields[0].children[0].name = "flag";
         fields[0].children[1].kind = Types.BlueprintFieldKind.Uint32;
+        fields[0].children[1].name = "value";
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
         fields[0].children[1].children = new Types.BlueprintFieldType[](0);
         return SchemaLib.encodeSchema(fields);
@@ -330,8 +334,10 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.List;
         fields[0].arrayLength = 0;
+        fields[0].name = "flags";
         fields[0].children = new Types.BlueprintFieldType[](1);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
+        fields[0].children[0].name = "";
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
         return SchemaLib.encodeSchema(fields);
     }
@@ -340,8 +346,10 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Array;
         fields[0].arrayLength = length;
+        fields[0].name = "bools";
         fields[0].children = new Types.BlueprintFieldType[](1);
         fields[0].children[0].kind = Types.BlueprintFieldKind.Bool;
+        fields[0].children[0].name = "";
         fields[0].children[0].children = new Types.BlueprintFieldType[](0);
         return SchemaLib.encodeSchema(fields);
     }


### PR DESCRIPTION
## Summary

- Extend TLV schema format to include field names (version 2)
- Enable users to submit job params using object format (e.g., `{"recipient": "0x1234...", "amount": 1000}`) instead of positional arrays
- Add `InvalidSchemaVersion` error for v1 schema rejection

## Problem

When users define job schemas with named parameters, they expect to submit jobs using intuitive object format. Previously, field names were lost during TLV encoding, forcing users to use positional arrays which was less readable and error-prone.

## Solution

The TLV v2 binary format now includes:
- Version byte (0x02)
- Compact-encoded field name lengths
- UTF-8 field name strings

```
[1 byte:  version (0x02)]
[2 bytes: field_count]
For each field:
  [1 byte:  BlueprintFieldKind enum]
  [2 bytes: arrayLength]
  [2 bytes: childCount]
  [1-4 bytes: compact-encoded name length]
  [N bytes: field name UTF-8 string]
  [... children recursively ...]
```

## Files Changed

| File | Changes |
|------|---------|
| `src/v2/libraries/Errors.sol` | Added `InvalidSchemaVersion(uint8 expected, uint8 actual)` error |
| `src/v2/libraries/SchemaLib.sol` | Added `SCHEMA_VERSION = 0x02`, encode/decode field names |
| `src/v2/libraries/Types.sol` | Added `name` field to `BlueprintFieldType` struct |
| `test/support/*.sol` | Updated test helpers |
| `test/v2/libraries/SchemaLibFuzz.t.sol` | Updated fuzz tests |
| `script/v2/*.s.sol` | Test scripts for TLV v2 |

## Test plan

- [x] All 12 SchemaLib fuzz tests pass
- [ ] Manual testing with blueprint CLI

🤖 Generated with [Claude Code](https://claude.ai/code)