### PR TITLE
feat(migration-claim): add KiteAI Testnet support with SP1 verifier infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 target
 
 # Docs
-docs/
+/docs/
 
 # directories
 .yarn/*

--- a/apps/claim-relayer/src/index.ts
+++ b/apps/claim-relayer/src/index.ts
@@ -10,9 +10,33 @@ import {
   parseAbi,
   isAddress,
   isHex,
+  defineChain,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { localhost, baseSepolia, base } from "viem/chains";
+
+// KiteAI Testnet chain definition
+const kiteTestnet = defineChain({
+  id: 2368,
+  name: "KiteAI Testnet",
+  nativeCurrency: {
+    decimals: 18,
+    name: "KITE",
+    symbol: "KITE",
+  },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc-testnet.gokite.ai/"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "KiteScan",
+      url: "https://testnet.kitescan.ai",
+    },
+  },
+  testnet: true,
+});
 
 // ============================================================================
 // CONFIGURATION
@@ -59,6 +83,8 @@ const getChain = () => {
       return baseSepolia;
     case 8453:
       return base;
+    case 2368:
+      return kiteTestnet;
     default:
       return { ...localhost, id: CHAIN_ID };
   }

--- a/packages/migration-claim/docs/KITE_TESTNET_GUIDE.md
+++ b/packages/migration-claim/docs/KITE_TESTNET_GUIDE.md
@@ -1,0 +1,292 @@
+# KiteAI Testnet Deployment & Testing Guide
+
+This guide walks through deploying the Tangle Migration contracts to KiteAI Testnet and testing claims with the Alice test account.
+
+## KiteAI Testnet Info
+
+- **Chain ID:** 2368
+- **RPC URL:** https://rpc-testnet.gokite.ai/
+- **Block Explorer:** https://testnet.kitescan.ai/
+- **Native Token:** KITE
+- **Faucet:** https://faucet.gokite.ai
+
+## Alice Test Account
+
+Alice is included in the merkle tree for testing:
+
+- **SS58 Address:** `tgGmBRR5yM53bvq8tTzgsUirpPtfCXngYYU7uiihmWFJhmYGM`
+- **Public Key:** `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d`
+- **Balance:** `5009550328826873592` wei (~5.01 TNT)
+
+## Prerequisites
+
+1. **Tools:**
+   - Foundry (`forge`, `cast`)
+   - Rust with SP1 toolchain (`cargo prove`)
+   - Node.js 18+
+   - `jq` for JSON processing
+
+2. **Accounts:**
+   - Deployer wallet with KITE tokens (get from faucet)
+   - Relayer wallet with KITE tokens for gas
+
+3. **SP1 Prover:**
+   - SP1 Prover Network access (or use mock verifier for testing)
+
+## Step 1: Deploy SP1 Infrastructure
+
+KiteAI doesn't have a pre-deployed SP1 verifier, so we deploy our own.
+
+```bash
+cd packages/migration-claim
+
+# Get KITE tokens for deployer from faucet
+# https://faucet.gokite.ai
+
+# Deploy SP1 Gateway + Verifier
+PRIVATE_KEY=0x... \
+RPC_URL=https://rpc-testnet.gokite.ai/ \
+  ./scripts/deploy-sp1-gateway.sh
+```
+
+Save the `SP1VerifierGateway` address from the output.
+
+## Step 2: Build SP1 Program & Get VKey
+
+```bash
+cd sp1/program
+
+# Build the SP1 program
+cargo prove build
+
+# Get the verification key
+cd ..
+cargo +succinct run --release -p sr25519-claim-script --bin vkey
+```
+
+Save the `PROGRAM_VKEY` from the output.
+
+## Step 3: Deploy Migration Contracts
+
+The migration includes token allocations for the foundation and liquidity operations. For testnet, use your deployer address as the recipient for both.
+
+```bash
+cd packages/migration-claim
+
+PRIVATE_KEY=0x... \
+PROGRAM_VKEY=0x<from-step-2> \
+SP1_VERIFIER=0x<gateway-from-step-1> \
+FOUNDATION_RECIPIENT=0x<your-deployer-address> \
+LIQUIDITY_OPS_RECIPIENT=0x<your-deployer-address> \
+  ./scripts/deploy-tangle-migration.sh --kite
+```
+
+**Environment variables:**
+- `FOUNDATION_RECIPIENT`: EVM address to receive foundation tokens (~15M TNT)
+- `LIQUIDITY_OPS_RECIPIENT`: EVM address to receive liquidity/ops tokens (5M TNT)
+
+Save the deployed addresses:
+- `TNT_TOKEN`
+- `MIGRATION_CONTRACT`
+
+## Step 4: Start the Prover API
+
+For testing, you can use mock mode:
+
+```bash
+cd sp1/prover-api
+
+# Mock mode (no real ZK proofs)
+SP1_PROVER=mock \
+ALLOW_MOCK=true \
+  cargo run --release
+```
+
+For production proofs:
+
+```bash
+cd sp1/prover-api
+
+# Network mode (requires SP1 Prover Network access)
+SP1_PROVER=network \
+NETWORK_PRIVATE_KEY=0x... \
+VERIFY_PROOF=true \
+CORS_ALLOWED_ORIGINS=http://localhost:3000 \
+  cargo run --release
+```
+
+**Environment variables for network mode:**
+- `NETWORK_PRIVATE_KEY`: Your SP1 Prover Network private key
+- `VERIFY_PROOF=true`: Required for production safety
+- `CORS_ALLOWED_ORIGINS`: Allowed origins (e.g., your frontend URL)
+
+The prover API runs on `http://localhost:8080`.
+
+## Step 5: Start the Claim Relayer
+
+```bash
+cd apps/claim-relayer
+
+npm install
+
+RELAYER_PRIVATE_KEY=0x... \
+RPC_URL=https://rpc-testnet.gokite.ai/ \
+CHAIN_ID=2368 \
+MIGRATION_CONTRACT=0x<from-step-3> \
+  npm run dev
+```
+
+The relayer runs on `http://localhost:3001`.
+
+## Step 6: Test Claim as Alice
+
+### 6.1 Generate the Challenge
+
+The challenge is `keccak256(abi.encode(contractAddress, chainId, recipient, amount))`:
+
+```bash
+# Variables
+CONTRACT=0x<migration-contract>
+CHAIN_ID=2368
+RECIPIENT=0x<your-evm-address>
+AMOUNT=5009550328826873592
+
+# Generate challenge
+CHALLENGE=$(cast keccak256 $(cast abi-encode "f(address,uint256,address,uint256)" $CONTRACT $CHAIN_ID $RECIPIENT $AMOUNT))
+echo "Challenge: $CHALLENGE"
+```
+
+### 6.2 Sign with Alice's Key
+
+Using `subkey` (from Substrate):
+
+```bash
+# Sign the challenge with Alice's key
+# Alice's dev seed: "//Alice"
+SIGNATURE=$(subkey sign --suri "//Alice" --message-hex ${CHALLENGE#0x})
+echo "Signature: 0x$SIGNATURE"
+```
+
+### 6.3 Get Merkle Proof
+
+```bash
+# Extract Alice's merkle proof
+ALICE_SS58="tgGmBRR5yM53bvq8tTzgsUirpPtfCXngYYU7uiihmWFJhmYGM"
+MERKLE_PROOF=$(jq -r ".entries[\"$ALICE_SS58\"].proof | @json" merkle-tree.json)
+echo "Merkle Proof: $MERKLE_PROOF"
+```
+
+### 6.4 Request ZK Proof from Prover
+
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pubkey": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+    "signature": "0x<signature-from-6.2>",
+    "recipient": "'$RECIPIENT'",
+    "amount": "'$AMOUNT'",
+    "chain_id": 2368,
+    "contract_address": "'$CONTRACT'"
+  }'
+```
+
+Save the `proof` from the response.
+
+### 6.5 Submit Claim via Relayer
+
+```bash
+curl -X POST http://localhost:3001/claim \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pubkey": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+    "amount": "'$AMOUNT'",
+    "merkleProof": '$MERKLE_PROOF',
+    "zkProof": "0x<proof-from-6.4>",
+    "recipient": "'$RECIPIENT'"
+  }'
+```
+
+### 6.6 Verify Claim
+
+Check recipient's TNT balance:
+
+```bash
+cast call $TNT_TOKEN "balanceOf(address)" $RECIPIENT \
+  --rpc-url https://rpc-testnet.gokite.ai/
+```
+
+Check claim status:
+
+```bash
+curl http://localhost:3001/status/0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+```
+
+## Troubleshooting
+
+### "RouteNotFound" Error
+
+The SP1 verifier route wasn't added. Ensure the gateway owner called `addRoute()`:
+
+```bash
+cast send $SP1_GATEWAY "addRoute(address)" $SP1_VERIFIER \
+  --private-key $OWNER_PRIVATE_KEY \
+  --rpc-url https://rpc-testnet.gokite.ai/
+```
+
+### "InvalidZKProof" Error
+
+- Check the proof was generated for the correct chain ID (2368)
+- Check the contract address matches
+- Verify the signature is valid for Alice's pubkey
+
+### "InvalidMerkleProof" Error
+
+- Verify Alice's entry exists in merkle-tree.json
+- Ensure the amount matches exactly
+- Check the pubkey format (0x + 64 hex chars)
+
+### Relayer Returns 429
+
+Rate limit hit. Wait 60 seconds and try again.
+
+### Low KITE Balance
+
+Get more KITE tokens from the faucet: https://faucet.gokite.ai
+
+## Quick Reference
+
+| Component | URL/Address |
+|-----------|-------------|
+| RPC | https://rpc-testnet.gokite.ai/ |
+| Explorer | https://testnet.kitescan.ai/ |
+| Faucet | https://faucet.gokite.ai |
+| Prover API | http://localhost:8080 |
+| Claim Relayer | http://localhost:3001 |
+
+## Environment Variables Summary
+
+```bash
+# Deployer
+export PRIVATE_KEY=0x...
+export PROGRAM_VKEY=0x...
+export SP1_VERIFIER=0x...
+export FOUNDATION_RECIPIENT=0x...      # Receives ~15M TNT (use deployer address for testnet)
+export LIQUIDITY_OPS_RECIPIENT=0x...   # Receives 5M TNT (use deployer address for testnet)
+
+# Relayer
+export RELAYER_PRIVATE_KEY=0x...
+export RPC_URL=https://rpc-testnet.gokite.ai/
+export CHAIN_ID=2368
+export MIGRATION_CONTRACT=0x...
+
+# Prover (mock mode for testing)
+export SP1_PROVER=mock
+export ALLOW_MOCK=true
+
+# Prover (network mode for production)
+export SP1_PROVER=network
+export NETWORK_PRIVATE_KEY=0x...
+export VERIFY_PROOF=true
+export CORS_ALLOWED_ORIGINS=http://localhost:3000
+```

--- a/packages/migration-claim/foundry.toml
+++ b/packages/migration-claim/foundry.toml
@@ -21,7 +21,9 @@ fs_permissions = [{ access = "read", path = "./" }]
 base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 base = "${BASE_RPC_URL}"
 localhost = "http://127.0.0.1:8545"
+kite_testnet = "${KITE_TESTNET_RPC_URL}"
 
 [etherscan]
 base_sepolia = { key = "${BASESCAN_API_KEY}", url = "https://api-sepolia.basescan.org/api" }
 base = { key = "${BASESCAN_API_KEY}", url = "https://api.basescan.org/api" }
+kite_testnet = { key = "${KITESCAN_API_KEY}", url = "https://testnet.kitescan.ai/api" }

--- a/packages/migration-claim/script/DeploySP1Infrastructure.s.sol
+++ b/packages/migration-claim/script/DeploySP1Infrastructure.s.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SP1VerifierGateway} from "../src/sp1/SP1VerifierGateway.sol";
+import {SP1Verifier} from "../src/sp1/SP1Verifier.sol";
+
+/// @title Deploy SP1 Infrastructure
+/// @notice Deploys SP1VerifierGateway and SP1Verifier v5.0.0 to any EVM chain
+/// @dev Usage:
+///   PRIVATE_KEY=0x... OWNER=0x... forge script script/DeploySP1Infrastructure.s.sol:DeploySP1Infrastructure \
+///     --rpc-url $RPC_URL --broadcast -vvv
+contract DeploySP1Infrastructure is Script {
+    function run() external {
+        // Get owner address from environment (defaults to deployer if not set)
+        address deployer = vm.addr(vm.envUint("PRIVATE_KEY"));
+        address owner = vm.envOr("OWNER", deployer);
+
+        console.log("============================================");
+        console.log("SP1 Infrastructure Deployment");
+        console.log("============================================");
+        console.log("Deployer:", deployer);
+        console.log("Owner:", owner);
+        console.log("");
+
+        vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
+
+        // 1. Deploy SP1VerifierGateway with owner
+        SP1VerifierGateway gateway = new SP1VerifierGateway(owner);
+        console.log("SP1VerifierGateway deployed at:", address(gateway));
+
+        // 2. Deploy SP1Verifier v5.0.0
+        SP1Verifier verifier = new SP1Verifier();
+        console.log("SP1Verifier (v5.0.0) deployed at:", address(verifier));
+        console.log("  VERIFIER_HASH:", vm.toString(verifier.VERIFIER_HASH()));
+
+        // 3. Add verifier route to gateway
+        // Note: This must be called by the owner
+        if (deployer == owner) {
+            gateway.addRoute(address(verifier));
+            console.log("Route added to gateway for SP1Verifier v5.0.0");
+        } else {
+            console.log("");
+            console.log("WARNING: Deployer is not the owner. You must manually add the route:");
+            console.log("  gateway.addRoute(", vm.toString(address(verifier)), ")");
+        }
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("============================================");
+        console.log("Deployment Complete!");
+        console.log("============================================");
+        console.log("");
+        console.log("Use this address as SP1_VERIFIER for migration deployment:");
+        console.log("  SP1_VERIFIER=", vm.toString(address(gateway)));
+        console.log("");
+        console.log("Export for shell:");
+        console.log("  export SP1_VERIFIER=", vm.toString(address(gateway)));
+    }
+}

--- a/packages/migration-claim/scripts/deploy-sp1-gateway.sh
+++ b/packages/migration-claim/scripts/deploy-sp1-gateway.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Deploy SP1 infrastructure (Gateway + Verifier v5.0.0) to any EVM chain
+#
+# This is a one-time deployment per chain. The deployed SP1VerifierGateway address
+# should be used as SP1_VERIFIER when deploying the migration contracts.
+#
+# Prerequisites:
+# - Foundry installed
+# - Native tokens for gas (KITE for KiteAI, ETH for Base Sepolia, etc.)
+#
+# Environment Variables:
+#   PRIVATE_KEY (required) - Deployer private key
+#   OWNER (optional) - Gateway owner address, defaults to deployer
+#   RPC_URL (required) - RPC endpoint for the target chain
+#
+# Usage:
+#   # KiteAI Testnet
+#   PRIVATE_KEY=0x... RPC_URL=https://rpc-testnet.gokite.ai/ ./scripts/deploy-sp1-gateway.sh
+#
+#   # Base Sepolia (already has SP1 deployed, but can deploy custom if needed)
+#   PRIVATE_KEY=0x... RPC_URL=https://sepolia.base.org ./scripts/deploy-sp1-gateway.sh
+#
+#   # Local Anvil
+#   PRIVATE_KEY=0x... RPC_URL=http://localhost:8545 ./scripts/deploy-sp1-gateway.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "============================================"
+echo "SP1 Infrastructure Deployment"
+echo "============================================"
+
+# Check prerequisites
+command -v forge >/dev/null 2>&1 || { echo "Error: Foundry not installed"; exit 1; }
+
+# Validate required environment variables
+if [ -z "$PRIVATE_KEY" ]; then
+    echo "Error: PRIVATE_KEY environment variable is required"
+    echo ""
+    echo "Usage:"
+    echo "  PRIVATE_KEY=0x... RPC_URL=<rpc-url> $0"
+    exit 1
+fi
+
+if [ -z "$RPC_URL" ]; then
+    echo "Error: RPC_URL environment variable is required"
+    echo ""
+    echo "Usage:"
+    echo "  PRIVATE_KEY=0x... RPC_URL=<rpc-url> $0"
+    exit 1
+fi
+
+echo ""
+echo "Configuration:"
+echo "  RPC URL: $RPC_URL"
+if [ -n "$OWNER" ]; then
+    echo "  Owner: $OWNER"
+else
+    echo "  Owner: (deployer address)"
+fi
+echo ""
+
+# Check RPC connection
+if ! cast block-number --rpc-url "$RPC_URL" >/dev/null 2>&1; then
+    echo "Error: Cannot connect to RPC at $RPC_URL"
+    exit 1
+fi
+
+# Get chain ID for logging
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL")
+echo "Connected to chain ID: $CHAIN_ID"
+echo ""
+
+cd "$ROOT_DIR"
+
+# Check dependencies exist (managed at repo root level)
+DEPS_DIR="$ROOT_DIR/../../dependencies"
+if [ ! -d "$DEPS_DIR/forge-std" ]; then
+    echo "Error: forge-std not found in $DEPS_DIR"
+    echo "Run 'forge soldeer update' from the repository root first."
+    exit 1
+fi
+
+# Build contracts
+echo "Building contracts..."
+forge build
+
+# Deploy
+echo ""
+echo "Deploying SP1 infrastructure..."
+
+PRIVATE_KEY="$PRIVATE_KEY" \
+OWNER="${OWNER:-}" \
+forge script script/DeploySP1Infrastructure.s.sol:DeploySP1Infrastructure \
+    --rpc-url "$RPC_URL" \
+    --broadcast \
+    -vvv
+
+# Extract deployed addresses from broadcast
+BROADCAST_FILE=$(ls -t broadcast/DeploySP1Infrastructure.s.sol/*/run-latest.json 2>/dev/null | head -1)
+
+if [ -f "$BROADCAST_FILE" ]; then
+    GATEWAY_ADDRESS=$(grep -o '"contractName": "SP1VerifierGateway"' -A5 "$BROADCAST_FILE" | grep '"contractAddress"' | head -1 | grep -o '0x[a-fA-F0-9]\{40\}')
+    VERIFIER_ADDRESS=$(grep -o '"contractName": "SP1Verifier"' -A5 "$BROADCAST_FILE" | grep '"contractAddress"' | head -1 | grep -o '0x[a-fA-F0-9]\{40\}')
+
+    echo ""
+    echo "============================================"
+    echo "Deployment Summary"
+    echo "============================================"
+    echo ""
+    echo "Chain ID: $CHAIN_ID"
+    echo ""
+    echo "Deployed Contracts:"
+    echo "  SP1VerifierGateway: $GATEWAY_ADDRESS"
+    echo "  SP1Verifier v5.0.0: $VERIFIER_ADDRESS"
+    echo ""
+    echo "============================================"
+    echo "Next Steps"
+    echo "============================================"
+    echo ""
+    echo "Use the gateway address when deploying migration contracts:"
+    echo ""
+    echo "  export SP1_VERIFIER=$GATEWAY_ADDRESS"
+    echo ""
+    echo "Then run:"
+    echo "  PRIVATE_KEY=0x... PROGRAM_VKEY=0x... SP1_VERIFIER=$GATEWAY_ADDRESS \\"
+    echo "    ./scripts/deploy-tangle-migration.sh --kite"
+    echo ""
+fi

--- a/packages/migration-claim/scripts/deploy-tangle-migration.sh
+++ b/packages/migration-claim/scripts/deploy-tangle-migration.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Deploy Tangle Migration contracts to local testnet or Base Sepolia
+# Deploy Tangle Migration contracts to local testnet, Base Sepolia, or KiteAI Testnet
 #
 # This deploys:
 # 1. TNT Token (ERC20)
@@ -18,7 +18,7 @@
 #
 # Prerequisites:
 # - Foundry installed
-# - Local testnet running (or Base Sepolia RPC URL)
+# - Local testnet running (or Base Sepolia/KiteAI RPC URL)
 # - Run deploy-with-snapshot.ts first to generate JSON files
 #
 # Environment Variables:
@@ -26,58 +26,135 @@
 #   TREASURY_RECIPIENT - Address to receive treasury allocation (vested)
 #   FOUNDATION_RECIPIENT - Address to receive foundation allocation
 #   LIQUIDITY_OPS_RECIPIENT - Address to receive liquidity ops allocation
-#   PROGRAM_VKEY - SP1 program verification key (required for --production)
+#   PROGRAM_VKEY - SP1 program verification key (required for --base-sepolia, --kite-testnet)
+#   SP1_VERIFIER - SP1 verifier gateway address (required for --kite-testnet)
 #
 # Usage:
-#   ./scripts/deploy-tangle-migration.sh              # Local testnet with mock verifier
-#   ./scripts/deploy-tangle-migration.sh --production # Base Sepolia with SP1 verifier
+#   ./scripts/deploy-tangle-migration.sh                  # Local testnet with mock verifier
+#   ./scripts/deploy-tangle-migration.sh --base-sepolia    # Base Sepolia with SP1 verifier
+#   ./scripts/deploy-tangle-migration.sh --kite-testnet   # KiteAI Testnet with SP1 verifier
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Check for production flag
-PRODUCTION=false
-if [[ "$1" == "--production" ]]; then
-    PRODUCTION=true
-fi
+# Default network is local
+NETWORK="local"
+USE_MOCK_VERIFIER=true
+
+# Parse arguments
+for arg in "$@"; do
+    case $arg in
+        --base-sepolia)
+            NETWORK="base-sepolia"
+            USE_MOCK_VERIFIER=false
+            ;;
+        --kite-testnet)
+            NETWORK="kite-testnet"
+            USE_MOCK_VERIFIER=false
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --base-sepolia    Deploy to Base Sepolia testnet"
+            echo "  --kite-testnet    Deploy to KiteAI Testnet (Chain ID: 2368)"
+            echo "  --help, -h       Show this help message"
+            echo ""
+            echo "Default: Deploy to local testnet with mock verifier"
+            echo ""
+            echo "Required environment variables:"
+            echo "  PRIVATE_KEY      Deployer private key"
+            echo ""
+            echo "Required for --base-sepolia and --kite-testnet:"
+            echo "  PROGRAM_VKEY     SP1 program verification key"
+            echo ""
+            echo "Required for --kite-testnet:"
+            echo "  SP1_VERIFIER     SP1 verifier gateway address"
+            echo "                   Deploy with: ./scripts/deploy-sp1-gateway.sh"
+            exit 0
+            ;;
+    esac
+done
+
+# Network-specific configuration
+case $NETWORK in
+    local)
+        RPC_URL="${RPC_URL:-http://localhost:8545}"
+        SP1_VERIFIER_DEFAULT=""
+        CHAIN_NAME="Local Testnet"
+        ;;
+    base-sepolia)
+        RPC_URL="${RPC_URL:-https://sepolia.base.org}"
+        # Base Sepolia has SP1 verifier gateway deployed by Succinct
+        SP1_VERIFIER_DEFAULT="0x397A5f7f3dBd538f23DE225B51f532c34448dA9B"
+        CHAIN_NAME="Base Sepolia"
+        ;;
+    kite-testnet)
+        RPC_URL="${RPC_URL:-https://rpc-testnet.gokite.ai/}"
+        # KiteAI requires custom SP1 deployment - no default
+        SP1_VERIFIER_DEFAULT="${SP1_VERIFIER:-}"
+        CHAIN_NAME="KiteAI Testnet"
+        ;;
+esac
 
 echo "============================================"
 echo "Tangle Migration Deployment"
 echo "============================================"
+echo "Network: $CHAIN_NAME"
+
+if [ "$USE_MOCK_VERIFIER" = true ]; then
+    echo "Mode: LOCAL TESTING (Mock Verifier)"
+else
+    echo "Mode: PRODUCTION (SP1 Verifier)"
+fi
 
 # Check prerequisites
 command -v forge >/dev/null 2>&1 || { echo "Error: Foundry not installed"; exit 1; }
 
-# Configuration
-if [ "$PRODUCTION" = true ]; then
-    RPC_URL="${RPC_URL:-https://sepolia.base.org}"
-    USE_MOCK_VERIFIER=false
-    echo "Mode: PRODUCTION (Base Sepolia)"
-else
-    RPC_URL="${RPC_URL:-http://localhost:8545}"
-    USE_MOCK_VERIFIER=true
-    echo "Mode: LOCAL TESTING (Mock Verifier)"
-fi
-
 # PRIVATE_KEY is required
 if [ -z "$PRIVATE_KEY" ]; then
     echo "Error: PRIVATE_KEY environment variable is required"
-    echo "Usage: PRIVATE_KEY=0x... $0 [--production]"
+    echo "Usage: PRIVATE_KEY=0x... $0 [--base-sepolia|--kite]"
     exit 1
 fi
 
 # PROGRAM_VKEY is required in production mode
-if [ "$PRODUCTION" = true ] && [ -z "$PROGRAM_VKEY" ]; then
-    echo "Error: PROGRAM_VKEY environment variable is required in production mode"
-    echo "Usage: PRIVATE_KEY=0x... PROGRAM_VKEY=0x... $0 --production"
+if [ "$USE_MOCK_VERIFIER" = false ] && [ -z "$PROGRAM_VKEY" ]; then
+    echo "Error: PROGRAM_VKEY environment variable is required for $CHAIN_NAME"
+    echo ""
+    echo "Generate the vkey with:"
+    echo "  cd sp1/program && cargo prove build"
+    echo "  cd .. && cargo +succinct run --release -p sr25519-claim-script --bin vkey"
+    echo ""
+    echo "Usage: PRIVATE_KEY=0x... PROGRAM_VKEY=0x... $0 --$NETWORK"
     exit 1
 fi
+
+# SP1_VERIFIER is required for KiteAI (no default)
+if [ "$NETWORK" = "kite-testnet" ] && [ -z "$SP1_VERIFIER_DEFAULT" ]; then
+    echo "Error: SP1_VERIFIER environment variable is required for KiteAI Testnet"
+    echo ""
+    echo "KiteAI doesn't have a pre-deployed SP1 verifier. Deploy one first:"
+    echo "  PRIVATE_KEY=0x... RPC_URL=https://rpc-testnet.gokite.ai/ \\"
+    echo "    ./scripts/deploy-sp1-gateway.sh"
+    echo ""
+    echo "Then use the deployed gateway address:"
+    echo "  PRIVATE_KEY=0x... PROGRAM_VKEY=0x... SP1_VERIFIER=0x<gateway> \\"
+    echo "    $0 --kite-testnet"
+    exit 1
+fi
+
+# Use environment SP1_VERIFIER if set, otherwise use default for the network
+SP1_VERIFIER="${SP1_VERIFIER:-$SP1_VERIFIER_DEFAULT}"
 
 echo ""
 echo "Configuration:"
 echo "  RPC URL: $RPC_URL"
+if [ "$USE_MOCK_VERIFIER" = false ]; then
+    echo "  SP1 Verifier: $SP1_VERIFIER"
+fi
 echo ""
 
 # Check RPC connection
@@ -167,6 +244,7 @@ LIQUIDITY_OPS_RECIPIENT="${LIQUIDITY_OPS_RECIPIENT:-}" \
 USE_MOCK_VERIFIER="$USE_MOCK_VERIFIER" \
 ALLOW_STANDALONE_TOKEN="true" \
 PRIVATE_KEY="$PRIVATE_KEY" \
+SP1_VERIFIER="${SP1_VERIFIER:-0x397A5f7f3dBd538f23DE225B51f532c34448dA9B}" \
 PROGRAM_VKEY="${PROGRAM_VKEY:-0x0043b75837095121e5cfc178612414bddea823bad5aa08f3061b15b49c63a99f}" \
 forge script script/DeployTangleMigration.s.sol:DeployTangleMigration \
     --rpc-url "$RPC_URL" \
@@ -187,6 +265,8 @@ echo "============================================"
 echo "Deployment Complete!"
 echo "============================================"
 echo ""
+echo "Network: $CHAIN_NAME"
+echo ""
 echo "Contract Addresses:"
 echo "  TNT Token: $TNT_ADDRESS"
 echo "  TangleMigration: $MIGRATION_ADDRESS"
@@ -200,6 +280,31 @@ echo "  VITE_TANGLE_MIGRATION_ADDRESS=$MIGRATION_ADDRESS"
 echo "  VITE_ZK_VERIFIER_ADDRESS=$VERIFIER_ADDRESS"
 echo "  VITE_MIGRATION_MERKLE_ROOT=$MERKLE_ROOT"
 echo ""
+
+# Network-specific next steps
+case $NETWORK in
+    kite-testnet)
+        echo "Claim Relayer Configuration:"
+        echo "  CHAIN_ID=2368"
+        echo "  RPC_URL=https://rpc-testnet.gokite.ai/"
+        echo "  MIGRATION_CONTRACT=$MIGRATION_ADDRESS"
+        echo ""
+        echo "Block Explorer:"
+        echo "  https://testnet.kitescan.ai/address/$MIGRATION_ADDRESS"
+        echo ""
+        ;;
+    base-sepolia)
+        echo "Claim Relayer Configuration:"
+        echo "  CHAIN_ID=84532"
+        echo "  RPC_URL=https://sepolia.base.org"
+        echo "  MIGRATION_CONTRACT=$MIGRATION_ADDRESS"
+        echo ""
+        echo "Block Explorer:"
+        echo "  https://sepolia.basescan.org/address/$MIGRATION_ADDRESS"
+        echo ""
+        ;;
+esac
+
 echo "Next Steps:"
 echo "  1. Copy entries from merkle-tree.json to frontend (note: just entries field): "
 echo "     jq '.entries' $ROOT_DIR/merkle-tree.json > <path to frontend repo>/apps/tangle-dapp/public/data/migration-proofs.json"

--- a/packages/migration-claim/src/sp1/Groth16Verifier.sol
+++ b/packages/migration-claim/src/sp1/Groth16Verifier.sol
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+/// @title Groth16 verifier template.
+/// @author Remco Bloemen
+/// @notice Supports verifying Groth16 proofs. Proofs can be in uncompressed
+/// (256 bytes) and compressed (128 bytes) format. A view function is provided
+/// to compress proofs.
+/// @notice See <https://2π.com/23/bn254-compression> for further explanation.
+contract Groth16Verifier {
+
+    /// Some of the provided public input values are larger than the field modulus.
+    /// @dev Public input elements are not automatically reduced, as this is can be
+    /// a dangerous source of bugs.
+    error PublicInputNotInField();
+
+    /// The proof is invalid.
+    /// @dev This can mean that provided Groth16 proof points are not on their
+    /// curves, that pairing equation fails, or that the proof is not for the
+    /// provided public input.
+    error ProofInvalid();
+
+    // Addresses of precompiles
+    uint256 constant PRECOMPILE_MODEXP = 0x05;
+    uint256 constant PRECOMPILE_ADD = 0x06;
+    uint256 constant PRECOMPILE_MUL = 0x07;
+    uint256 constant PRECOMPILE_VERIFY = 0x08;
+
+    // Base field Fp order P and scalar field Fr order R.
+    // For BN254 these are computed as follows:
+    //     t = 4965661367192848881
+    //     P = 36⋅t⁴ + 36⋅t³ + 24⋅t² + 6⋅t + 1
+    //     R = 36⋅t⁴ + 36⋅t³ + 18⋅t² + 6⋅t + 1
+    uint256 constant P = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
+    uint256 constant R = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+
+    // Extension field Fp2 = Fp[i] / (i² + 1)
+    // Note: This is the complex extension field of Fp with i² = -1.
+    //       Values in Fp2 are represented as a pair of Fp elements (a₀, a₁) as a₀ + a₁⋅i.
+    // Note: The order of Fp2 elements is *opposite* that of the pairing contract, which
+    //       expects Fp2 elements in order (a₁, a₀). This is also the order in which
+    //       Fp2 elements are encoded in the public interface as this became convention.
+
+    // Constants in Fp
+    uint256 constant FRACTION_1_2_FP = 0x183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea4;
+    uint256 constant FRACTION_27_82_FP = 0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5;
+    uint256 constant FRACTION_3_82_FP = 0x2fcd3ac2a640a154eb23960892a85a68f031ca0c8344b23a577dcf1052b9e775;
+
+    // Exponents for inversions and square roots mod P
+    uint256 constant EXP_INVERSE_FP = 0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD45; // P - 2
+    uint256 constant EXP_SQRT_FP = 0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
+
+    // Groth16 alpha point in G1
+    uint256 constant ALPHA_X = 20491192805390485299153009773594534940189261866228447918068658471970481763042;
+    uint256 constant ALPHA_Y = 9383485363053290200918347156157836566562967994039712273449902621266178545958;
+
+    // Groth16 beta point in G2 in powers of i
+    uint256 constant BETA_NEG_X_0 = 6375614351688725206403948262868962793625744043794305715222011528459656738731;
+    uint256 constant BETA_NEG_X_1 = 4252822878758300859123897981450591353533073413197771768651442665752259397132;
+    uint256 constant BETA_NEG_Y_0 = 11383000245469012944693504663162918391286475477077232690815866754273895001727;
+    uint256 constant BETA_NEG_Y_1 = 41207766310529818958173054109690360505148424997958324311878202295167071904;
+
+    // Groth16 gamma point in G2 in powers of i
+    uint256 constant GAMMA_NEG_X_0 = 10857046999023057135944570762232829481370756359578518086990519993285655852781;
+    uint256 constant GAMMA_NEG_X_1 = 11559732032986387107991004021392285783925812861821192530917403151452391805634;
+    uint256 constant GAMMA_NEG_Y_0 = 13392588948715843804641432497768002650278120570034223513918757245338268106653;
+    uint256 constant GAMMA_NEG_Y_1 = 17805874995975841540914202342111839520379459829704422454583296818431106115052;
+
+    // Groth16 delta point in G2 in powers of i
+    uint256 constant DELTA_NEG_X_0 = 1807939758600928081661535078044266309701426477869595321608690071623627252461;
+    uint256 constant DELTA_NEG_X_1 = 13017767206419180294867239590191240882490168779777616723978810680471506089190;
+    uint256 constant DELTA_NEG_Y_0 = 11385252965472363874004017020523979267854101512663014352368174256411716100034;
+    uint256 constant DELTA_NEG_Y_1 = 707821308472421780425082520239282952693670279239989952629124761519869475067;
+
+    // Constant and public input points
+    uint256 constant CONSTANT_X = 17203997695518370725253383800612862082040222186834248316724952811913305748878;
+    uint256 constant CONSTANT_Y = 282619892079818506885924724237935832196325815176482254129420869757043108110;
+    uint256 constant PUB_0_X = 2763789253671512309630211343474627955637016507408470052385640371173442321228;
+    uint256 constant PUB_0_Y = 7070003421332099028511324531870215047017050364545890942981741487547942466073;
+    uint256 constant PUB_1_X = 2223923876691923064813371578678400285087400227347901303400514986210692294428;
+    uint256 constant PUB_1_Y = 3228708299174762375496115493137156328822199374794870011715145604387710550517;
+
+    /// Negation in Fp.
+    /// @notice Returns a number x such that a + x = 0 in Fp.
+    /// @notice The input does not need to be reduced.
+    /// @param a the base
+    /// @return x the result
+    function negate(uint256 a) internal pure returns (uint256 x) {
+        unchecked {
+            x = (P - (a % P)) % P; // Modulo is cheaper than branching
+        }
+    }
+
+    /// Exponentiation in Fp.
+    /// @notice Returns a number x such that a ^ e = x in Fp.
+    /// @notice The input does not need to be reduced.
+    /// @param a the base
+    /// @param e the exponent
+    /// @return x the result
+    function exp(uint256 a, uint256 e) internal view returns (uint256 x) {
+        bool success;
+        assembly ("memory-safe") {
+            let f := mload(0x40)
+            mstore(f, 0x20)
+            mstore(add(f, 0x20), 0x20)
+            mstore(add(f, 0x40), 0x20)
+            mstore(add(f, 0x60), a)
+            mstore(add(f, 0x80), e)
+            mstore(add(f, 0xa0), P)
+            success := staticcall(gas(), PRECOMPILE_MODEXP, f, 0xc0, f, 0x20)
+            x := mload(f)
+        }
+        if (!success) {
+            // Exponentiation failed.
+            // Should not happen.
+            revert ProofInvalid();
+        }
+    }
+
+    /// Invertsion in Fp.
+    /// @notice Returns a number x such that a * x = 1 in Fp.
+    /// @notice The input does not need to be reduced.
+    /// @notice Reverts with ProofInvalid() if the inverse does not exist
+    /// @param a the input
+    /// @return x the solution
+    function invert_Fp(uint256 a) internal view returns (uint256 x) {
+        x = exp(a, EXP_INVERSE_FP);
+        if (mulmod(a, x, P) != 1) {
+            // Inverse does not exist.
+            // Can only happen during G2 point decompression.
+            revert ProofInvalid();
+        }
+    }
+
+    /// Square root in Fp.
+    /// @notice Returns a number x such that x * x = a in Fp.
+    /// @notice Will revert with InvalidProof() if the input is not a square
+    /// or not reduced.
+    /// @param a the square
+    /// @return x the solution
+    function sqrt_Fp(uint256 a) internal view returns (uint256 x) {
+        x = exp(a, EXP_SQRT_FP);
+        if (mulmod(x, x, P) != a) {
+            // Square root does not exist or a is not reduced.
+            // Happens when G1 point is not on curve.
+            revert ProofInvalid();
+        }
+    }
+
+    /// Square test in Fp.
+    /// @notice Returns whether a number x exists such that x * x = a in Fp.
+    /// @notice Will revert with InvalidProof() if the input is not a square
+    /// or not reduced.
+    /// @param a the square
+    /// @return x the solution
+    function isSquare_Fp(uint256 a) internal view returns (bool) {
+        uint256 x = exp(a, EXP_SQRT_FP);
+        return mulmod(x, x, P) == a;
+    }
+
+    /// Square root in Fp2.
+    /// @notice Fp2 is the complex extension Fp[i]/(i^2 + 1). The input is
+    /// a0 + a1 ⋅ i and the result is x0 + x1 ⋅ i.
+    /// @notice Will revert with InvalidProof() if
+    ///   * the input is not a square,
+    ///   * the hint is incorrect, or
+    ///   * the input coefficents are not reduced.
+    /// @param a0 The real part of the input.
+    /// @param a1 The imaginary part of the input.
+    /// @param hint A hint which of two possible signs to pick in the equation.
+    /// @return x0 The real part of the square root.
+    /// @return x1 The imaginary part of the square root.
+    function sqrt_Fp2(uint256 a0, uint256 a1, bool hint) internal view returns (uint256 x0, uint256 x1) {
+        // If this square root reverts there is no solution in Fp2.
+        uint256 d = sqrt_Fp(addmod(mulmod(a0, a0, P), mulmod(a1, a1, P), P));
+        if (hint) {
+            d = negate(d);
+        }
+        // If this square root reverts there is no solution in Fp2.
+        x0 = sqrt_Fp(mulmod(addmod(a0, d, P), FRACTION_1_2_FP, P));
+        x1 = mulmod(a1, invert_Fp(mulmod(x0, 2, P)), P);
+
+        // Check result to make sure we found a root.
+        // Note: this also fails if a0 or a1 is not reduced.
+        if (a0 != addmod(mulmod(x0, x0, P), negate(mulmod(x1, x1, P)), P)
+        ||  a1 != mulmod(2, mulmod(x0, x1, P), P)) {
+            revert ProofInvalid();
+        }
+    }
+
+    /// Compress a G1 point.
+    /// @notice Reverts with InvalidProof if the coordinates are not reduced
+    /// or if the point is not on the curve.
+    /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+    /// @param x The X coordinate in Fp.
+    /// @param y The Y coordinate in Fp.
+    /// @return c The compresed point (x with one signal bit).
+    function compress_g1(uint256 x, uint256 y) internal view returns (uint256 c) {
+        if (x >= P || y >= P) {
+            // G1 point not in field.
+            revert ProofInvalid();
+        }
+        if (x == 0 && y == 0) {
+            // Point at infinity
+            return 0;
+        }
+
+        // Note: sqrt_Fp reverts if there is no solution, i.e. the x coordinate is invalid.
+        uint256 y_pos = sqrt_Fp(addmod(mulmod(mulmod(x, x, P), x, P), 3, P));
+        if (y == y_pos) {
+            return (x << 1) | 0;
+        } else if (y == negate(y_pos)) {
+            return (x << 1) | 1;
+        } else {
+            // G1 point not on curve.
+            revert ProofInvalid();
+        }
+    }
+
+    /// Decompress a G1 point.
+    /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+    /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+    /// @param c The compresed point (x with one signal bit).
+    /// @return x The X coordinate in Fp.
+    /// @return y The Y coordinate in Fp.
+    function decompress_g1(uint256 c) internal view returns (uint256 x, uint256 y) {
+        // Note that X = 0 is not on the curve since 0³ + 3 = 3 is not a square.
+        // so we can use it to represent the point at infinity.
+        if (c == 0) {
+            // Point at infinity as encoded in EIP196 and EIP197.
+            return (0, 0);
+        }
+        bool negate_point = c & 1 == 1;
+        x = c >> 1;
+        if (x >= P) {
+            // G1 x coordinate not in field.
+            revert ProofInvalid();
+        }
+
+        // Note: (x³ + 3) is irreducible in Fp, so it can not be zero and therefore
+        //       y can not be zero.
+        // Note: sqrt_Fp reverts if there is no solution, i.e. the point is not on the curve.
+        y = sqrt_Fp(addmod(mulmod(mulmod(x, x, P), x, P), 3, P));
+        if (negate_point) {
+            y = negate(y);
+        }
+    }
+
+    /// Compress a G2 point.
+    /// @notice Reverts with InvalidProof if the coefficients are not reduced
+    /// or if the point is not on the curve.
+    /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+    /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+    /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+    /// @param x0 The real part of the X coordinate.
+    /// @param x1 The imaginary poart of the X coordinate.
+    /// @param y0 The real part of the Y coordinate.
+    /// @param y1 The imaginary part of the Y coordinate.
+    /// @return c0 The first half of the compresed point (x0 with two signal bits).
+    /// @return c1 The second half of the compressed point (x1 unmodified).
+    function compress_g2(uint256 x0, uint256 x1, uint256 y0, uint256 y1)
+    internal view returns (uint256 c0, uint256 c1) {
+        if (x0 >= P || x1 >= P || y0 >= P || y1 >= P) {
+            // G2 point not in field.
+            revert ProofInvalid();
+        }
+        if ((x0 | x1 | y0 | y1) == 0) {
+            // Point at infinity
+            return (0, 0);
+        }
+
+        // Compute y^2
+        // Note: shadowing variables and scoping to avoid stack-to-deep.
+        uint256 y0_pos;
+        uint256 y1_pos;
+        {
+            uint256 n3ab = mulmod(mulmod(x0, x1, P), P-3, P);
+            uint256 a_3 = mulmod(mulmod(x0, x0, P), x0, P);
+            uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
+            y0_pos = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
+            y1_pos = negate(addmod(FRACTION_3_82_FP,  addmod(b_3, mulmod(n3ab, x0, P), P), P));
+        }
+
+        // Determine hint bit
+        // If this sqrt fails the x coordinate is not on the curve.
+        bool hint;
+        {
+            uint256 d = sqrt_Fp(addmod(mulmod(y0_pos, y0_pos, P), mulmod(y1_pos, y1_pos, P), P));
+            hint = !isSquare_Fp(mulmod(addmod(y0_pos, d, P), FRACTION_1_2_FP, P));
+        }
+
+        // Recover y
+        (y0_pos, y1_pos) = sqrt_Fp2(y0_pos, y1_pos, hint);
+        if (y0 == y0_pos && y1 == y1_pos) {
+            c0 = (x0 << 2) | (hint ? 2  : 0) | 0;
+            c1 = x1;
+        } else if (y0 == negate(y0_pos) && y1 == negate(y1_pos)) {
+            c0 = (x0 << 2) | (hint ? 2  : 0) | 1;
+            c1 = x1;
+        } else {
+            // G1 point not on curve.
+            revert ProofInvalid();
+        }
+    }
+
+    /// Decompress a G2 point.
+    /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+    /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+    /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+    /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+    /// @param c0 The first half of the compresed point (x0 with two signal bits).
+    /// @param c1 The second half of the compressed point (x1 unmodified).
+    /// @return x0 The real part of the X coordinate.
+    /// @return x1 The imaginary poart of the X coordinate.
+    /// @return y0 The real part of the Y coordinate.
+    /// @return y1 The imaginary part of the Y coordinate.
+    function decompress_g2(uint256 c0, uint256 c1)
+    internal view returns (uint256 x0, uint256 x1, uint256 y0, uint256 y1) {
+        // Note that X = (0, 0) is not on the curve since 0³ + 3/(9 + i) is not a square.
+        // so we can use it to represent the point at infinity.
+        if (c0 == 0 && c1 == 0) {
+            // Point at infinity as encoded in EIP197.
+            return (0, 0, 0, 0);
+        }
+        bool negate_point = c0 & 1 == 1;
+        bool hint = c0 & 2 == 2;
+        x0 = c0 >> 2;
+        x1 = c1;
+        if (x0 >= P || x1 >= P) {
+            // G2 x0 or x1 coefficient not in field.
+            revert ProofInvalid();
+        }
+
+        uint256 n3ab = mulmod(mulmod(x0, x1, P), P-3, P);
+        uint256 a_3 = mulmod(mulmod(x0, x0, P), x0, P);
+        uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
+
+        y0 = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
+        y1 = negate(addmod(FRACTION_3_82_FP,  addmod(b_3, mulmod(n3ab, x0, P), P), P));
+
+        // Note: sqrt_Fp2 reverts if there is no solution, i.e. the point is not on the curve.
+        // Note: (X³ + 3/(9 + i)) is irreducible in Fp2, so y can not be zero.
+        //       But y0 or y1 may still independently be zero.
+        (y0, y1) = sqrt_Fp2(y0, y1, hint);
+        if (negate_point) {
+            y0 = negate(y0);
+            y1 = negate(y1);
+        }
+    }
+
+    /// Compute the public input linear combination.
+    /// @notice Reverts with PublicInputNotInField if the input is not in the field.
+    /// @notice Computes the multi-scalar-multiplication of the public input
+    /// elements and the verification key including the constant term.
+    /// @param input The public inputs. These are elements of the scalar field Fr.
+    /// @return x The X coordinate of the resulting G1 point.
+    /// @return y The Y coordinate of the resulting G1 point.
+    function publicInputMSM(uint256[2] calldata input)
+    internal view returns (uint256 x, uint256 y) {
+        // Note: The ECMUL precompile does not reject unreduced values, so we check this.
+        // Note: Unrolling this loop does not cost much extra in code-size, the bulk of the
+        //       code-size is in the PUB_ constants.
+        // ECMUL has input (x, y, scalar) and output (x', y').
+        // ECADD has input (x1, y1, x2, y2) and output (x', y').
+        // We reduce commitments(if any) with constants as the first point argument to ECADD.
+        // We call them such that ecmul output is already in the second point
+        // argument to ECADD so we can have a tight loop.
+        bool success = true;
+        assembly ("memory-safe") {
+            let f := mload(0x40)
+            let g := add(f, 0x40)
+            let s
+            mstore(f, CONSTANT_X)
+            mstore(add(f, 0x20), CONSTANT_Y)
+            mstore(g, PUB_0_X)
+            mstore(add(g, 0x20), PUB_0_Y)
+            s :=  calldataload(input)
+            mstore(add(g, 0x40), s)
+            success := and(success, lt(s, R))
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+            mstore(g, PUB_1_X)
+            mstore(add(g, 0x20), PUB_1_Y)
+            s :=  calldataload(add(input, 32))
+            mstore(add(g, 0x40), s)
+            success := and(success, lt(s, R))
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+
+            x := mload(f)
+            y := mload(add(f, 0x20))
+        }
+        if (!success) {
+            // Either Public input not in field, or verification key invalid.
+            // We assume the contract is correctly generated, so the verification key is valid.
+            revert PublicInputNotInField();
+        }
+    }
+
+    /// Compress a proof.
+    /// @notice Will revert with InvalidProof if the curve points are invalid,
+    /// but does not verify the proof itself.
+    /// @param proof The uncompressed Groth16 proof. Elements are in the same order as for
+    /// verifyProof. I.e. Groth16 points (A, B, C) encoded as in EIP-197.
+    /// @return compressed The compressed proof. Elements are in the same order as for
+    /// verifyCompressedProof. I.e. points (A, B, C) in compressed format.
+    function compressProof(uint256[8] calldata proof)
+    public view returns (uint256[4] memory compressed) {
+        compressed[0] = compress_g1(proof[0], proof[1]);
+        (compressed[2], compressed[1]) = compress_g2(proof[3], proof[2], proof[5], proof[4]);
+        compressed[3] = compress_g1(proof[6], proof[7]);
+    }
+
+    /// Verify a Groth16 proof with compressed points.
+    /// @notice Reverts with InvalidProof if the proof is invalid or
+    /// with PublicInputNotInField the public input is not reduced.
+    /// @notice There is no return value. If the function does not revert, the
+    /// proof was successfully verified.
+    /// @param compressedProof the points (A, B, C) in compressed format
+    /// matching the output of compressProof.
+    /// @param input the public input field elements in the scalar field Fr.
+    /// Elements must be reduced.
+    function verifyCompressedProof(
+        uint256[4] calldata compressedProof,
+        uint256[2] calldata input
+    ) public view {
+        uint256[24] memory pairings;
+
+        {
+            (uint256 Ax, uint256 Ay) = decompress_g1(compressedProof[0]);
+            (uint256 Bx0, uint256 Bx1, uint256 By0, uint256 By1) = decompress_g2(compressedProof[2], compressedProof[1]);
+            (uint256 Cx, uint256 Cy) = decompress_g1(compressedProof[3]);
+            (uint256 Lx, uint256 Ly) = publicInputMSM(input);
+
+            // Verify the pairing
+            // Note: The precompile expects the F2 coefficients in big-endian order.
+            // Note: The pairing precompile rejects unreduced values, so we won't check that here.
+            // e(A, B)
+            pairings[ 0] = Ax;
+            pairings[ 1] = Ay;
+            pairings[ 2] = Bx1;
+            pairings[ 3] = Bx0;
+            pairings[ 4] = By1;
+            pairings[ 5] = By0;
+            // e(C, -δ)
+            pairings[ 6] = Cx;
+            pairings[ 7] = Cy;
+            pairings[ 8] = DELTA_NEG_X_1;
+            pairings[ 9] = DELTA_NEG_X_0;
+            pairings[10] = DELTA_NEG_Y_1;
+            pairings[11] = DELTA_NEG_Y_0;
+            // e(α, -β)
+            pairings[12] = ALPHA_X;
+            pairings[13] = ALPHA_Y;
+            pairings[14] = BETA_NEG_X_1;
+            pairings[15] = BETA_NEG_X_0;
+            pairings[16] = BETA_NEG_Y_1;
+            pairings[17] = BETA_NEG_Y_0;
+            // e(L_pub, -γ)
+            pairings[18] = Lx;
+            pairings[19] = Ly;
+            pairings[20] = GAMMA_NEG_X_1;
+            pairings[21] = GAMMA_NEG_X_0;
+            pairings[22] = GAMMA_NEG_Y_1;
+            pairings[23] = GAMMA_NEG_Y_0;
+
+            // Check pairing equation.
+            bool success;
+            uint256[1] memory output;
+            assembly ("memory-safe") {
+                success := staticcall(gas(), PRECOMPILE_VERIFY, pairings, 0x300, output, 0x20)
+            }
+            if (!success || output[0] != 1) {
+                // Either proof or verification key invalid.
+                // We assume the contract is correctly generated, so the verification key is valid.
+                revert ProofInvalid();
+            }
+        }
+    }
+
+    /// Verify an uncompressed Groth16 proof.
+    /// @notice Reverts with InvalidProof if the proof is invalid or
+    /// with PublicInputNotInField the public input is not reduced.
+    /// @notice There is no return value. If the function does not revert, the
+    /// proof was successfully verified.
+    /// @param proof the points (A, B, C) in EIP-197 format matching the output
+    /// of compressProof.
+    /// @param input the public input field elements in the scalar field Fr.
+    /// Elements must be reduced.
+    function Verify(
+        uint256[8] calldata proof,
+        uint256[2] calldata input
+    ) public view {
+        (uint256 x, uint256 y) = publicInputMSM(input);
+
+        // Note: The precompile expects the F2 coefficients in big-endian order.
+        // Note: The pairing precompile rejects unreduced values, so we won't check that here.
+        bool success;
+        assembly ("memory-safe") {
+            let f := mload(0x40) // Free memory pointer.
+
+            // Copy points (A, B, C) to memory. They are already in correct encoding.
+            // This is pairing e(A, B) and G1 of e(C, -δ).
+            calldatacopy(f, proof, 0x100)
+
+            // Complete e(C, -δ) and write e(α, -β), e(L_pub, -γ) to memory.
+            // OPT: This could be better done using a single codecopy, but
+            //      Solidity (unlike standalone Yul) doesn't provide a way to
+            //      to do this.
+            mstore(add(f, 0x100), DELTA_NEG_X_1)
+            mstore(add(f, 0x120), DELTA_NEG_X_0)
+            mstore(add(f, 0x140), DELTA_NEG_Y_1)
+            mstore(add(f, 0x160), DELTA_NEG_Y_0)
+            mstore(add(f, 0x180), ALPHA_X)
+            mstore(add(f, 0x1a0), ALPHA_Y)
+            mstore(add(f, 0x1c0), BETA_NEG_X_1)
+            mstore(add(f, 0x1e0), BETA_NEG_X_0)
+            mstore(add(f, 0x200), BETA_NEG_Y_1)
+            mstore(add(f, 0x220), BETA_NEG_Y_0)
+            mstore(add(f, 0x240), x)
+            mstore(add(f, 0x260), y)
+            mstore(add(f, 0x280), GAMMA_NEG_X_1)
+            mstore(add(f, 0x2a0), GAMMA_NEG_X_0)
+            mstore(add(f, 0x2c0), GAMMA_NEG_Y_1)
+            mstore(add(f, 0x2e0), GAMMA_NEG_Y_0)
+
+            // Check pairing equation.
+            success := staticcall(gas(), PRECOMPILE_VERIFY, f, 0x300, f, 0x20)
+            // Also check returned value (both are either 1 or 0).
+            success := and(success, mload(f))
+        }
+        if (!success) {
+            // Either proof or verification key invalid.
+            // We assume the contract is correctly generated, so the verification key is valid.
+            revert ProofInvalid();
+        }
+    }
+}

--- a/packages/migration-claim/src/sp1/ISP1Verifier.sol
+++ b/packages/migration-claim/src/sp1/ISP1Verifier.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title SP1 Verifier Interface
+/// @author Succinct Labs
+/// @notice This contract is the interface for the SP1 Verifier.
+interface ISP1Verifier {
+    /// @notice Verifies a proof with given public values and vkey.
+    /// @dev It is expected that the first 4 bytes of proofBytes must match the first 4 bytes of
+    /// target verifier's VERIFIER_HASH.
+    /// @param programVKey The verification key for the RISC-V program.
+    /// @param publicValues The public values encoded as bytes.
+    /// @param proofBytes The proof of the program execution the SP1 zkVM encoded as bytes.
+    function verifyProof(
+        bytes32 programVKey,
+        bytes calldata publicValues,
+        bytes calldata proofBytes
+    ) external view;
+}
+
+interface ISP1VerifierWithHash is ISP1Verifier {
+    /// @notice Returns the hash of the verifier.
+    function VERIFIER_HASH() external pure returns (bytes32);
+}

--- a/packages/migration-claim/src/sp1/ISP1VerifierGateway.sol
+++ b/packages/migration-claim/src/sp1/ISP1VerifierGateway.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISP1Verifier} from "./ISP1Verifier.sol";
+
+/// @dev A struct containing the address of a verifier and whether the verifier is frozen. A
+/// frozen verifier cannot be routed to.
+struct VerifierRoute {
+    address verifier;
+    bool frozen;
+}
+
+interface ISP1VerifierGatewayEvents {
+    /// @notice Emitted when a verifier route is added.
+    /// @param selector The verifier selector that was added.
+    /// @param verifier The address of the verifier contract.
+    event RouteAdded(bytes4 selector, address verifier);
+
+    /// @notice Emitted when a verifier route is frozen.
+    /// @param selector The verifier selector that was frozen.
+    /// @param verifier The address of the verifier contract.
+    event RouteFrozen(bytes4 selector, address verifier);
+}
+
+interface ISP1VerifierGatewayErrors {
+    /// @notice Thrown when the verifier route is not found.
+    /// @param selector The verifier selector that was specified.
+    error RouteNotFound(bytes4 selector);
+
+    /// @notice Thrown when the verifier route is found, but is frozen.
+    /// @param selector The verifier selector that was specified.
+    error RouteIsFrozen(bytes4 selector);
+
+    /// @notice Thrown when adding a verifier route and the selector already contains a route.
+    /// @param verifier The address of the verifier contract in the existing route.
+    error RouteAlreadyExists(address verifier);
+
+    /// @notice Thrown when adding a verifier route and the selector returned by the verifier is
+    /// zero.
+    error SelectorCannotBeZero();
+}
+
+/// @title SP1 Verifier Gateway Interface
+/// @author Succinct Labs
+/// @notice This contract is the interface for the SP1 Verifier Gateway.
+interface ISP1VerifierGateway is
+    ISP1VerifierGatewayEvents,
+    ISP1VerifierGatewayErrors,
+    ISP1Verifier
+{
+    /// @notice Mapping of 4-byte verifier selectors to verifier routes.
+    /// @dev Only one verifier route can be added for each selector.
+    /// @param selector The verifier selector, which is both the first 4 bytes of the VERIFIER_HASH
+    /// and the first 4 bytes of the proofs designed for that verifier.
+    /// @return verifier The address of the verifier contract.
+    /// @return frozen Whether the verifier is frozen.
+    function routes(bytes4 selector) external view returns (address verifier, bool frozen);
+
+    /// @notice Adds a verifier route. This enable proofs to be routed to this verifier.
+    /// @dev Only callable by the owner. The owner is responsible for ensuring that the specified
+    /// verifier is correct with a valid VERIFIER_HASH. Once a route to a verifier is added, it
+    /// cannot be removed.
+    /// @param verifier The address of the verifier contract. This verifier MUST implement the
+    /// ISP1VerifierWithHash interface.
+    function addRoute(address verifier) external;
+
+    /// @notice Freezes a verifier route. This prevents proofs from being routed to this verifier.
+    /// @dev Only callable by the owner. Once a route to a verifier is frozen, it cannot be
+    /// unfrozen.
+    /// @param selector The verifier selector to freeze.
+    function freezeRoute(bytes4 selector) external;
+}

--- a/packages/migration-claim/src/sp1/README.md
+++ b/packages/migration-claim/src/sp1/README.md
@@ -1,0 +1,5 @@
+# SP1 Verifier Contracts
+
+These contracts are copied from [succinctlabs/sp1-contracts](https://github.com/succinctlabs/sp1-contracts) v5.0.0 under the MIT License.
+
+Copyright (c) Succinct Labs

--- a/packages/migration-claim/src/sp1/SP1Verifier.sol
+++ b/packages/migration-claim/src/sp1/SP1Verifier.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISP1Verifier, ISP1VerifierWithHash} from "./ISP1Verifier.sol";
+import {Groth16Verifier} from "./Groth16Verifier.sol";
+
+/// @title SP1 Verifier
+/// @author Succinct Labs
+/// @notice This contracts implements a solidity verifier for SP1.
+contract SP1Verifier is Groth16Verifier, ISP1VerifierWithHash {
+    /// @notice Thrown when the verifier selector from this proof does not match the one in this
+    /// verifier. This indicates that this proof was sent to the wrong verifier.
+    /// @param received The verifier selector from the first 4 bytes of the proof.
+    /// @param expected The verifier selector from the first 4 bytes of the VERIFIER_HASH().
+    error WrongVerifierSelector(bytes4 received, bytes4 expected);
+
+    /// @notice Thrown when the proof is invalid.
+    error InvalidProof();
+
+    function VERSION() external pure returns (string memory) {
+        return "v5.0.0";
+    }
+
+    /// @inheritdoc ISP1VerifierWithHash
+    function VERIFIER_HASH() public pure returns (bytes32) {
+        return 0xa4594c59bbc142f3b81c3ecb7f50a7c34bc9af7c4c444b5d48b795427e285913;
+    }
+
+    /// @notice Hashes the public values to a field elements inside Bn254.
+    /// @param publicValues The public values.
+    function hashPublicValues(
+        bytes calldata publicValues
+    ) public pure returns (bytes32) {
+        return sha256(publicValues) & bytes32(uint256((1 << 253) - 1));
+    }
+
+    /// @notice Verifies a proof with given public values and vkey.
+    /// @param programVKey The verification key for the RISC-V program.
+    /// @param publicValues The public values encoded as bytes.
+    /// @param proofBytes The proof of the program execution the SP1 zkVM encoded as bytes.
+    function verifyProof(
+        bytes32 programVKey,
+        bytes calldata publicValues,
+        bytes calldata proofBytes
+    ) external view {
+        bytes4 receivedSelector = bytes4(proofBytes[:4]);
+        bytes4 expectedSelector = bytes4(VERIFIER_HASH());
+        if (receivedSelector != expectedSelector) {
+            revert WrongVerifierSelector(receivedSelector, expectedSelector);
+        }
+
+        bytes32 publicValuesDigest = hashPublicValues(publicValues);
+        uint256[2] memory inputs;
+        inputs[0] = uint256(programVKey);
+        inputs[1] = uint256(publicValuesDigest);
+        uint256[8] memory proof = abi.decode(proofBytes[4:], (uint256[8]));
+        this.Verify(proof, inputs);
+    }
+}

--- a/packages/migration-claim/src/sp1/SP1VerifierGateway.sol
+++ b/packages/migration-claim/src/sp1/SP1VerifierGateway.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISP1Verifier, ISP1VerifierWithHash} from "./ISP1Verifier.sol";
+import {ISP1VerifierGateway, VerifierRoute} from "./ISP1VerifierGateway.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title SP1 Verifier Gateway
+/// @author Succinct Labs
+/// @notice This contract verifies proofs by routing to the correct verifier based on the verifier
+/// selector contained in the first 4 bytes of the proof. It additionally checks that to see that
+/// the verifier route is not frozen.
+contract SP1VerifierGateway is ISP1VerifierGateway, Ownable {
+    /// @inheritdoc ISP1VerifierGateway
+    mapping(bytes4 => VerifierRoute) public routes;
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    /// @inheritdoc ISP1Verifier
+    function verifyProof(
+        bytes32 programVKey,
+        bytes calldata publicValues,
+        bytes calldata proofBytes
+    ) external view {
+        bytes4 selector = bytes4(proofBytes[:4]);
+        VerifierRoute memory route = routes[selector];
+        if (route.verifier == address(0)) {
+            revert RouteNotFound(selector);
+        } else if (route.frozen) {
+            revert RouteIsFrozen(selector);
+        }
+
+        ISP1Verifier(route.verifier).verifyProof(programVKey, publicValues, proofBytes);
+    }
+
+    /// @inheritdoc ISP1VerifierGateway
+    function addRoute(address verifier) external onlyOwner {
+        bytes4 selector = bytes4(ISP1VerifierWithHash(verifier).VERIFIER_HASH());
+        if (selector == bytes4(0)) {
+            revert SelectorCannotBeZero();
+        }
+
+        VerifierRoute storage route = routes[selector];
+        if (route.verifier != address(0)) {
+            revert RouteAlreadyExists(route.verifier);
+        }
+
+        route.verifier = verifier;
+
+        emit RouteAdded(selector, verifier);
+    }
+
+    /// @inheritdoc ISP1VerifierGateway
+    function freezeRoute(bytes4 selector) external onlyOwner {
+        VerifierRoute storage route = routes[selector];
+        if (route.verifier == address(0)) {
+            revert RouteNotFound(selector);
+        }
+        if (route.frozen) {
+            revert RouteIsFrozen(selector);
+        }
+
+        route.frozen = true;
+
+        emit RouteFrozen(selector, route.verifier);
+    }
+}


### PR DESCRIPTION
## Summary

- Add KiteAI Testnet (chain ID 2368) support for deploying migration contracts
- Include SP1 verifier infrastructure for chains without pre-deployed SP1 contracts
- Refactor deployment script to support multiple networks with proper argument parsing

## Changes

- **claim-relayer**: Add KiteAI Testnet chain definition
- **foundry.toml**: Add kite_testnet RPC and etherscan configuration
- **deploy-tangle-migration.sh**: Refactor to support `--base-sepolia` and `--kite-testnet` flags with help text
- **SP1 contracts**: Add Groth16Verifier, SP1Verifier, SP1VerifierGateway for custom deployments
- **DeploySP1Infrastructure.s.sol**: Script to deploy SP1 verifier gateway
- **deploy-sp1-gateway.sh**: Shell wrapper for SP1 gateway deployment
- **KITE_TESTNET_GUIDE.md**: Documentation for KiteAI deployment process
- **.gitignore**: Fix to only exclude root `/docs/` directory

## Test plan

- [ ] Deploy to local testnet with mock verifier
- [ ] Deploy SP1 gateway to KiteAI Testnet
- [ ] Deploy migration contracts to KiteAI Testnet
- [ ] Verify claim-relayer works with KiteAI chain ID 2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)