### PR TITLE
feat(staking): add operator delegation config for securities compliance

### DIFF
--- a/src/v2/facets/staking/StakingOperatorsFacet.sol
+++ b/src/v2/facets/staking/StakingOperatorsFacet.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.26;
 
 import { StakingFacetBase } from "../../staking/StakingFacetBase.sol";
 import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
+import { Types } from "../../libraries/Types.sol";
 
 /// @title StakingOperatorsFacet
 /// @notice Facet for operator lifecycle management
 contract StakingOperatorsFacet is StakingFacetBase, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](10);
+        selectorList = new bytes4[](14);
         selectorList[0] = this.registerOperator.selector;
         selectorList[1] = this.registerOperatorWithAsset.selector;
         selectorList[2] = this.increaseStake.selector;
@@ -19,6 +20,10 @@ contract StakingOperatorsFacet is StakingFacetBase, IFacetSelectors {
         selectorList[7] = this.removeBlueprintForOperator.selector;
         selectorList[8] = this.startLeaving.selector;
         selectorList[9] = this.completeLeaving.selector;
+        selectorList[10] = this.setDelegationMode.selector;
+        selectorList[11] = this.setDelegationWhitelist.selector;
+        selectorList[12] = this.getDelegationMode.selector;
+        selectorList[13] = this.isWhitelisted.selector;
     }
 
     /// @notice Register as an operator with native stake
@@ -74,5 +79,33 @@ contract StakingOperatorsFacet is StakingFacetBase, IFacetSelectors {
     /// @notice Complete leaving and withdraw all stake
     function completeLeaving() external nonReentrant {
         _completeLeaving();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // DELEGATION CONFIG
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Set delegation mode for your operator
+    /// @dev Default is Disabled (self-stake only). Open allows anyone to delegate.
+    /// @param mode Delegation mode: Disabled (0), Whitelist (1), or Open (2)
+    function setDelegationMode(Types.DelegationMode mode) external {
+        _setDelegationMode(mode);
+    }
+
+    /// @notice Update delegation whitelist (batch)
+    /// @param delegators Array of delegator addresses
+    /// @param approved Whether to approve or revoke
+    function setDelegationWhitelist(address[] calldata delegators, bool approved) external {
+        _setDelegationWhitelist(delegators, approved);
+    }
+
+    /// @notice Get operator's delegation mode
+    function getDelegationMode(address operator) external view returns (Types.DelegationMode) {
+        return _getDelegationMode(operator);
+    }
+
+    /// @notice Check if delegator is whitelisted for operator
+    function isWhitelisted(address operator, address delegator) external view returns (bool) {
+        return _isWhitelisted(operator, delegator);
     }
 }

--- a/src/v2/facets/staking/StakingOperatorsFacet.sol
+++ b/src/v2/facets/staking/StakingOperatorsFacet.sol
@@ -86,25 +86,37 @@ contract StakingOperatorsFacet is StakingFacetBase, IFacetSelectors {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Set delegation mode for your operator
-    /// @dev Default is Disabled (self-stake only). Open allows anyone to delegate.
+    /// @dev Changes take effect immediately for NEW delegations only.
+    ///      Existing delegations remain valid regardless of mode change.
+    ///      Default is Disabled (self-stake only) - lowest securities risk.
+    ///      - Disabled: Only operator can self-stake
+    ///      - Whitelist: Only approved addresses can delegate
+    ///      - Open: Anyone can delegate (highest securities risk)
     /// @param mode Delegation mode: Disabled (0), Whitelist (1), or Open (2)
     function setDelegationMode(Types.DelegationMode mode) external {
         _setDelegationMode(mode);
     }
 
     /// @notice Update delegation whitelist (batch)
-    /// @param delegators Array of delegator addresses
-    /// @param approved Whether to approve or revoke
+    /// @dev Whitelist only applies when delegation mode is set to Whitelist.
+    ///      Can be called regardless of current mode to pre-configure.
+    /// @param delegators Array of delegator addresses to update
+    /// @param approved True to approve for delegation, false to revoke
     function setDelegationWhitelist(address[] calldata delegators, bool approved) external {
         _setDelegationWhitelist(delegators, approved);
     }
 
     /// @notice Get operator's delegation mode
+    /// @param operator The operator address to query
+    /// @return The current delegation mode (Disabled=0, Whitelist=1, Open=2)
     function getDelegationMode(address operator) external view returns (Types.DelegationMode) {
         return _getDelegationMode(operator);
     }
 
     /// @notice Check if delegator is whitelisted for operator
+    /// @param operator The operator address
+    /// @param delegator The delegator address to check
+    /// @return True if delegator is on operator's whitelist
     function isWhitelisted(address operator, address delegator) external view returns (bool) {
         return _isWhitelisted(operator, delegator);
     }

--- a/src/v2/facets/staking/StakingOperatorsFacet.sol
+++ b/src/v2/facets/staking/StakingOperatorsFacet.sol
@@ -88,10 +88,9 @@ contract StakingOperatorsFacet is StakingFacetBase, IFacetSelectors {
     /// @notice Set delegation mode for your operator
     /// @dev Changes take effect immediately for NEW delegations only.
     ///      Existing delegations remain valid regardless of mode change.
-    ///      Default is Disabled (self-stake only) - lowest securities risk.
-    ///      - Disabled: Only operator can self-stake
+    ///      - Disabled: Only operator can self-stake (default)
     ///      - Whitelist: Only approved addresses can delegate
-    ///      - Open: Anyone can delegate (highest securities risk)
+    ///      - Open: Anyone can delegate
     /// @param mode Delegation mode: Disabled (0), Whitelist (1), or Open (2)
     function setDelegationMode(Types.DelegationMode mode) external {
         _setDelegationMode(mode);

--- a/src/v2/libraries/Types.sol
+++ b/src/v2/libraries/Types.sol
@@ -466,6 +466,15 @@ library Types {
         Leaving     // Exit scheduled, waiting for delay
     }
 
+    /// @notice Operator delegation mode - controls who can delegate to this operator
+    /// @dev IMPORTANT: Enum values must only be APPENDED, never reordered or inserted.
+    /// Disabled=0 (self-stake only), Whitelist=1, Open=2.
+    enum DelegationMode {
+        Disabled,   // Only operator can self-stake (lowest securities risk)
+        Whitelist,  // Only approved addresses can delegate
+        Open        // Anyone can delegate (highest securities risk)
+    }
+
     /// @notice Operator metadata
     struct OperatorMetadata {
         uint256 stake;              // Self-stake amount

--- a/src/v2/libraries/Types.sol
+++ b/src/v2/libraries/Types.sol
@@ -470,9 +470,9 @@ library Types {
     /// @dev IMPORTANT: Enum values must only be APPENDED, never reordered or inserted.
     /// Disabled=0 (self-stake only), Whitelist=1, Open=2.
     enum DelegationMode {
-        Disabled,   // Only operator can self-stake (lowest securities risk)
+        Disabled,   // Only operator can self-stake
         Whitelist,  // Only approved addresses can delegate
-        Open        // Anyone can delegate (highest securities risk)
+        Open        // Anyone can delegate
     }
 
     /// @notice Operator metadata

--- a/src/v2/staking/DelegationErrors.sol
+++ b/src/v2/staking/DelegationErrors.sol
@@ -45,6 +45,8 @@ library DelegationErrors {
     error InsufficientDelegation(uint256 available, uint256 requested);
     error InsufficientAvailableBalance(uint256 available, uint256 requested);
     error AmountLocked(uint256 locked, uint256 requested);
+    error DelegationDisabled(address operator);
+    error DelegatorNotWhitelisted(address operator, address delegator);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // TIMING ERRORS

--- a/src/v2/staking/DelegationManagerLib.sol
+++ b/src/v2/staking/DelegationManagerLib.sol
@@ -156,6 +156,16 @@ abstract contract DelegationManagerLib is OperatorManager {
             revert DelegationErrors.OperatorNotActive(operator);
         }
 
+        // Check delegation mode permissions
+        if (!_canDelegate(operator, msg.sender)) {
+            Types.DelegationMode mode = _operatorDelegationMode[operator];
+            if (mode == Types.DelegationMode.Disabled) {
+                revert DelegationErrors.DelegationDisabled(operator);
+            } else {
+                revert DelegationErrors.DelegatorNotWhitelisted(operator, msg.sender);
+            }
+        }
+
         bytes32 assetHash = _assetHash(asset);
         Types.Deposit storage dep = _deposits[msg.sender][assetHash];
 

--- a/src/v2/staking/DelegationStorage.sol
+++ b/src/v2/staking/DelegationStorage.sol
@@ -333,7 +333,7 @@ abstract contract DelegationStorage {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Operator delegation mode: operator => DelegationMode
-    /// @dev Default is Disabled (self-stake only) for lowest securities risk
+    /// @dev Default is Disabled (self-stake only)
     mapping(address => Types.DelegationMode) internal _operatorDelegationMode;
 
     /// @notice Whitelist of approved delegators: operator => delegator => approved

--- a/src/v2/staking/DelegationStorage.sol
+++ b/src/v2/staking/DelegationStorage.sol
@@ -328,7 +328,18 @@ abstract contract DelegationStorage {
     /// @dev Used to check if operator has active service commitments before exit
     address internal _tangleCore;
 
+    // ═══════════════════════════════════════════════════════════════════════════
+    // OPERATOR DELEGATION CONFIG
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Operator delegation mode: operator => DelegationMode
+    /// @dev Default is Disabled (self-stake only) for lowest securities risk
+    mapping(address => Types.DelegationMode) internal _operatorDelegationMode;
+
+    /// @notice Whitelist of approved delegators: operator => delegator => approved
+    mapping(address => mapping(address => bool)) internal _operatorDelegationWhitelist;
+
     /// @notice Reserved storage gap for future upgrades
     /// @dev Standard gap size is 50 slots. When adding new storage, decrease this gap accordingly.
-    uint256[48] private __gap;
+    uint256[46] private __gap;
 }

--- a/src/v2/staking/OperatorManager.sol
+++ b/src/v2/staking/OperatorManager.sol
@@ -29,6 +29,8 @@ abstract contract OperatorManager is DelegationStorage {
     event OperatorLeft(address indexed operator);
     event OperatorBlueprintAdded(address indexed operator, uint64 indexed blueprintId);
     event OperatorBlueprintRemoved(address indexed operator, uint64 indexed blueprintId);
+    event OperatorDelegationModeSet(address indexed operator, Types.DelegationMode mode);
+    event OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // REGISTRATION
@@ -314,5 +316,58 @@ abstract contract OperatorManager is DelegationStorage {
     /// @notice Get operator at index
     function _operatorAt(uint256 index) internal view returns (address) {
         return _operators.at(index);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // DELEGATION CONFIG
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Set delegation mode for operator
+    /// @dev Only callable by the operator themselves
+    /// @param mode Delegation mode: Disabled (self-only), Whitelist, or Open
+    function _setDelegationMode(Types.DelegationMode mode) internal {
+        if (!_operators.contains(msg.sender)) {
+            revert DelegationErrors.OperatorNotRegistered(msg.sender);
+        }
+        _operatorDelegationMode[msg.sender] = mode;
+        emit OperatorDelegationModeSet(msg.sender, mode);
+    }
+
+    /// @notice Update whitelist for an operator (batch)
+    /// @dev Only callable by the operator themselves
+    /// @param delegators Array of delegator addresses
+    /// @param approved Whether to approve or revoke
+    function _setDelegationWhitelist(address[] calldata delegators, bool approved) internal {
+        if (!_operators.contains(msg.sender)) {
+            revert DelegationErrors.OperatorNotRegistered(msg.sender);
+        }
+        for (uint256 i = 0; i < delegators.length;) {
+            _operatorDelegationWhitelist[msg.sender][delegators[i]] = approved;
+            emit OperatorWhitelistUpdated(msg.sender, delegators[i], approved);
+            unchecked { ++i; }
+        }
+    }
+
+    /// @notice Check if delegator can delegate to operator
+    /// @param operator Operator address
+    /// @param delegator Delegator address
+    function _canDelegate(address operator, address delegator) internal view returns (bool) {
+        Types.DelegationMode mode = _operatorDelegationMode[operator];
+        if (mode == Types.DelegationMode.Open) return true;
+        if (mode == Types.DelegationMode.Whitelist) {
+            return _operatorDelegationWhitelist[operator][delegator];
+        }
+        // Disabled: only operator can self-stake
+        return delegator == operator;
+    }
+
+    /// @notice Get operator's delegation mode
+    function _getDelegationMode(address operator) internal view returns (Types.DelegationMode) {
+        return _operatorDelegationMode[operator];
+    }
+
+    /// @notice Check if delegator is whitelisted
+    function _isWhitelisted(address operator, address delegator) internal view returns (bool) {
+        return _operatorDelegationWhitelist[operator][delegator];
     }
 }


### PR DESCRIPTION
## Summary

Allow operators to control who can delegate to them, reducing securities law risk.

### Changes
- **DelegationMode enum**: `Disabled` (self-only), `Whitelist`, `Open`
- **Default is Disabled** (lowest securities risk - operators must opt-in to accept delegations)
- Operators can whitelist specific delegators for controlled delegation
- Check enforced in `_delegate()` before any delegation proceeds

### New Functions
| Function | Description |
|----------|-------------|
| `setDelegationMode(mode)` | Operator sets their delegation mode |
| `setDelegationWhitelist(addresses, approved)` | Batch whitelist management |
| `getDelegationMode(operator)` | View operator's current mode |
| `isWhitelisted(operator, delegator)` | Check if delegator is whitelisted |

### Securities Law Impact
This structural change reduces risk by:
- Defaulting to self-stake only (no "investment contract" under Howey)
- Shifting liability to operators who choose to enable delegation
- Providing whitelist mode for controlled/permissioned delegation

### Files Changed
- `Types.sol` - Added `DelegationMode` enum
- `DelegationStorage.sol` - Added storage for mode and whitelist
- `DelegationErrors.sol` - Added `DelegationDisabled`, `DelegatorNotWhitelisted`
- `OperatorManager.sol` - Added config management functions
- `DelegationManagerLib.sol` - Added delegation check
- `StakingOperatorsFacet.sol` - Exposed public functions

## Test plan
- [ ] Unit test: operator can set delegation mode
- [ ] Unit test: delegation blocked when mode is Disabled
- [ ] Unit test: delegation blocked for non-whitelisted in Whitelist mode
- [ ] Unit test: delegation allowed in Open mode
- [ ] Integration test: mode persists across upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)