### PR TITLE
feat(quotes): resource commitment tiers in signed quotes

### DIFF
--- a/script/CreateServiceForTLV2Test.s.sol
+++ b/script/CreateServiceForTLV2Test.s.sol
@@ -11,45 +11,46 @@ contract CreateServiceForTLV2Test is Script {
     uint256 constant OPERATOR1_KEY = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
     address constant TANGLE = 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9;
     address constant OPERATOR1 = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
-    
+
     function run() external {
         ITangleFull tangle = ITangleFull(payable(TANGLE));
-        
+
         // 1. Register operator1 for blueprint 1
         console2.log("Registering operator for blueprint 1...");
         vm.startBroadcast(OPERATOR1_KEY);
-        bytes memory operator1Key = hex"040102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40";
+        bytes memory operator1Key =
+            hex"040102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40";
         tangle.registerOperator(1, operator1Key, "http://operator1.local:8545");
         vm.stopBroadcast();
         console2.log("Operator registered");
-        
+
         // 2. Request service for blueprint 1 with operator1
         console2.log("Requesting service for blueprint 1...");
         vm.startBroadcast(DEPLOYER_KEY);
-        
+
         address[] memory operators = new address[](1);
         operators[0] = OPERATOR1;
         address[] memory permittedCallers = new address[](0); // Anyone can call
-        
+
         uint64 serviceId = tangle.requestService(
-            1,                      // blueprintId
-            operators,              // operators 
-            "",                     // config
-            permittedCallers,       // permittedCallers
-            uint64(7 days),         // ttl
-            address(0),             // paymentToken (native)
-            0                       // paymentAmount
+            1, // blueprintId
+            operators, // operators
+            "", // config
+            permittedCallers, // permittedCallers
+            uint64(7 days), // ttl
+            address(0), // paymentToken (native)
+            0 // paymentAmount
         );
         console2.log("Service requested with ID:", serviceId);
         vm.stopBroadcast();
-        
+
         // 3. Approve service as operator1
         console2.log("Approving service as operator1...");
         vm.startBroadcast(OPERATOR1_KEY);
         tangle.approveService(serviceId, 100); // 100% restaking
         vm.stopBroadcast();
         console2.log("Service approved and active");
-        
+
         console2.log("Done! Service ID:", serviceId);
     }
 }

--- a/script/CreateTestBlueprintTLV2.s.sol
+++ b/script/CreateTestBlueprintTLV2.s.sol
@@ -12,10 +12,10 @@ import { BlueprintDefinitionHelper } from "../test/support/BlueprintDefinitionHe
 contract CreateTestBlueprintTLV2 is Script, BlueprintDefinitionHelper {
     uint256 constant DEPLOYER_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
     address constant TANGLE = 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9;
-    
+
     function run() external {
         vm.startBroadcast(DEPLOYER_KEY);
-        
+
         // Create blueprint with TLV v2 schemas
         Types.BlueprintDefinition memory def = _blueprintDefinition("http://localhost/test", address(0));
         def.config.membership = Types.MembershipModel.Dynamic;
@@ -23,31 +23,31 @@ contract CreateTestBlueprintTLV2 is Script, BlueprintDefinitionHelper {
         def.config.maxOperators = 0;
         def.metadata.name = "TLV v2 Test Blueprint";
         def.metadata.description = "Blueprint with named parameters for TLV v2 testing";
-        
+
         // Add jobs with proper schemas that have field names
         Types.JobDefinition[] memory jobs = new Types.JobDefinition[](2);
-        
+
         // Job 0: hello with "name" param (string)
         jobs[0].name = "hello";
         jobs[0].description = "Greets with a personalized message";
         jobs[0].paramsSchema = _stringSchema("name");
         jobs[0].resultSchema = _stringSchema("greeting");
-        
+
         // Job 1: multiplyNumbers with "a" and "b" params
         jobs[1].name = "multiplyNumbers";
         jobs[1].description = "Multiplies two numbers";
         jobs[1].paramsSchema = _twoUint256Schema("a", "b");
         jobs[1].resultSchema = _uint256Schema("product");
-        
+
         def.jobs = jobs;
-        
+
         ITangleFull tangle = ITangleFull(payable(TANGLE));
         uint64 blueprintId = tangle.createBlueprint(def);
         console2.log("Blueprint created with ID:", blueprintId);
-        
+
         vm.stopBroadcast();
     }
-    
+
     function _stringSchema(string memory fieldName) internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.String;
@@ -56,7 +56,7 @@ contract CreateTestBlueprintTLV2 is Script, BlueprintDefinitionHelper {
         fields[0].name = fieldName;
         return SchemaLib.encodeSchema(fields);
     }
-    
+
     function _uint256Schema(string memory fieldName) internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](1);
         fields[0].kind = Types.BlueprintFieldKind.Uint256;
@@ -65,7 +65,7 @@ contract CreateTestBlueprintTLV2 is Script, BlueprintDefinitionHelper {
         fields[0].name = fieldName;
         return SchemaLib.encodeSchema(fields);
     }
-    
+
     function _twoUint256Schema(string memory name1, string memory name2) internal pure returns (bytes memory) {
         Types.BlueprintFieldType[] memory fields = new Types.BlueprintFieldType[](2);
         fields[0].kind = Types.BlueprintFieldKind.Uint256;

--- a/script/DemoSimulation.s.sol
+++ b/script/DemoSimulation.s.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Script, console2} from "forge-std/Script.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Script, console2 } from "forge-std/Script.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import {Tangle} from "../src/Tangle.sol";
+import { Tangle } from "../src/Tangle.sol";
 import { ITangleFull } from "../src/interfaces/ITangle.sol";
 import { IMultiAssetDelegation } from "../src/interfaces/IMultiAssetDelegation.sol";
-import {MultiAssetDelegation} from "../src/staking/MultiAssetDelegation.sol";
-import {OperatorStatusRegistry} from "../src/staking/OperatorStatusRegistry.sol";
-import {TangleToken} from "../src/governance/TangleToken.sol";
-import {MasterBlueprintServiceManager} from "../src/MasterBlueprintServiceManager.sol";
-import {MBSMRegistry} from "../src/MBSMRegistry.sol";
-import {Types} from "../src/libraries/Types.sol";
-import {BlueprintDefinitionHelper} from "../test/support/BlueprintDefinitionHelper.sol";
+import { MultiAssetDelegation } from "../src/staking/MultiAssetDelegation.sol";
+import { OperatorStatusRegistry } from "../src/staking/OperatorStatusRegistry.sol";
+import { TangleToken } from "../src/governance/TangleToken.sol";
+import { MasterBlueprintServiceManager } from "../src/MasterBlueprintServiceManager.sol";
+import { MBSMRegistry } from "../src/MBSMRegistry.sol";
+import { Types } from "../src/libraries/Types.sol";
+import { BlueprintDefinitionHelper } from "../test/support/BlueprintDefinitionHelper.sol";
 import { TangleBlueprintsFacet } from "../src/facets/tangle/TangleBlueprintsFacet.sol";
 import { TangleBlueprintsManagementFacet } from "../src/facets/tangle/TangleBlueprintsManagementFacet.sol";
 import { TangleOperatorsFacet } from "../src/facets/tangle/TangleOperatorsFacet.sol";
@@ -284,7 +284,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
         // Fund operators
         for (uint256 i = 0; i < operators.length; i++) {
-            vm.deal(operators[i], 1_000 ether);
+            vm.deal(operators[i], 1000 ether);
         }
 
         // Fund delegators
@@ -365,8 +365,8 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         vm.startBroadcast(ADMIN_KEY);
 
         // Enable assets in restaking
-        staking.enableAsset(address(usdc), 100e18, 10e18, 0, 10000);
-        staking.enableAsset(address(weth), 0.1 ether, 0.01 ether, 0, 10000);
+        staking.enableAsset(address(usdc), 100e18, 10e18, 0, 10_000);
+        staking.enableAsset(address(weth), 0.1 ether, 0.01 ether, 0, 10_000);
 
         // Distribute TNT to operators for incentives
         for (uint256 i = 0; i < operators.length; i++) {
@@ -391,7 +391,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
             uint256 stake = 5 ether + (i * 1 ether); // Varying stakes
 
             vm.startBroadcast(operatorKeys[i]);
-            staking.registerOperator{value: stake}();
+            staking.registerOperator{ value: stake }();
             vm.stopBroadcast();
 
             console2.log("  Operator registered with stake:", stake / 1e18);
@@ -404,8 +404,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         vm.startBroadcast(ADMIN_KEY);
 
         string[3] memory names = ["Compute Blueprint", "Storage Blueprint", "Oracle Blueprint"];
-        string[3] memory uris =
-            ["ipfs://QmCompute123", "ipfs://QmStorage456", "ipfs://QmOracle789"];
+        string[3] memory uris = ["ipfs://QmCompute123", "ipfs://QmStorage456", "ipfs://QmOracle789"];
 
         for (uint256 i = 0; i < NUM_BLUEPRINTS; i++) {
             Types.BlueprintDefinition memory def = _blueprintDefinition(uris[i], address(0));
@@ -432,7 +431,8 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
             for (uint256 j = 0; j < numBlueprints && j < blueprintIds.length; j++) {
                 bytes memory ecdsaKey = _generateOperatorKey(i, j);
-                string memory rpcUrl = string(abi.encodePacked("http://operator", vm.toString(i), ".local:854", vm.toString(j)));
+                string memory rpcUrl =
+                    string(abi.encodePacked("http://operator", vm.toString(i), ".local:854", vm.toString(j)));
 
                 tangle.registerOperator(blueprintIds[j], ecdsaKey, rpcUrl);
                 console2.log("  Operator", i, "registered for blueprint", blueprintIds[j]);
@@ -499,7 +499,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
             for (uint256 j = 0; j < numDelegations; j++) {
                 address op = operators[(i + j) % operators.length];
-                staking.depositAndDelegate{value: amountPerDelegation}(op);
+                staking.depositAndDelegate{ value: amountPerDelegation }(op);
                 totalDelegations++;
             }
 
@@ -575,7 +575,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         try tangle.submitJob(serviceId, 0, inputs) returns (uint64 callId) {
             serviceCallIds[serviceId] = callId;
             totalJobs++;
-        } catch {}
+        } catch { }
         vm.stopBroadcast();
     }
 
@@ -589,7 +589,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         uint256 opIndex = tick % operators.length;
 
         vm.startBroadcast(operatorKeys[opIndex]);
-        try tangle.submitResult(serviceId, callId, abi.encode("result", tick)) {} catch {}
+        try tangle.submitResult(serviceId, callId, abi.encode("result", tick)) { } catch { }
         vm.stopBroadcast();
     }
 
@@ -599,10 +599,10 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         uint256 amount = 0.5 ether + ((tick % 10) * 0.1 ether);
 
         vm.startBroadcast(delegatorKeys[delegatorIndex]);
-        try staking.depositAndDelegate{value: amount}(operators[operatorIndex]) {
+        try staking.depositAndDelegate{ value: amount }(operators[operatorIndex]) {
             totalDelegations++;
             totalDeposits++;
-        } catch {}
+        } catch { }
         vm.stopBroadcast();
     }
 
@@ -615,30 +615,22 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         // Alternate between USDC and WETH
         if (tick % 8 < 4) {
             uint256 amount = 100e18 + (tick * 10e18);
-            try usdc.approve(address(staking), amount) {} catch {}
+            try usdc.approve(address(staking), amount) { } catch { }
             try staking.depositAndDelegateWithOptions(
-                operators[operatorIndex],
-                address(usdc),
-                amount,
-                Types.BlueprintSelectionMode.All,
-                new uint64[](0)
+                operators[operatorIndex], address(usdc), amount, Types.BlueprintSelectionMode.All, new uint64[](0)
             ) {
                 totalDeposits++;
                 totalDelegations++;
-            } catch {}
+            } catch { }
         } else {
             uint256 amount = 0.1 ether + (tick * 0.01 ether);
-            try weth.approve(address(staking), amount) {} catch {}
+            try weth.approve(address(staking), amount) { } catch { }
             try staking.depositAndDelegateWithOptions(
-                operators[operatorIndex],
-                address(weth),
-                amount,
-                Types.BlueprintSelectionMode.All,
-                new uint64[](0)
+                operators[operatorIndex], address(weth), amount, Types.BlueprintSelectionMode.All, new uint64[](0)
             ) {
                 totalDeposits++;
                 totalDelegations++;
-            } catch {}
+            } catch { }
         }
 
         vm.stopBroadcast();
@@ -659,7 +651,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
             try statusRegistry.submitHeartbeat(serviceId, blueprintId, 0, metrics, signature) {
                 totalHeartbeats++;
-            } catch {}
+            } catch { }
 
             vm.stopBroadcast();
         }
@@ -667,7 +659,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
     function _advanceRound() internal {
         vm.startBroadcast(ADMIN_KEY);
-        try staking.advanceRound() {} catch {}
+        try staking.advanceRound() { } catch { }
         vm.stopBroadcast();
     }
 
@@ -676,14 +668,14 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         uint256 operatorIndex = (tick / 10) % operators.length;
 
         vm.startBroadcast(delegatorKeys[delegatorIndex]);
-        try staking.scheduleDelegatorUnstake(operators[operatorIndex], address(0), 0.1 ether) {} catch {}
+        try staking.scheduleDelegatorUnstake(operators[operatorIndex], address(0), 0.1 ether) { } catch { }
         vm.stopBroadcast();
     }
 
     function _executeUnstakes() internal {
         for (uint256 i = 0; i < delegators.length; i++) {
             vm.startBroadcast(delegatorKeys[i]);
-            try staking.executeDelegatorUnstake() {} catch {}
+            try staking.executeDelegatorUnstake() { } catch { }
             vm.stopBroadcast();
         }
     }
@@ -712,7 +704,7 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
         vm.startBroadcast(SLASHER_KEY);
         try tangle.proposeSlash(serviceId, operators[operatorIndex], slashBps, evidence) {
             totalSlashes++;
-        } catch {}
+        } catch { }
         vm.stopBroadcast();
     }
 
@@ -759,7 +751,8 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
 
 /// @title DemoSimulationContinuous
 /// @notice Version that runs indefinitely until stopped
-/// @dev Run with: forge script script/DemoSimulation.s.sol:DemoSimulationContinuous --rpc-url http://127.0.0.1:8545 --broadcast
+/// @dev Run with: forge script script/DemoSimulation.s.sol:DemoSimulationContinuous --rpc-url http://127.0.0.1:8545
+/// --broadcast
 contract DemoSimulationContinuous is DemoSimulation {
     function run() external override {
         console2.log("\n");

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -145,13 +145,8 @@ contract DeployV2 is DeployScriptBase {
         console2.log("Admin:", admin);
         console2.log("Treasury:", treasury);
 
-        (
-            address stakingProxy,
-            address stakingImpl,
-            address tangleProxy,
-            address tangleImpl,
-            address statusRegistry
-        ) = _deployCore(deployerPrivateKey, deployer, admin, treasury, true);
+        (address stakingProxy, address stakingImpl, address tangleProxy, address tangleImpl, address statusRegistry) =
+            _deployCore(deployerPrivateKey, deployer, admin, treasury, true);
 
         // Log summary
         console2.log("\n=== Deployment Summary ===");

--- a/script/DeployBeaconSlashing.s.sol
+++ b/script/DeployBeaconSlashing.s.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Script, console2} from "forge-std/Script.sol";
+import { Script, console2 } from "forge-std/Script.sol";
 
-import {ValidatorPodManager} from "../src/beacon/ValidatorPodManager.sol";
-import {MockBeaconOracle} from "../src/beacon/BeaconRootReceiver.sol";
-import {EIP4788Oracle} from "../src/beacon/l1/EIP4788Oracle.sol";
-import {L2SlashingConnector} from "../src/beacon/L2SlashingConnector.sol";
-import {HyperlaneCrossChainMessenger} from "../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
-import {LayerZeroCrossChainMessenger} from "../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
+import { ValidatorPodManager } from "../src/beacon/ValidatorPodManager.sol";
+import { MockBeaconOracle } from "../src/beacon/BeaconRootReceiver.sol";
+import { EIP4788Oracle } from "../src/beacon/l1/EIP4788Oracle.sol";
+import { L2SlashingConnector } from "../src/beacon/L2SlashingConnector.sol";
+import { HyperlaneCrossChainMessenger } from "../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
+import { LayerZeroCrossChainMessenger } from "../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
 
 error MissingEnv(string key);
 error AddressNotAllowlisted(string key, address provided, address expected);
@@ -20,7 +20,7 @@ error BridgeContractInvalid(string name, address addr);
 /// @dev Deploys to Ethereum mainnet/testnet
 contract DeployBeaconSlashingL1 is Script {
     // Configuration
-    uint256 public minOperatorStake = 32 ether;  // Standard beacon chain validator stake
+    uint256 public minOperatorStake = 32 ether; // Standard beacon chain validator stake
 
     // Chain IDs
     uint256 public constant TANGLE_MAINNET = 5845;
@@ -65,12 +65,7 @@ contract DeployBeaconSlashingL1 is Script {
             console2.log("Skipping L2 chain config (set later via ConfigureL2SlashingConnector)");
         }
 
-        (
-            address beaconOracle,
-            address podManager,
-            address connector,
-            address messenger
-        ) = _deploy(
+        (address beaconOracle, address podManager, address connector, address messenger) = _deploy(
             bridge,
             deployerPrivateKey,
             deployer,
@@ -83,7 +78,18 @@ contract DeployBeaconSlashingL1 is Script {
             true
         );
 
-        _writeManifest(_envStringOrEmpty("BEACON_SLASHING_MANIFEST"), bridge, admin, oracle, tangleChainId, l2Receiver, beaconOracle, podManager, connector, messenger);
+        _writeManifest(
+            _envStringOrEmpty("BEACON_SLASHING_MANIFEST"),
+            bridge,
+            admin,
+            oracle,
+            tangleChainId,
+            l2Receiver,
+            beaconOracle,
+            podManager,
+            connector,
+            messenger
+        );
 
         // Log deployment summary
         console2.log("\n=== L1 Deployment Summary ===");
@@ -137,12 +143,7 @@ contract DeployBeaconSlashingL1 is Script {
         bool broadcast
     )
         internal
-        returns (
-            address beaconOracle,
-            address podManager,
-            address connector,
-            address messenger
-        )
+        returns (address beaconOracle, address podManager, address connector, address messenger)
     {
         if (broadcast) {
             vm.startBroadcast(deployerPrivateKey);
@@ -215,11 +216,11 @@ contract DeployBeaconSlashingL1 is Script {
             // Ethereum mainnet
             mailbox = 0xc005dc82818d67AF737725bD4bf75435d065D239;
             igp = 0x6cA0B6D22da47f091B7613223cD4BB03a2d77918;
-        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 11155111) {
+        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 11_155_111) {
             // Sepolia testnet
             mailbox = 0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766;
             igp = 0x6f2756380FD49228ae25Aa7F2817993cB74Ecc56;
-        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 17000) {
+        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 17_000) {
             // Holesky testnet
             mailbox = 0x5b6CFf85442B851A8e6eaBd2A4E4507B5135B3B0;
             igp = 0x6f2756380FD49228ae25Aa7F2817993cB74Ecc56; // Same as Sepolia - verify before mainnet
@@ -227,7 +228,7 @@ contract DeployBeaconSlashingL1 is Script {
             // Base mainnet
             mailbox = 0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D;
             igp = 0xc3F23848Ed2e04C0c6d41bd7804fa8f89F940B94;
-        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 84532) {
+        } else if (mailbox == address(0) && igp == address(0) && block.chainid == 84_532) {
             // Base Sepolia testnet
             mailbox = 0x6966b0E55883d49BFB24539356a2f8A673E02039;
             igp = 0x28B02B97a850872C4D33C3E024fab6499ad96564;
@@ -241,10 +242,7 @@ contract DeployBeaconSlashingL1 is Script {
         _verifyBridgeContract("Hyperlane Mailbox", mailbox);
         _verifyBridgeContract("Hyperlane IGP", igp);
 
-        HyperlaneCrossChainMessenger messenger = new HyperlaneCrossChainMessenger(
-            mailbox,
-            igp
-        );
+        HyperlaneCrossChainMessenger messenger = new HyperlaneCrossChainMessenger(mailbox, igp);
         console2.log("HyperlaneCrossChainMessenger:", address(messenger));
         return address(messenger);
     }
@@ -258,16 +256,16 @@ contract DeployBeaconSlashingL1 is Script {
         if (endpoint == address(0) && block.chainid == 1) {
             // Ethereum mainnet
             endpoint = 0x1a44076050125825900e736c501f859c50fE728c;
-        } else if (endpoint == address(0) && block.chainid == 11155111) {
+        } else if (endpoint == address(0) && block.chainid == 11_155_111) {
             // Sepolia testnet
             endpoint = 0x6EDCE65403992e310A62460808c4b910D972f10f;
-        } else if (endpoint == address(0) && block.chainid == 17000) {
+        } else if (endpoint == address(0) && block.chainid == 17_000) {
             // Holesky testnet
             endpoint = 0x6EDCE65403992e310A62460808c4b910D972f10f;
         } else if (endpoint == address(0) && block.chainid == 8453) {
             // Base mainnet
             endpoint = 0x1a44076050125825900e736c501f859c50fE728c;
-        } else if (endpoint == address(0) && block.chainid == 84532) {
+        } else if (endpoint == address(0) && block.chainid == 84_532) {
             // Base Sepolia testnet
             endpoint = 0x6EDCE65403992e310A62460808c4b910D972f10f;
         }
@@ -311,7 +309,9 @@ contract DeployBeaconSlashingL1 is Script {
         address podManager,
         address connector,
         address messenger
-    ) internal {
+    )
+        internal
+    {
         if (bytes(path).length == 0) return;
         _ensureParentDir(path);
 
@@ -379,7 +379,7 @@ contract DeployBeaconSlashingL1 is Script {
             if (allowed != address(0) && candidate != allowed) {
                 revert AddressNotAllowlisted(key, candidate, allowed);
             }
-        } catch {}
+        } catch { }
     }
 
     /// @notice Verify bridge contract exists and has code
@@ -404,7 +404,8 @@ contract DeployBeaconSlashingL1Testnet is Script {
 
 /// @title DeployBeaconSlashingL1Holesky
 /// @notice Convenience script for Holesky testnet deployment
-/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingL1Holesky --rpc-url $HOLESKY_RPC --broadcast
+/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingL1Holesky --rpc-url $HOLESKY_RPC
+/// --broadcast
 contract DeployBeaconSlashingL1Holesky is Script {
     function run() external {
         DeployBeaconSlashingL1 deploy = new DeployBeaconSlashingL1();
@@ -423,7 +424,8 @@ contract DeployBeaconSlashingL1HoleskyLayerZero is Script {
 
 /// @title DeployBeaconSlashingBase
 /// @notice Convenience script for Base mainnet deployment
-/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingBase --rpc-url $BASE_RPC --broadcast
+/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingBase --rpc-url $BASE_RPC
+/// --broadcast
 contract DeployBeaconSlashingBase is Script {
     function run() external {
         DeployBeaconSlashingL1 deploy = new DeployBeaconSlashingL1();
@@ -433,7 +435,8 @@ contract DeployBeaconSlashingBase is Script {
 
 /// @title DeployBeaconSlashingBaseSepolia
 /// @notice Convenience script for Base Sepolia testnet deployment
-/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingBaseSepolia --rpc-url $BASE_SEPOLIA_RPC --broadcast
+/// @dev Run with: forge script script/DeployBeaconSlashing.s.sol:DeployBeaconSlashingBaseSepolia --rpc-url
+/// $BASE_SEPOLIA_RPC --broadcast
 contract DeployBeaconSlashingBaseSepolia is Script {
     function run() external {
         DeployBeaconSlashingL1 deploy = new DeployBeaconSlashingL1();

--- a/script/DeployContractsOnly.s.sol
+++ b/script/DeployContractsOnly.s.sol
@@ -35,7 +35,8 @@ import { StakingAdminFacet } from "../src/facets/staking/StakingAdminFacet.sol";
 
 /// @title DeployContractsOnly
 /// @notice Deploys ONLY the core contracts without creating any blueprints, services, or operators
-/// @dev Run with: forge script script/DeployContractsOnly.s.sol:DeployContractsOnly --rpc-url http://localhost:8545 --broadcast -vvv
+/// @dev Run with: forge script script/DeployContractsOnly.s.sol:DeployContractsOnly --rpc-url http://localhost:8545
+/// --broadcast -vvv
 contract DeployContractsOnly is Script {
     // Anvil default deployer key
     uint256 constant DEPLOYER_KEY = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;

--- a/script/DeployL2Slashing.s.sol
+++ b/script/DeployL2Slashing.s.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Script, console2} from "forge-std/Script.sol";
+import { Script, console2 } from "forge-std/Script.sol";
 
-import {L2SlashingReceiver} from "../src/beacon/L2SlashingReceiver.sol";
-import {TangleL2Slasher} from "../src/beacon/TangleL2Slasher.sol";
-import {HyperlaneReceiver} from "../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
-import {LayerZeroReceiver} from "../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
+import { L2SlashingReceiver } from "../src/beacon/L2SlashingReceiver.sol";
+import { TangleL2Slasher } from "../src/beacon/TangleL2Slasher.sol";
+import { HyperlaneReceiver } from "../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
+import { LayerZeroReceiver } from "../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
 
 error MissingEnv(string key);
 error AddressNotAllowlisted(string key, address provided, address expected);
@@ -45,7 +45,7 @@ abstract contract EnvUtils is Script {
             if (allowed != address(0) && candidate != allowed) {
                 revert AddressNotAllowlisted(key, candidate, allowed);
             }
-        } catch {}
+        } catch { }
     }
 
     /// @notice Verify bridge contract exists and has code
@@ -65,17 +65,17 @@ abstract contract EnvUtils is Script {
 contract DeployL2Slashing is EnvUtils {
     // Chain IDs - Ethereum
     uint256 public constant ETHEREUM_MAINNET = 1;
-    uint256 public constant ETHEREUM_SEPOLIA = 11155111;
-    uint256 public constant ETHEREUM_HOLESKY = 17000;
+    uint256 public constant ETHEREUM_SEPOLIA = 11_155_111;
+    uint256 public constant ETHEREUM_HOLESKY = 17_000;
     // Chain IDs - Base
     uint256 public constant BASE_MAINNET = 8453;
-    uint256 public constant BASE_SEPOLIA = 84532;
+    uint256 public constant BASE_SEPOLIA = 84_532;
 
     // Bridge protocol selection
     enum BridgeProtocol {
         Hyperlane,
         LayerZero,
-        DirectMessenger  // For testing with direct calls
+        DirectMessenger // For testing with direct calls
     }
 
     function run() external {
@@ -113,11 +113,7 @@ contract DeployL2Slashing is EnvUtils {
             console2.log("L1 Messenger:", l1Messenger);
         }
 
-        (
-            address slasher,
-            address receiver,
-            address bridgeReceiver
-        ) = _deploy(
+        (address slasher, address receiver, address bridgeReceiver) = _deploy(
             bridge,
             deployerPrivateKey,
             deployer,
@@ -261,7 +257,10 @@ contract DeployL2Slashing is EnvUtils {
         address admin,
         uint256 sourceChainId,
         address l1Messenger
-    ) internal returns (address) {
+    )
+        internal
+        returns (address)
+    {
         address mailbox = vm.envOr("HYPERLANE_MAILBOX", _defaultHyperlaneMailbox(block.chainid));
         if (mailbox == address(0)) revert MissingEnv("HYPERLANE_MAILBOX");
 
@@ -287,7 +286,10 @@ contract DeployL2Slashing is EnvUtils {
         address admin,
         uint256 sourceChainId,
         address l1Messenger
-    ) internal returns (address) {
+    )
+        internal
+        returns (address)
+    {
         address endpoint = vm.envOr("LAYERZERO_ENDPOINT", _defaultLayerZeroEndpoint(block.chainid));
         if (endpoint == address(0)) revert MissingEnv("LAYERZERO_ENDPOINT");
 
@@ -316,16 +318,16 @@ contract DeployL2Slashing is EnvUtils {
         if (chainId == 1) {
             return 0xc005dc82818d67AF737725bD4bf75435d065D239;
         }
-        if (chainId == 11155111) {
+        if (chainId == 11_155_111) {
             return 0xfFAEF09B3cd11D9b20d1a19bECca54EEC2884766;
         }
-        if (chainId == 17000) {
+        if (chainId == 17_000) {
             return 0x5b6CFf85442B851A8e6eaBd2A4E4507B5135B3B0;
         }
         if (chainId == 8453) {
             return 0xeA87ae93Fa0019a82A727bfd3eBd1cFCa8f64f1D;
         }
-        if (chainId == 84532) {
+        if (chainId == 84_532) {
             return 0x6966b0E55883d49BFB24539356a2f8A673E02039;
         }
         return address(0);
@@ -335,28 +337,28 @@ contract DeployL2Slashing is EnvUtils {
         if (chainId == 1) {
             return 0x1a44076050125825900e736c501f859c50fE728c;
         }
-        if (chainId == 11155111) {
+        if (chainId == 11_155_111) {
             return 0x6EDCE65403992e310A62460808c4b910D972f10f;
         }
-        if (chainId == 17000) {
+        if (chainId == 17_000) {
             return 0x6EDCE65403992e310A62460808c4b910D972f10f;
         }
         if (chainId == 8453) {
             return 0x1a44076050125825900e736c501f859c50fE728c;
         }
-        if (chainId == 84532) {
+        if (chainId == 84_532) {
             return 0x6EDCE65403992e310A62460808c4b910D972f10f;
         }
         return address(0);
     }
 
     function _defaultLayerZeroEid(uint256 chainId) internal pure returns (uint32) {
-        if (chainId == 1) return 30101;
-        if (chainId == 42161) return 30110;
-        if (chainId == 8453) return 30184;
-        if (chainId == 11155111) return 40161;
-        if (chainId == 421614) return 40231;
-        if (chainId == 84532) return 40245;
+        if (chainId == 1) return 30_101;
+        if (chainId == 42_161) return 30_110;
+        if (chainId == 8453) return 30_184;
+        if (chainId == 11_155_111) return 40_161;
+        if (chainId == 421_614) return 40_231;
+        if (chainId == 84_532) return 40_245;
         return 0;
     }
 
@@ -379,7 +381,9 @@ contract DeployL2Slashing is EnvUtils {
         address slasher,
         address receiver,
         address messenger
-    ) internal {
+    )
+        internal
+    {
         if (bytes(path).length == 0) return;
         _ensureParentDir(path);
 

--- a/script/DistributeTNT.s.sol
+++ b/script/DistributeTNT.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Script, console2} from "forge-std/Script.sol";
-import {stdJson} from "forge-std/StdJson.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Script, console2 } from "forge-std/Script.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title DistributeTNT
 /// @notice Batch transfer TNT (or any ERC20) from the deployer to a recipient list.

--- a/script/FullDeploy.s.sol
+++ b/script/FullDeploy.s.sol
@@ -211,8 +211,8 @@ contract FullDeploy is DeployV2 {
         if (migration.deploy) {
             migration = _resolveMigrationConfig(migration);
             require(!migration.useMockVerifier, "Mock verifier disabled");
-            uint256 totalSupply =
-                migration.substrateAllocation + migration.evmAllocation + migration.treasuryAmount + migration.foundationAmount;
+            uint256 totalSupply = migration.substrateAllocation + migration.evmAllocation + migration.treasuryAmount
+                + migration.foundationAmount;
             if (cfg.incentives.tntToken == address(0)) {
                 tntInitialSupply = totalSupply;
             }
@@ -346,11 +346,15 @@ contract FullDeploy is DeployV2 {
         if (jsonBlob.keyExists(".core.deploy")) cfg.core.deploy = jsonBlob.readBool(".core.deploy");
         if (jsonBlob.keyExists(".core.tangle")) cfg.core.tangle = jsonBlob.readAddress(".core.tangle");
         if (jsonBlob.keyExists(".core.staking")) cfg.core.staking = jsonBlob.readAddress(".core.staking");
-        if (jsonBlob.keyExists(".core.statusRegistry")) cfg.core.statusRegistry = jsonBlob.readAddress(".core.statusRegistry");
+        if (jsonBlob.keyExists(".core.statusRegistry")) {
+            cfg.core.statusRegistry = jsonBlob.readAddress(".core.statusRegistry");
+        }
         if (jsonBlob.keyExists(".core.minOperatorStake")) {
             cfg.core.minOperatorStake = jsonBlob.readUint(".core.minOperatorStake");
         }
-        if (jsonBlob.keyExists(".core.minDelegation")) cfg.core.minDelegation = jsonBlob.readUint(".core.minDelegation");
+        if (jsonBlob.keyExists(".core.minDelegation")) {
+            cfg.core.minDelegation = jsonBlob.readUint(".core.minDelegation");
+        }
         if (jsonBlob.keyExists(".core.operatorCommissionBps")) {
             cfg.core.operatorCommissionBps = uint16(jsonBlob.readUint(".core.operatorCommissionBps"));
         }
@@ -373,9 +377,12 @@ contract FullDeploy is DeployV2 {
             cfg.incentives.deployServiceFeeDistributor = jsonBlob.readBool(".incentives.deployServiceFeeDistributor");
         }
         if (jsonBlob.keyExists(".incentives.deployStreamingPaymentManager")) {
-            cfg.incentives.deployStreamingPaymentManager = jsonBlob.readBool(".incentives.deployStreamingPaymentManager");
+            cfg.incentives.deployStreamingPaymentManager =
+                jsonBlob.readBool(".incentives.deployStreamingPaymentManager");
         }
-        if (jsonBlob.keyExists(".incentives.metrics")) cfg.incentives.metrics = jsonBlob.readAddress(".incentives.metrics");
+        if (jsonBlob.keyExists(".incentives.metrics")) {
+            cfg.incentives.metrics = jsonBlob.readAddress(".incentives.metrics");
+        }
         if (jsonBlob.keyExists(".incentives.rewardVaults")) {
             cfg.incentives.rewardVaults = jsonBlob.readAddress(".incentives.rewardVaults");
         }
@@ -388,7 +395,9 @@ contract FullDeploy is DeployV2 {
         if (jsonBlob.keyExists(".incentives.streamingPaymentManager")) {
             cfg.incentives.streamingPaymentManager = jsonBlob.readAddress(".incentives.streamingPaymentManager");
         }
-        if (jsonBlob.keyExists(".incentives.tntToken")) cfg.incentives.tntToken = jsonBlob.readAddress(".incentives.tntToken");
+        if (jsonBlob.keyExists(".incentives.tntToken")) {
+            cfg.incentives.tntToken = jsonBlob.readAddress(".incentives.tntToken");
+        }
         if (jsonBlob.keyExists(".incentives.priceOracle")) {
             cfg.incentives.priceOracle = jsonBlob.readAddress(".incentives.priceOracle");
         }
@@ -399,9 +408,12 @@ contract FullDeploy is DeployV2 {
             cfg.incentives.tntPaymentDiscountBps = uint16(jsonBlob.readUint(".incentives.tntPaymentDiscountBps"));
         }
         if (jsonBlob.keyExists(".incentives.vaultOperatorCommissionBps")) {
-            cfg.incentives.vaultOperatorCommissionBps = uint16(jsonBlob.readUint(".incentives.vaultOperatorCommissionBps"));
+            cfg.incentives.vaultOperatorCommissionBps =
+                uint16(jsonBlob.readUint(".incentives.vaultOperatorCommissionBps"));
         }
-        if (jsonBlob.keyExists(".incentives.epochLength")) cfg.incentives.epochLength = jsonBlob.readUint(".incentives.epochLength");
+        if (jsonBlob.keyExists(".incentives.epochLength")) {
+            cfg.incentives.epochLength = jsonBlob.readUint(".incentives.epochLength");
+        }
 
         if (jsonBlob.keyExists(".incentives.weights.stakingBps")) {
             cfg.incentives.weights.stakingBps = uint16(jsonBlob.readUint(".incentives.weights.stakingBps"));
@@ -421,27 +433,49 @@ contract FullDeploy is DeployV2 {
 
         cfg.incentives.vaults = _loadVaults(jsonBlob);
 
-        if (jsonBlob.keyExists(".guards.pauseRestaking")) cfg.guards.pauseRestaking = jsonBlob.readBool(".guards.pauseRestaking");
-        if (jsonBlob.keyExists(".guards.pauseTangle")) cfg.guards.pauseTangle = jsonBlob.readBool(".guards.pauseTangle");
-        if (jsonBlob.keyExists(".guards.requireAdapters")) cfg.guards.requireAdapters = jsonBlob.readBool(".guards.requireAdapters");
-        if (jsonBlob.keyExists(".guards.delegatorDelay")) cfg.guards.delegatorDelay = uint64(jsonBlob.readUint(".guards.delegatorDelay"));
-        if (jsonBlob.keyExists(".guards.operatorDelay")) cfg.guards.operatorDelay = uint64(jsonBlob.readUint(".guards.operatorDelay"));
-        if (jsonBlob.keyExists(".guards.bondLessDelay")) cfg.guards.bondLessDelay = uint64(jsonBlob.readUint(".guards.bondLessDelay"));
+        if (jsonBlob.keyExists(".guards.pauseRestaking")) {
+            cfg.guards.pauseRestaking = jsonBlob.readBool(".guards.pauseRestaking");
+        }
+        if (jsonBlob.keyExists(".guards.pauseTangle")) {
+            cfg.guards.pauseTangle = jsonBlob.readBool(".guards.pauseTangle");
+        }
+        if (jsonBlob.keyExists(".guards.requireAdapters")) {
+            cfg.guards.requireAdapters = jsonBlob.readBool(".guards.requireAdapters");
+        }
+        if (jsonBlob.keyExists(".guards.delegatorDelay")) {
+            cfg.guards.delegatorDelay = uint64(jsonBlob.readUint(".guards.delegatorDelay"));
+        }
+        if (jsonBlob.keyExists(".guards.operatorDelay")) {
+            cfg.guards.operatorDelay = uint64(jsonBlob.readUint(".guards.operatorDelay"));
+        }
+        if (jsonBlob.keyExists(".guards.bondLessDelay")) {
+            cfg.guards.bondLessDelay = uint64(jsonBlob.readUint(".guards.bondLessDelay"));
+        }
         if (jsonBlob.keyExists(".guards.maxBlueprintsPerOperator")) {
             cfg.guards.maxBlueprintsPerOperator = uint32(jsonBlob.readUint(".guards.maxBlueprintsPerOperator"));
         }
 
         if (jsonBlob.keyExists(".manifest.path")) cfg.manifest.path = jsonBlob.readString(".manifest.path");
-        if (jsonBlob.keyExists(".manifest.logSummary")) cfg.manifest.logSummary = jsonBlob.readBool(".manifest.logSummary");
+        if (jsonBlob.keyExists(".manifest.logSummary")) {
+            cfg.manifest.logSummary = jsonBlob.readBool(".manifest.logSummary");
+        }
 
         if (jsonBlob.keyExists(".migration.deploy")) cfg.migration.deploy = jsonBlob.readBool(".migration.deploy");
-        if (jsonBlob.keyExists(".migration.emitArtifacts")) cfg.migration.emitArtifacts = jsonBlob.readBool(".migration.emitArtifacts");
+        if (jsonBlob.keyExists(".migration.emitArtifacts")) {
+            cfg.migration.emitArtifacts = jsonBlob.readBool(".migration.emitArtifacts");
+        }
         if (jsonBlob.keyExists(".migration.useMockVerifier")) {
             cfg.migration.useMockVerifier = jsonBlob.readBool(".migration.useMockVerifier");
         }
-        if (jsonBlob.keyExists(".migration.artifactsPath")) cfg.migration.artifactsPath = jsonBlob.readString(".migration.artifactsPath");
-        if (jsonBlob.keyExists(".migration.merklePath")) cfg.migration.merklePath = jsonBlob.readString(".migration.merklePath");
-        if (jsonBlob.keyExists(".migration.evmClaimsPath")) cfg.migration.evmClaimsPath = jsonBlob.readString(".migration.evmClaimsPath");
+        if (jsonBlob.keyExists(".migration.artifactsPath")) {
+            cfg.migration.artifactsPath = jsonBlob.readString(".migration.artifactsPath");
+        }
+        if (jsonBlob.keyExists(".migration.merklePath")) {
+            cfg.migration.merklePath = jsonBlob.readString(".migration.merklePath");
+        }
+        if (jsonBlob.keyExists(".migration.evmClaimsPath")) {
+            cfg.migration.evmClaimsPath = jsonBlob.readString(".migration.evmClaimsPath");
+        }
         if (jsonBlob.keyExists(".migration.treasuryCarveoutPath")) {
             cfg.migration.treasuryCarveoutPath = jsonBlob.readString(".migration.treasuryCarveoutPath");
         }
@@ -606,7 +640,10 @@ contract FullDeploy is DeployV2 {
         CreditsConfig memory cfg,
         address admin,
         address timelock
-    ) internal returns (address credits) {
+    )
+        internal
+        returns (address credits)
+    {
         if (!cfg.deploy) {
             return cfg.credits;
         }
@@ -702,12 +739,14 @@ contract FullDeploy is DeployV2 {
         address staking,
         address tangle,
         address oracle
-    ) internal returns (address proxy) {
+    )
+        internal
+        returns (address proxy)
+    {
         ServiceFeeDistributor impl = new ServiceFeeDistributor();
         proxy = address(
             new ERC1967Proxy(
-                address(impl),
-                abi.encodeCall(ServiceFeeDistributor.initialize, (admin, staking, tangle, oracle))
+                address(impl), abi.encodeCall(ServiceFeeDistributor.initialize, (admin, staking, tangle, oracle))
             )
         );
         console2.log("Deployed ServiceFeeDistributor:", proxy);
@@ -717,12 +756,14 @@ contract FullDeploy is DeployV2 {
         address admin,
         address tangle,
         address distributorAddr
-    ) internal returns (address proxy) {
+    )
+        internal
+        returns (address proxy)
+    {
         StreamingPaymentManager impl = new StreamingPaymentManager();
         proxy = address(
             new ERC1967Proxy(
-                address(impl),
-                abi.encodeCall(StreamingPaymentManager.initialize, (admin, tangle, distributorAddr))
+                address(impl), abi.encodeCall(StreamingPaymentManager.initialize, (admin, tangle, distributorAddr))
             )
         );
         console2.log("Deployed StreamingPaymentManager:", proxy);
@@ -909,10 +950,12 @@ contract FullDeploy is DeployV2 {
         address distributor,
         address streamingMgr,
         address oracle
-    ) internal {
+    )
+        internal
+    {
         if (distributor == address(0)) {
             if (tangleAddr != address(0)) {
-                (, , , uint16 stakerBps) = ITangleAdmin(tangleAddr).paymentSplit();
+                (,,, uint16 stakerBps) = ITangleAdmin(tangleAddr).paymentSplit();
                 require(stakerBps == 0, "ServiceFeeDistributor required when stakerBps > 0");
             }
             return;
@@ -1176,7 +1219,8 @@ contract FullDeploy is DeployV2 {
         // Treasury for unclaimed token sweep - use configured treasury or fallback to global treasury
         address sweepTreasury = migration.treasuryRecipient != address(0) ? migration.treasuryRecipient : treasury;
         if (sweepTreasury == address(0)) sweepTreasury = deployer; // Final fallback
-        TangleMigration claim = new TangleMigration(tntToken, migration.merkleRoot, address(verifier), deployer, sweepTreasury);
+        TangleMigration claim =
+            new TangleMigration(tntToken, migration.merkleRoot, address(verifier), deployer, sweepTreasury);
 
         uint256 claimDeadline = migration.claimDeadline;
         if (claimDeadline == 0) {
@@ -1198,16 +1242,14 @@ contract FullDeploy is DeployV2 {
 
         // Treasury: 0% unlocked, 100% vested with 6-month cliff + 30-month linear (3 years)
         if (migration.treasuryAmount > 0) {
-            address treasuryRecipient = migration.treasuryRecipient == address(0) ? treasury : migration.treasuryRecipient;
+            address treasuryRecipient =
+                migration.treasuryRecipient == address(0) ? treasury : migration.treasuryRecipient;
             require(treasuryRecipient != address(0), "Missing treasury recipient");
 
             // Create vesting contract for 100% of treasury allocation
             TNTVestingFactory treasuryVestingFactory = new TNTVestingFactory(180 days, 912 days);
             address treasuryVesting = treasuryVestingFactory.getOrCreateVesting(
-                address(tnt),
-                treasuryRecipient,
-                uint64(block.timestamp),
-                treasuryRecipient
+                address(tnt), treasuryRecipient, uint64(block.timestamp), treasuryRecipient
             );
             tnt.safeTransfer(treasuryVesting, migration.treasuryAmount);
             migration.treasuryRecipient = treasuryRecipient;
@@ -1228,10 +1270,7 @@ contract FullDeploy is DeployV2 {
             // 70% to vesting contract
             TNTVestingFactory foundationVestingFactory = new TNTVestingFactory(180 days, 912 days);
             address foundationVesting = foundationVestingFactory.getOrCreateVesting(
-                address(tnt),
-                foundationRecipient,
-                uint64(block.timestamp),
-                foundationRecipient
+                address(tnt), foundationRecipient, uint64(block.timestamp), foundationRecipient
             );
             tnt.safeTransfer(foundationVesting, foundationVested);
         }
@@ -1656,8 +1695,7 @@ contract FullDeploy is DeployV2 {
 
     function _hexToBytes(bytes memory data) internal pure returns (bytes memory) {
         if (
-            data.length < 2
-                || data[0] != bytes1(uint8(48))
+            data.length < 2 || data[0] != bytes1(uint8(48))
                 || (data[1] != bytes1(uint8(120)) && data[1] != bytes1(uint8(88)))
         ) {
             revert("Invalid hex prefix");

--- a/script/FullStackScenario.s.sol
+++ b/script/FullStackScenario.s.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Script, console2} from "forge-std/Script.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Script, console2 } from "forge-std/Script.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import { IMultiAssetDelegation } from "../src/interfaces/IMultiAssetDelegation.sol";
 import { MultiAssetDelegation } from "../src/staking/MultiAssetDelegation.sol";
@@ -64,8 +64,8 @@ contract ScenarioERC20 {
 }
 
 /// @notice Forge script that replays the full stack scenario on a live RPC (e.g., anvil).
-///         Run with: `forge script script/FullStackScenario.s.sol:FullStackScenario --rpc-url http://127.0.0.1:8545 --broadcast --slow`
-///         Optionally set FULLSTACK_MNEMONIC to match the mnemonic used by your RPC node.
+///         Run with: `forge script script/FullStackScenario.s.sol:FullStackScenario --rpc-url http://127.0.0.1:8545
+/// --broadcast --slow` Optionally set FULLSTACK_MNEMONIC to match the mnemonic used by your RPC node.
 ///         For local RPC time advances, set FULLSTACK_USE_FFI=1 and pass --ffi (uses cast rpc).
 ///         Use FULLSTACK_RPC_URL to override the RPC URL used for time advances.
 contract FullStackScenario is Script {
@@ -155,17 +155,10 @@ contract FullStackScenario is Script {
 
     function _fundActors() internal {
         uint256[8] memory keys = [
-            adminKey,
-            slasherKey,
-            operator1Key,
-            operator2Key,
-            operator3Key,
-            delegator1Key,
-            delegator2Key,
-            delegator3Key
+            adminKey, slasherKey, operator1Key, operator2Key, operator3Key, delegator1Key, delegator2Key, delegator3Key
         ];
         for (uint256 i = 0; i < keys.length; i++) {
-            vm.deal(vm.addr(keys[i]), 1_000 ether);
+            vm.deal(vm.addr(keys[i]), 1000 ether);
         }
     }
 
@@ -174,8 +167,7 @@ contract FullStackScenario is Script {
 
         MultiAssetDelegation impl = new MultiAssetDelegation();
         bytes memory initData = abi.encodeCall(
-            MultiAssetDelegation.initialize,
-            (vm.addr(adminKey), 1 ether, DEFAULT_DELAY, COMMISSION_BPS)
+            MultiAssetDelegation.initialize, (vm.addr(adminKey), 1 ether, DEFAULT_DELAY, COMMISSION_BPS)
         );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         _registerFacets(address(proxy));
@@ -184,8 +176,8 @@ contract FullStackScenario is Script {
         tokenA = new ScenarioERC20("Scenario Token A", "STA");
         tokenB = new ScenarioERC20("Scenario Token B", "STB");
 
-        delegation.enableAsset(address(tokenA), 1 ether, 0.1 ether, 0, 10000);
-        delegation.enableAsset(address(tokenB), 1 ether, 0.1 ether, 0, 10000);
+        delegation.enableAsset(address(tokenA), 1 ether, 0.1 ether, 0, 10_000);
+        delegation.enableAsset(address(tokenB), 1 ether, 0.1 ether, 0, 10_000);
         delegation.addSlasher(vm.addr(slasherKey));
 
         vm.stopBroadcast();
@@ -205,8 +197,8 @@ contract FullStackScenario is Script {
     function _seedTokens() internal {
         vm.startBroadcast(adminKey);
         for (uint256 i = 0; i < delegators.length; i++) {
-            tokenA.mint(delegators[i], 1_000 ether);
-            tokenB.mint(delegators[i], 1_000 ether);
+            tokenA.mint(delegators[i], 1000 ether);
+            tokenB.mint(delegators[i], 1000 ether);
         }
         vm.stopBroadcast();
     }
@@ -214,7 +206,7 @@ contract FullStackScenario is Script {
     function _registerOperators() internal {
         for (uint256 i = 0; i < operators.length; i++) {
             vm.startBroadcast(operatorKeys[i]);
-            delegation.registerOperator{value: 10 ether}();
+            delegation.registerOperator{ value: 10 ether }();
             vm.stopBroadcast();
         }
     }
@@ -227,18 +219,14 @@ contract FullStackScenario is Script {
 
         if (isNative) {
             vm.startBroadcast(delegatorKey);
-            delegation.depositAndDelegate{value: amount}(operator);
+            delegation.depositAndDelegate{ value: amount }(operator);
             vm.stopBroadcast();
         } else {
             ScenarioERC20 token = tick % 2 == 1 ? tokenA : tokenB;
             vm.startBroadcast(delegatorKey);
             token.approve(address(delegation), amount);
             delegation.depositAndDelegateWithOptions(
-                operator,
-                address(token),
-                amount,
-                Types.BlueprintSelectionMode.All,
-                new uint64[](0)
+                operator, address(token), amount, Types.BlueprintSelectionMode.All, new uint64[](0)
             );
             vm.stopBroadcast();
         }
@@ -261,7 +249,7 @@ contract FullStackScenario is Script {
         if (tick % 5 == 4) {
             uint256 liquidAmount = amount / 2;
             vm.startBroadcast(delegatorKey);
-            delegation.deposit{value: liquidAmount}();
+            delegation.deposit{ value: liquidAmount }();
             delegation.scheduleWithdraw(address(0), liquidAmount / 2);
             vm.stopBroadcast();
         }

--- a/script/LocalTestnet.s.sol
+++ b/script/LocalTestnet.s.sol
@@ -57,7 +57,8 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
     uint256 constant OPERATOR2_KEY = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
     uint256 constant OPERATOR3_KEY = 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a; // Account 4
     uint256 constant DELEGATOR_KEY = 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6;
-    uint256 constant WHITELISTED_DELEGATOR_KEY = 0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba; // Account 5
+    uint256 constant WHITELISTED_DELEGATOR_KEY = 0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba; // Account
+    // 5
 
     address deployer;
     address operator1;

--- a/script/MBSMDeployer.s.sol
+++ b/script/MBSMDeployer.s.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.20;
-import {Script} from "forge-std/Script.sol";
+import { Script } from "forge-std/Script.sol";
 
 import "../src/MasterBlueprintServiceManager.sol";
 
 // Here is how you can run this script:
-// forge script scripts/MBSMDeployer.s.sol -vvvv --broadcast --evm-version london --legacy --private-key $(subkey inspect //Alice --scheme Ecdsa --output-type json | jq -r .secretSeed)
+// forge script scripts/MBSMDeployer.s.sol -vvvv --broadcast --evm-version london --legacy --private-key $(subkey
+// inspect //Alice --scheme Ecdsa --output-type json | jq -r .secretSeed)
 
 contract MBSMDeployerScript is Script {
     function run() public {

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -126,12 +126,12 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     }
 
     /// @inheritdoc IBlueprintServiceManager
-    function getExitConfig(uint64) external view virtual returns (
-        bool useDefault,
-        uint64 minCommitmentDuration,
-        uint64 exitQueueDuration,
-        bool forceExitAllowed
-    ) {
+    function getExitConfig(uint64)
+        external
+        view
+        virtual
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed)
+    {
         // Use protocol defaults:
         // - minCommitmentDuration: 1 day
         // - exitQueueDuration: 7 days
@@ -144,7 +144,15 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @inheritdoc IBlueprintServiceManager
-    function onRequest(uint64, address, address[] calldata, bytes calldata, uint64, address, uint256)
+    function onRequest(
+        uint64,
+        address,
+        address[] calldata,
+        bytes calldata,
+        uint64,
+        address,
+        uint256
+    )
         external
         payable
         virtual
@@ -164,7 +172,14 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     }
 
     /// @inheritdoc IBlueprintServiceManager
-    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64)
+    function onServiceInitialized(
+        uint64,
+        uint64,
+        uint64,
+        address,
+        address[] calldata,
+        uint64
+    )
         external
         virtual
         onlyFromTangle
@@ -221,7 +236,14 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     }
 
     /// @inheritdoc IBlueprintServiceManager
-    function onJobResult(uint64, uint8, uint64, address, bytes calldata, bytes calldata)
+    function onJobResult(
+        uint64,
+        uint8,
+        uint64,
+        address,
+        bytes calldata,
+        bytes calldata
+    )
         external
         payable
         virtual
@@ -308,7 +330,15 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     }
 
     /// @inheritdoc IBlueprintServiceManager
-    function onAggregatedResult(uint64, uint8, uint64, bytes calldata, uint256, uint256[2] calldata, uint256[4] calldata)
+    function onAggregatedResult(
+        uint64,
+        uint8,
+        uint64,
+        bytes calldata,
+        uint256,
+        uint256[2] calldata,
+        uint256[4] calldata
+    )
         external
         virtual
         onlyFromTangle

--- a/src/MBSMRegistry.sol
+++ b/src/MBSMRegistry.sol
@@ -122,7 +122,9 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     function initiateDeprecation(uint32 revision) external onlyRole(MANAGER_ROLE) {
         if (revision == 0 || revision > _versions.length) revert InvalidRevision(revision);
         if (_versions[revision - 1] == address(0)) revert InvalidRevision(revision); // Already deprecated
-        if (_deprecationTimestamp[revision] != 0) revert VersionInGracePeriod(revision, _deprecationTimestamp[revision] + deprecationGracePeriod);
+        if (_deprecationTimestamp[revision] != 0) {
+            revert VersionInGracePeriod(revision, _deprecationTimestamp[revision] + deprecationGracePeriod);
+        }
 
         _deprecationTimestamp[revision] = block.timestamp;
         emit MBSMVersionDeprecated(revision, _versions[revision - 1]);
@@ -299,7 +301,11 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     function getVersionsPaginated(
         uint256 offset,
         uint256 limit
-    ) external view returns (address[] memory addresses, uint256 total) {
+    )
+        external
+        view
+        returns (address[] memory addresses, uint256 total)
+    {
         total = _versions.length;
 
         if (offset >= total) {
@@ -324,11 +330,11 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     function getActiveVersionsPaginated(
         uint256 offset,
         uint256 limit
-    ) external view returns (
-        address[] memory addresses,
-        uint32[] memory revisions,
-        uint256 totalActive
-    ) {
+    )
+        external
+        view
+        returns (address[] memory addresses, uint32[] memory revisions, uint256 totalActive)
+    {
         // First pass: count active versions
         for (uint256 i = 0; i < _versions.length; i++) {
             if (_versions[i] != address(0)) {
@@ -366,5 +372,5 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     // UPGRADE
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
 }

--- a/src/MasterBlueprintServiceManager.sol
+++ b/src/MasterBlueprintServiceManager.sol
@@ -43,11 +43,13 @@ contract MasterBlueprintServiceManager is IMasterBlueprintServiceManager, Access
         uint64 blueprintId,
         address owner,
         bytes calldata encodedDefinition
-    ) external override onlyRole(TANGLE_ROLE) {
+    )
+        external
+        override
+        onlyRole(TANGLE_ROLE)
+    {
         _records[blueprintId] = BlueprintRecord({
-            owner: owner,
-            recordedAt: uint64(block.timestamp),
-            encodedDefinition: encodedDefinition
+            owner: owner, recordedAt: uint64(block.timestamp), encodedDefinition: encodedDefinition
         });
         emit BlueprintDefinitionRecorded(blueprintId, owner, encodedDefinition);
     }

--- a/src/Tangle.sol
+++ b/src/Tangle.sol
@@ -13,11 +13,7 @@ contract Tangle is Base {
     event FacetSelectorCleared(bytes4 indexed selector);
 
     /// @notice Initialize the contract
-    function initialize(
-        address admin,
-        address staking_,
-        address payable treasury_
-    ) external initializer {
+    function initialize(address admin, address staking_, address payable treasury_) external initializer {
         __Base_init(admin, staking_, treasury_);
     }
 
@@ -82,7 +78,7 @@ contract Tangle is Base {
             returndatacopy(0, 0, returndatasize())
             // Branch based on call result
             switch result
-            case 0 { revert(0, returndatasize()) }  // Call failed: revert with return data
+            case 0 { revert(0, returndatasize()) } // Call failed: revert with return data
             default { return(0, returndatasize()) } // Call succeeded: return with return data
         }
     }

--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -356,11 +356,15 @@ abstract contract TangleStorage {
     /// @notice Service ID => Call ID => Operator => Quoted price (for RFQ jobs)
     mapping(uint64 => mapping(uint64 => mapping(address => uint256))) internal _jobQuotedPrices;
 
+    /// @notice Service ID => Operator => Resource commitment hash (for QoS disputes)
+    /// @dev keccak256 of EIP-712-hashed ResourceCommitment[] from the operator's quote
+    mapping(uint64 => mapping(address => bytes32)) internal _serviceResourceCommitmentHash;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // RESERVED STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     /// @dev Standard gap size is 50 slots. When adding new storage, decrease this gap accordingly.
-    uint256[47] private __gap;
+    uint256[46] private __gap;
 }

--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -360,11 +360,17 @@ abstract contract TangleStorage {
     /// @dev keccak256 of EIP-712-hashed ResourceCommitment[] from the operator's quote
     mapping(uint64 => mapping(address => bytes32)) internal _serviceResourceCommitmentHash;
 
+    /// @notice Blueprint ID => Default resource requirements
+    mapping(uint64 => Types.ResourceCommitment[]) internal _blueprintResourceRequirements;
+
+    /// @notice Request ID => Resource requirements for this service request
+    mapping(uint64 => Types.ResourceCommitment[]) internal _requestResourceRequirements;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // RESERVED STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades
     /// @dev Standard gap size is 50 slots. When adding new storage, decrease this gap accordingly.
-    uint256[46] private __gap;
+    uint256[44] private __gap;
 }

--- a/src/beacon/BeaconChainProofs.sol
+++ b/src/beacon/BeaconChainProofs.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {ValidatorTypes} from "./ValidatorTypes.sol";
+import { ValidatorTypes } from "./ValidatorTypes.sol";
 
 /// @title BeaconChainProofs
 /// @notice Library for verifying Merkle proofs against beacon chain state
@@ -139,7 +139,11 @@ library BeaconChainProofs {
     function verifyStateRoot(
         bytes32 beaconBlockRoot,
         ValidatorTypes.StateRootProof calldata stateRootProof
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         // M-11 FIX: Reject zero beacon block root (could be genesis block or invalid root)
         // EIP-4788 returns 0 for timestamps before the fork or invalid timestamps
         if (beaconBlockRoot == bytes32(0)) {
@@ -157,12 +161,8 @@ library BeaconChainProofs {
             revert InvalidProofLength();
         }
 
-        return _verifyMerkleProof(
-            stateRootProof.proof,
-            beaconBlockRoot,
-            stateRootProof.beaconStateRoot,
-            STATE_ROOT_INDEX
-        );
+        return
+            _verifyMerkleProof(stateRootProof.proof, beaconBlockRoot, stateRootProof.beaconStateRoot, STATE_ROOT_INDEX);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -178,7 +178,11 @@ library BeaconChainProofs {
         bytes32 beaconStateRoot,
         uint40 validatorIndex,
         ValidatorTypes.ValidatorFieldsProof memory proof
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         if (proof.validatorFields.length != VALIDATOR_FIELDS_LENGTH) {
             revert InvalidValidatorFieldsLength();
         }
@@ -200,12 +204,7 @@ library BeaconChainProofs {
             revert InvalidProofLength();
         }
 
-        return _verifyMerkleProofFromGIndexMemory(
-            proof.proof,
-            beaconStateRoot,
-            validatorLeaf,
-            validatorGIndex
-        );
+        return _verifyMerkleProofFromGIndexMemory(proof.proof, beaconStateRoot, validatorLeaf, validatorGIndex);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -220,7 +219,11 @@ library BeaconChainProofs {
     function verifyBalanceContainer(
         bytes32 beaconStateRoot,
         ValidatorTypes.BalanceContainerProof calldata proof
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         // Balance container is at generalized index 44 in the beacon state
         // Proof length: BEACON_STATE_TREE_HEIGHT levels to reach balances from state root
         uint256 expectedProofLength = BEACON_STATE_TREE_HEIGHT * 32;
@@ -229,10 +232,7 @@ library BeaconChainProofs {
         }
 
         return _verifyMerkleProofFromGIndex(
-            proof.proof,
-            beaconStateRoot,
-            proof.balanceContainerRoot,
-            BALANCE_CONTAINER_GINDEX
+            proof.proof, beaconStateRoot, proof.balanceContainerRoot, BALANCE_CONTAINER_GINDEX
         );
     }
 
@@ -245,7 +245,11 @@ library BeaconChainProofs {
         bytes32 balanceContainerRoot,
         uint40 validatorIndex,
         ValidatorTypes.BalanceProof calldata proof
-    ) internal pure returns (uint64 balance) {
+    )
+        internal
+        pure
+        returns (uint64 balance)
+    {
         // Each balance leaf contains 4 validator balances packed together
         // Leaf index = validatorIndex / 4
         uint256 balanceLeafIndex = validatorIndex / VALIDATORS_PER_BALANCE_LEAF;
@@ -255,12 +259,7 @@ library BeaconChainProofs {
             revert InvalidProofLength();
         }
 
-        bool valid = _verifyMerkleProof(
-            proof.proof,
-            balanceContainerRoot,
-            proof.balanceRoot,
-            balanceLeafIndex
-        );
+        bool valid = _verifyMerkleProof(proof.proof, balanceContainerRoot, proof.balanceRoot, balanceLeafIndex);
 
         if (!valid) {
             revert ProofVerificationFailed();
@@ -346,10 +345,7 @@ library BeaconChainProofs {
     /// @param balanceRoot The 32-byte leaf containing 4 packed balances
     /// @param validatorIndex The validator's global index
     /// @return The 64-bit balance in gwei
-    function _extractBalanceFromLeaf(
-        bytes32 balanceRoot,
-        uint40 validatorIndex
-    ) internal pure returns (uint64) {
+    function _extractBalanceFromLeaf(bytes32 balanceRoot, uint40 validatorIndex) internal pure returns (uint64) {
         // Position within the leaf (0-3)
         uint256 position = validatorIndex % VALIDATORS_PER_BALANCE_LEAF;
         // Each balance is 8 bytes (64 bits), little-endian
@@ -369,7 +365,11 @@ library BeaconChainProofs {
         bytes32 root,
         bytes32 leaf,
         uint256 index
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         bytes32 computedHash = leaf;
 
         for (uint256 i = 0; i < proof.length; i += 32) {
@@ -396,7 +396,11 @@ library BeaconChainProofs {
         bytes32 root,
         bytes32 leaf,
         uint256 gindex
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         bytes32 computedHash = leaf;
 
         // Number of levels = log2(gindex) = position of highest bit
@@ -423,7 +427,11 @@ library BeaconChainProofs {
         bytes32 root,
         bytes32 leaf,
         uint256 gindex
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         bytes32 computedHash = leaf;
 
         for (uint256 i = 0; i < proof.length; i += 32) {

--- a/src/beacon/TangleL2Slasher.sol
+++ b/src/beacon/TangleL2Slasher.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IL2Slasher} from "./L2SlashingReceiver.sol";
-import {IStaking} from "../interfaces/IStaking.sol";
-import {Types} from "../libraries/Types.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import { IL2Slasher } from "./L2SlashingReceiver.sol";
+import { IStaking } from "../interfaces/IStaking.sol";
+import { Types } from "../libraries/Types.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title TangleL2Slasher
 /// @notice Implementation of IL2Slasher that integrates with Tangle's staking system
@@ -30,12 +30,7 @@ contract TangleL2Slasher is IL2Slasher, Ownable {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event BeaconSlashExecuted(
-        address indexed operator,
-        uint16 slashBps,
-        uint256 actualSlashed,
-        bytes reason
-    );
+    event BeaconSlashExecuted(address indexed operator, uint16 slashBps, uint256 actualSlashed, bytes reason);
 
     event AuthorizedCallerUpdated(address indexed caller, bool authorized);
     event StakingUpdated(address indexed oldRestaking, address indexed newRestaking);
@@ -108,7 +103,11 @@ contract TangleL2Slasher is IL2Slasher, Ownable {
         address operator,
         uint16 slashBps,
         bytes calldata reason
-    ) external onlyAuthorized whenNotPaused {
+    )
+        external
+        onlyAuthorized
+        whenNotPaused
+    {
         if (operator == address(0)) revert ZeroAddress();
         if (slashBps == 0) revert ZeroAmount();
 
@@ -117,21 +116,10 @@ contract TangleL2Slasher is IL2Slasher, Ownable {
 
         // Generate evidence hash from the reason
         // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 evidence = keccak256(abi.encodePacked(
-            "BEACON_CHAIN_SLASH",
-            operator,
-            slashBps,
-            slashNonce++,
-            reason
-        ));
+        bytes32 evidence = keccak256(abi.encodePacked("BEACON_CHAIN_SLASH", operator, slashBps, slashNonce++, reason));
 
         // Execute slash through staking contract
-        uint256 actualSlashed = staking.slash(
-            operator,
-            BEACON_SLASH_SERVICE_ID,
-            slashBps,
-            evidence
-        );
+        uint256 actualSlashed = staking.slash(operator, BEACON_SLASH_SERVICE_ID, slashBps, evidence);
 
         // Track total slashed
         totalBeaconSlashed[operator] += actualSlashed;
@@ -147,10 +135,8 @@ contract TangleL2Slasher is IL2Slasher, Ownable {
 
     /// @inheritdoc IL2Slasher
     function getSlashableStake(address operator) public view returns (uint256) {
-        return staking.getOperatorStakeForAsset(
-            operator,
-            Types.Asset({ kind: Types.AssetKind.Native, token: address(0) })
-        );
+        return
+            staking.getOperatorStakeForAsset(operator, Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/beacon/ValidatorTypes.sol
+++ b/src/beacon/ValidatorTypes.sol
@@ -36,9 +36,9 @@ library ValidatorTypes {
 
     /// @notice Status of a validator in the pod
     enum ValidatorStatus {
-        INACTIVE,    // Not yet verified or unknown
-        ACTIVE,      // Verified and restaked
-        WITHDRAWN    // Fully exited from beacon chain
+        INACTIVE, // Not yet verified or unknown
+        ACTIVE, // Verified and restaked
+        WITHDRAWN // Fully exited from beacon chain
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/beacon/interfaces/ICrossChainMessenger.sol
+++ b/src/beacon/interfaces/ICrossChainMessenger.sol
@@ -16,7 +16,10 @@ interface ICrossChainMessenger {
         address target,
         bytes calldata payload,
         uint256 gasLimit
-    ) external payable returns (bytes32 messageId);
+    )
+        external
+        payable
+        returns (bytes32 messageId);
 
     /// @notice Estimate the fee for sending a message
     /// @param destinationChainId The target chain ID
@@ -27,7 +30,10 @@ interface ICrossChainMessenger {
         uint256 destinationChainId,
         bytes calldata payload,
         uint256 gasLimit
-    ) external view returns (uint256 fee);
+    )
+        external
+        view
+        returns (uint256 fee);
 
     /// @notice Check if a destination chain is supported
     /// @param chainId The chain ID to check
@@ -42,9 +48,5 @@ interface ICrossChainReceiver {
     /// @param sourceChainId The chain ID where the message originated
     /// @param sender The sender address on the source chain
     /// @param payload The message payload
-    function receiveMessage(
-        uint256 sourceChainId,
-        address sender,
-        bytes calldata payload
-    ) external;
+    function receiveMessage(uint256 sourceChainId, address sender, bytes calldata payload) external;
 }

--- a/src/beacon/l1/BeaconRootRelayer.sol
+++ b/src/beacon/l1/BeaconRootRelayer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IL1CrossDomainMessenger} from "../IBeaconOracle.sol";
+import { IL1CrossDomainMessenger } from "../IBeaconOracle.sol";
 
 /// @title BeaconRootRelayer
 /// @notice L1 contract that reads beacon roots via EIP-4788 and relays them to L2
@@ -75,11 +75,7 @@ contract BeaconRootRelayer {
         relayedTimestamps[timestamp] = true;
 
         // Encode the call to receiveBeaconRoot on L2
-        bytes memory message = abi.encodeWithSignature(
-            "receiveBeaconRoot(uint64,bytes32)",
-            timestamp,
-            root
-        );
+        bytes memory message = abi.encodeWithSignature("receiveBeaconRoot(uint64,bytes32)", timestamp, root);
 
         // Send through the canonical bridge
         messenger.sendMessage(l2BeaconRootReceiver, message, DEFAULT_GAS_LIMIT);
@@ -101,11 +97,7 @@ contract BeaconRootRelayer {
 
             relayedTimestamps[timestamp] = true;
 
-            bytes memory message = abi.encodeWithSignature(
-                "receiveBeaconRoot(uint64,bytes32)",
-                timestamp,
-                root
-            );
+            bytes memory message = abi.encodeWithSignature("receiveBeaconRoot(uint64,bytes32)", timestamp, root);
 
             messenger.sendMessage(l2BeaconRootReceiver, message, DEFAULT_GAS_LIMIT);
 

--- a/src/config/ProtocolConfig.sol
+++ b/src/config/ProtocolConfig.sol
@@ -38,7 +38,7 @@ library ProtocolConfig {
     // OPERATOR REGISTRATION
     // ═══════════════════════════════════════════════════════════════════════════
 
-    uint32 internal constant MAX_BLUEPRINTS_PER_OPERATOR = 1_024;
+    uint32 internal constant MAX_BLUEPRINTS_PER_OPERATOR = 1024;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE REQUEST TTL

--- a/src/core/Base.sol
+++ b/src/core/Base.sol
@@ -143,11 +143,7 @@ abstract contract Base is
     ///      TangleTimelock contract to enforce governance delays on critical admin operations.
     ///      Failure to do so leaves the protocol vulnerable to instant malicious admin actions.
     // forge-lint: disable-next-line(mixed-case-function)
-    function __Base_init(
-        address admin,
-        address staking_,
-        address payable treasury_
-    ) internal onlyInitializing {
+    function __Base_init(address admin, address staking_, address payable treasury_) internal onlyInitializing {
         if (admin == address(0) || staking_ == address(0) || treasury_ == address(0)) {
             revert Errors.ZeroAddress();
         }
@@ -180,11 +176,7 @@ abstract contract Base is
         });
 
         // Initialize EIP-712 domain separator
-        _domainSeparator = SignatureLib.computeDomainSeparator(
-            "TangleQuote",
-            "1",
-            address(this)
-        );
+        _domainSeparator = SignatureLib.computeDomainSeparator("TangleQuote", "1", address(this));
 
         // Initialize slashing config
         SlashingLib.initializeConfig(_slashState);
@@ -209,7 +201,7 @@ abstract contract Base is
     /// @notice Authorize an upgrade to a new implementation
     /// @dev Required for UUPS pattern, only callable by UPGRADER_ROLE
     /// @param newImplementation Address of the new implementation (unused, just for interface)
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
 
     /// @notice Set the metrics recorder for incentive tracking
     /// @param recorder The metrics recorder address (set to address(0) to disable)
@@ -339,8 +331,8 @@ abstract contract Base is
         return _tntPaymentDiscountBps;
     }
 
-    /// @notice Configure discount applied to service payments made in TNT (bps of the payment amount; capped to protocol share)
-    /// @param discountBps The discount in basis points
+    /// @notice Configure discount applied to service payments made in TNT (bps of the payment amount; capped to
+    /// protocol share) @param discountBps The discount in basis points
     function setTntPaymentDiscountBps(uint16 discountBps) external onlyRole(ADMIN_ROLE) {
         if (discountBps > BPS_DENOMINATOR) revert Errors.InvalidState();
         uint16 oldBps = _tntPaymentDiscountBps;
@@ -415,7 +407,10 @@ abstract contract Base is
     /// @param requestId The request ID to query
     /// @param operator The operator address to query
     /// @return commitments The array of security commitments for the operator
-    function getServiceRequestSecurityCommitments(uint64 requestId, address operator)
+    function getServiceRequestSecurityCommitments(
+        uint64 requestId,
+        address operator
+    )
         external
         view
         returns (Types.AssetSecurityCommitment[] memory commitments)
@@ -446,7 +441,10 @@ abstract contract Base is
     /// @param serviceId The service ID to query
     /// @param operator The operator address to query
     /// @return commitments The array of security commitments for the operator
-    function getServiceSecurityCommitments(uint64 serviceId, address operator)
+    function getServiceSecurityCommitments(
+        uint64 serviceId,
+        address operator
+    )
         external
         view
         returns (Types.AssetSecurityCommitment[] memory commitments)
@@ -464,7 +462,11 @@ abstract contract Base is
         address operator,
         Types.AssetKind kind,
         address token
-    ) external view returns (uint16) {
+    )
+        external
+        view
+        returns (uint16)
+    {
         // forge-lint: disable-next-line(asm-keccak256)
         bytes32 assetHash = keccak256(abi.encode(kind, token));
         return _serviceSecurityCommitmentBps[serviceId][operator][assetHash];
@@ -528,51 +530,61 @@ abstract contract Base is
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Record a service creation event
-    function _recordServiceCreated(uint64 serviceId, uint64 blueprintId, address owner, uint256 operatorCount) internal {
+    function _recordServiceCreated(
+        uint64 serviceId,
+        uint64 blueprintId,
+        address owner,
+        uint256 operatorCount
+    )
+        internal
+    {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordServiceCreated(serviceId, blueprintId, owner, operatorCount) {} catch {}
+            try IMetricsRecorder(_metricsRecorder)
+                .recordServiceCreated(serviceId, blueprintId, owner, operatorCount) { }
+                catch { }
         }
     }
 
     /// @notice Record a job call event
     function _recordJobCall(uint64 serviceId, address caller, uint64 jobCallId) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordJobCall(serviceId, caller, jobCallId) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordJobCall(serviceId, caller, jobCallId) { } catch { }
         }
     }
 
     /// @notice Record a job completion event
     function _recordJobCompletion(address operator, uint64 serviceId, uint64 jobCallId, bool success) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordJobCompletion(operator, serviceId, jobCallId, success) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordJobCompletion(operator, serviceId, jobCallId, success) { }
+                catch { }
         }
     }
 
     /// @notice Record a payment event
     function _recordPayment(address payer, uint64 serviceId, address token, uint256 amount) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordPayment(payer, serviceId, token, amount) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordPayment(payer, serviceId, token, amount) { } catch { }
         }
     }
 
     /// @notice Record a blueprint creation event
     function _recordBlueprintCreated(uint64 blueprintId, address developer) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordBlueprintCreated(blueprintId, developer) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordBlueprintCreated(blueprintId, developer) { } catch { }
         }
     }
 
     /// @notice Record a blueprint registration event
     function _recordBlueprintRegistration(uint64 blueprintId, address operator) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordBlueprintRegistration(blueprintId, operator) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordBlueprintRegistration(blueprintId, operator) { } catch { }
         }
     }
 
     /// @notice Record a slash event
     function _recordSlash(address operator, uint64 serviceId, uint256 amount) internal {
         if (_metricsRecorder != address(0)) {
-            try IMetricsRecorder(_metricsRecorder).recordSlash(operator, serviceId, amount) {} catch {}
+            try IMetricsRecorder(_metricsRecorder).recordSlash(operator, serviceId, amount) { } catch { }
         }
     }
 
@@ -587,7 +599,14 @@ abstract contract Base is
     /// @param manager The blueprint's service manager address
     /// @param owner The service owner address
     /// @param operators The operators selected for this service instance
-    function _configureHeartbeat(uint64 serviceId, address manager, address owner, address[] memory operators) internal {
+    function _configureHeartbeat(
+        uint64 serviceId,
+        address manager,
+        address owner,
+        address[] memory operators
+    )
+        internal
+    {
         if (_operatorStatusRegistry == address(0)) return;
 
         // Get heartbeat interval from BSM (use default if not implemented or returns useDefault=true)
@@ -596,29 +615,33 @@ abstract contract Base is
 
         if (manager != address(0)) {
             // Try to get custom heartbeat interval
-            try IBlueprintServiceManager(manager).getHeartbeatInterval(serviceId) returns (bool useDefault, uint64 customInterval) {
+            try IBlueprintServiceManager(manager).getHeartbeatInterval(serviceId) returns (
+                bool useDefault, uint64 customInterval
+            ) {
                 if (!useDefault && customInterval > 0) {
                     interval = customInterval;
                 }
-            } catch {}
+            } catch { }
 
             // Try to get custom heartbeat threshold (max missed before offline)
-            try IBlueprintServiceManager(manager).getHeartbeatThreshold(serviceId) returns (bool useDefault, uint8 threshold) {
+            try IBlueprintServiceManager(manager).getHeartbeatThreshold(serviceId) returns (
+                bool useDefault, uint8 threshold
+            ) {
                 if (!useDefault && threshold > 0) {
                     // threshold is percentage, we interpret high values as max missed beats
                     // Lower threshold = stricter = fewer missed allowed
                     // e.g., 90% threshold ≈ allow 1 missed, 50% ≈ allow 3 missed
                     maxMissed = threshold > 80 ? 1 : (threshold > 50 ? 2 : 3);
                 }
-            } catch {}
+            } catch { }
         }
 
         // Register service owner and configure heartbeat
-        try IOperatorStatusRegistry(_operatorStatusRegistry).registerServiceOwner(serviceId, owner) {} catch {}
+        try IOperatorStatusRegistry(_operatorStatusRegistry).registerServiceOwner(serviceId, owner) { } catch { }
 
         // Register each selected operator for this service instance
         for (uint256 i = 0; i < operators.length; i++) {
-            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, operators[i]) {} catch {}
+            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, operators[i]) { } catch { }
         }
 
         // Configure heartbeat if custom values provided
@@ -627,11 +650,8 @@ abstract contract Base is
             if (interval == 0) interval = 300; // 5 minutes default
             if (maxMissed == 0) maxMissed = 3;
 
-            try IOperatorStatusRegistry(_operatorStatusRegistry).configureHeartbeat(
-                serviceId,
-                interval,
-                maxMissed
-            ) {} catch {}
+            try IOperatorStatusRegistry(_operatorStatusRegistry).configureHeartbeat(serviceId, interval, maxMissed) { }
+                catch { }
         }
     }
 
@@ -689,15 +709,21 @@ abstract contract Base is
 
     /// @notice Get total number of blueprints created
     /// @return The total blueprint count (also used as next blueprint ID)
-    function blueprintCount() external view returns (uint64) { return _blueprintCount; }
+    function blueprintCount() external view returns (uint64) {
+        return _blueprintCount;
+    }
 
     /// @notice Get total number of services created
     /// @return The total service count (also used as next service ID)
-    function serviceCount() external view returns (uint64) { return _serviceCount; }
+    function serviceCount() external view returns (uint64) {
+        return _serviceCount;
+    }
 
     /// @notice Get total number of service requests created
     /// @return The total service request count (also used as next request ID)
-    function serviceRequestCount() external view returns (uint64) { return _serviceRequestCount; }
+    function serviceRequestCount() external view returns (uint64) {
+        return _serviceRequestCount;
+    }
 
     /// @notice Get blueprint details by ID
     /// @param id The blueprint ID to query
@@ -754,7 +780,14 @@ abstract contract Base is
     /// @param blueprintId The blueprint ID
     /// @param op The operator address
     /// @return The operator's registration data
-    function getOperatorRegistration(uint64 blueprintId, address op) external view returns (Types.OperatorRegistration memory) {
+    function getOperatorRegistration(
+        uint64 blueprintId,
+        address op
+    )
+        external
+        view
+        returns (Types.OperatorRegistration memory)
+    {
         return _operatorRegistrations[blueprintId][op];
     }
 
@@ -770,7 +803,14 @@ abstract contract Base is
     /// @param blueprintId The blueprint ID
     /// @param op The operator address
     /// @return The operator's preferences including BLS and ECDSA keys
-    function getOperatorPreferences(uint64 blueprintId, address op) external view returns (Types.OperatorPreferences memory) {
+    function getOperatorPreferences(
+        uint64 blueprintId,
+        address op
+    )
+        external
+        view
+        returns (Types.OperatorPreferences memory)
+    {
         return _operatorPreferences[blueprintId][op];
     }
 
@@ -814,5 +854,5 @@ abstract contract Base is
     }
 
     /// @notice Accept native token
-    receive() external payable {}
+    receive() external payable { }
 }

--- a/src/core/Blueprints.sol
+++ b/src/core/Blueprints.sol
@@ -66,10 +66,7 @@ abstract contract Blueprints is Base {
         if (def.manager != address(0)) {
             _callManager(
                 def.manager,
-                abi.encodeCall(
-                    IBlueprintServiceManager.onBlueprintCreated,
-                    (blueprintId, msg.sender, address(this))
-                )
+                abi.encodeCall(IBlueprintServiceManager.onBlueprintCreated, (blueprintId, msg.sender, address(this)))
             );
         }
         _notifyMasterBlueprintManager(masterManager, blueprintId, msg.sender, encodedDefinition);
@@ -148,12 +145,7 @@ abstract contract Blueprints is Base {
         delete _blueprintJobSchemas[blueprintId];
         Types.StoredJobSchema[] storage schemas = _blueprintJobSchemas[blueprintId];
         for (uint256 i = 0; i < def.jobs.length; ++i) {
-            schemas.push(
-                Types.StoredJobSchema({
-                    params: def.jobs[i].paramsSchema,
-                    result: def.jobs[i].resultSchema
-                })
-            );
+            schemas.push(Types.StoredJobSchema({ params: def.jobs[i].paramsSchema, result: def.jobs[i].resultSchema }));
         }
     }
 
@@ -161,7 +153,9 @@ abstract contract Blueprints is Base {
         uint64 blueprintId,
         string calldata metadataUri,
         Types.BlueprintMetadata calldata metadata
-    ) private {
+    )
+        private
+    {
         _blueprintMetadataUri[blueprintId] = metadataUri;
         _blueprintMetadata[blueprintId] = metadata;
     }
@@ -242,7 +236,9 @@ abstract contract Blueprints is Base {
         uint64 blueprintId,
         address owner,
         bytes memory encodedDefinition
-    ) private {
+    )
+        private
+    {
         IMasterBlueprintServiceManager(masterManager).onBlueprintCreated(blueprintId, owner, encodedDefinition);
     }
 }

--- a/src/core/BlueprintsCreate.sol
+++ b/src/core/BlueprintsCreate.sol
@@ -59,10 +59,7 @@ abstract contract BlueprintsCreate is Base {
         if (def.manager != address(0)) {
             _callManager(
                 def.manager,
-                abi.encodeCall(
-                    IBlueprintServiceManager.onBlueprintCreated,
-                    (blueprintId, msg.sender, address(this))
-                )
+                abi.encodeCall(IBlueprintServiceManager.onBlueprintCreated, (blueprintId, msg.sender, address(this)))
             );
         }
         _notifyMasterBlueprintManager(masterManager, blueprintId, msg.sender, encodedDefinition);
@@ -76,12 +73,7 @@ abstract contract BlueprintsCreate is Base {
         delete _blueprintJobSchemas[blueprintId];
         Types.StoredJobSchema[] storage schemas = _blueprintJobSchemas[blueprintId];
         for (uint256 i = 0; i < def.jobs.length; ++i) {
-            schemas.push(
-                Types.StoredJobSchema({
-                    params: def.jobs[i].paramsSchema,
-                    result: def.jobs[i].resultSchema
-                })
-            );
+            schemas.push(Types.StoredJobSchema({ params: def.jobs[i].paramsSchema, result: def.jobs[i].resultSchema }));
         }
     }
 
@@ -89,7 +81,9 @@ abstract contract BlueprintsCreate is Base {
         uint64 blueprintId,
         string calldata metadataUri,
         Types.BlueprintMetadata calldata metadata
-    ) private {
+    )
+        private
+    {
         _blueprintMetadataUri[blueprintId] = metadataUri;
         _blueprintMetadata[blueprintId] = metadata;
     }
@@ -170,7 +164,9 @@ abstract contract BlueprintsCreate is Base {
         uint64 blueprintId,
         address owner,
         bytes memory encodedDefinition
-    ) private {
+    )
+        private
+    {
         IMasterBlueprintServiceManager(masterManager).onBlueprintCreated(blueprintId, owner, encodedDefinition);
     }
 }

--- a/src/core/PaymentsEffectiveExposure.sol
+++ b/src/core/PaymentsEffectiveExposure.sol
@@ -16,7 +16,7 @@ abstract contract PaymentsEffectiveExposure {
     /// @notice Precision multiplier for effective exposure calculations
     /// @dev Used to maintain precision when combining delegation amounts with exposure bps
     uint256 internal constant EXPOSURE_PRECISION = 1e18;
-    
+
     /// @notice Local BPS constant for calculations (matches TangleStorage._BPS_DENOM)
     uint256 private constant _BPS_DENOM = 10_000;
 
@@ -26,15 +26,19 @@ abstract contract PaymentsEffectiveExposure {
 
     /// @notice Get the staking contract
     function _getStaking() internal view virtual returns (IStaking);
-    
+
     /// @notice Get the price oracle (may return address(0) if not configured)
     function _getPriceOracle() internal view virtual returns (address);
-    
+
     /// @notice Get security commitments for an operator on a service
     function _getServiceSecurityCommitments(
         uint64 serviceId,
         address operator
-    ) internal view virtual returns (Types.AssetSecurityCommitment[] storage);
+    )
+        internal
+        view
+        virtual
+        returns (Types.AssetSecurityCommitment[] storage);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EFFECTIVE EXPOSURE CALCULATION
@@ -51,10 +55,14 @@ abstract contract PaymentsEffectiveExposure {
     function _calculateEffectiveExposures(
         uint64 serviceId,
         address[] memory operators
-    ) internal view returns (uint256[] memory effectiveExposures, uint256 totalEffectiveExposure) {
+    )
+        internal
+        view
+        returns (uint256[] memory effectiveExposures, uint256 totalEffectiveExposure)
+    {
         uint256 operatorsLength = operators.length;
         effectiveExposures = new uint256[](operatorsLength);
-        
+
         IStaking staking = _getStaking();
         address priceOracleAddr = _getPriceOracle();
         bool useOracle = priceOracleAddr != address(0);
@@ -63,25 +71,24 @@ abstract contract PaymentsEffectiveExposure {
         for (uint256 i = 0; i < operatorsLength;) {
             address operator = operators[i];
             Types.AssetSecurityCommitment[] storage commitments = _getServiceSecurityCommitments(serviceId, operator);
-            
+
             uint256 operatorEffectiveExposure = 0;
             uint256 commitmentsLength = commitments.length;
-            
+
             for (uint256 j = 0; j < commitmentsLength;) {
                 Types.AssetSecurityCommitment storage commitment = commitments[j];
-                
+
                 // Get delegation for this asset
                 uint256 delegation = staking.getOperatorStakeForAsset(operator, commitment.asset);
-                
+
                 if (delegation > 0) {
                     // Calculate exposed amount: delegation × exposureBps / _BPS_DENOM
                     uint256 exposedAmount = (delegation * commitment.exposureBps) / _BPS_DENOM;
-                    
+
                     if (useOracle && exposedAmount > 0) {
                         // Convert to USD for cross-asset comparison
-                        address token = commitment.asset.kind == Types.AssetKind.Native 
-                            ? address(0) 
-                            : commitment.asset.token;
+                        address token =
+                            commitment.asset.kind == Types.AssetKind.Native ? address(0) : commitment.asset.token;
                         try oracle.toUSD(token, exposedAmount) returns (uint256 usdValue) {
                             operatorEffectiveExposure += usdValue;
                         } catch {
@@ -93,14 +100,18 @@ abstract contract PaymentsEffectiveExposure {
                         operatorEffectiveExposure += exposedAmount;
                     }
                 }
-                
-                unchecked { ++j; }
+
+                unchecked {
+                    ++j;
+                }
             }
-            
+
             effectiveExposures[i] = operatorEffectiveExposure;
             totalEffectiveExposure += operatorEffectiveExposure;
-            
-            unchecked { ++i; }
+
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -113,14 +124,20 @@ abstract contract PaymentsEffectiveExposure {
     function _calculateSimpleExposures(
         address[] memory operators,
         uint16[] memory exposureBps
-    ) internal pure returns (uint256[] memory effectiveExposures, uint256 totalEffectiveExposure) {
+    )
+        internal
+        pure
+        returns (uint256[] memory effectiveExposures, uint256 totalEffectiveExposure)
+    {
         uint256 operatorsLength = operators.length;
         effectiveExposures = new uint256[](operatorsLength);
-        
+
         for (uint256 i = 0; i < operatorsLength;) {
             effectiveExposures[i] = exposureBps[i];
             totalEffectiveExposure += exposureBps[i];
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
     }
 }

--- a/src/core/Services.sol
+++ b/src/core/Services.sol
@@ -40,18 +40,16 @@ abstract contract Services is Base {
     // ═══════════════════════════════════════════════════════════════════════════
 
     event ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
-    event ServiceRequestedWithSecurity(
-        uint64 indexed requestId,
-        uint64 indexed blueprintId,
-        address indexed requester
-    );
+    event ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
     event ServiceApproved(uint64 indexed requestId, address indexed operator);
     event ServiceRejected(uint64 indexed requestId, address indexed operator);
     // ServiceActivated defined in Base.sol
     event ServiceTerminated(uint64 indexed serviceId);
     event OperatorJoinedService(uint64 indexed serviceId, address indexed operator, uint16 exposureBps);
     event OperatorSecurityCommitmentsStored(uint64 indexed serviceId, address indexed operator, uint256 count);
-    event OperatorSecurityCommitment(uint64 indexed serviceId, address indexed operator, uint8 assetKind, address asset, uint16 exposureBps);
+    event OperatorSecurityCommitment(
+        uint64 indexed serviceId, address indexed operator, uint8 assetKind, address asset, uint16 exposureBps
+    );
     event OperatorLeftService(uint64 indexed serviceId, address indexed operator);
     event ExitScheduled(uint64 indexed serviceId, address indexed operator, uint64 executeAfter);
     event ExitCanceled(uint64 indexed serviceId, address indexed operator);
@@ -70,7 +68,13 @@ abstract contract Services is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceWithDefaultExposure(
             blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount
@@ -89,7 +93,13 @@ abstract contract Services is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         if (operators.length != exposures.length) revert Errors.LengthMismatch();
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceInternal(
@@ -109,7 +119,13 @@ abstract contract Services is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         _validateSecurityRequirements(securityRequirements);
 
         requestId = _requestServiceWithDefaultExposure(
@@ -128,7 +144,10 @@ abstract contract Services is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) private returns (uint64 requestId) {
+    )
+        private
+        returns (uint64 requestId)
+    {
         uint16[] memory exposures = _defaultExposures(operators.length);
         _validateRequestConfig(blueprintId, config);
         return _requestServiceInternal(
@@ -146,7 +165,10 @@ abstract contract Services is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) internal returns (uint64 requestId) {
+    )
+        internal
+        returns (uint64 requestId)
+    {
         if (operators.length == 0) revert Errors.NoOperators();
 
         BlueprintRequestData memory blueprintData = _loadBlueprintRequestData(blueprintId);
@@ -158,14 +180,7 @@ abstract contract Services is Base {
 
         RequestBounds memory bounds = _computeRequestBounds(blueprintId, uint32(operators.length));
 
-        requestId = _createServiceRequest(
-            blueprintId,
-            ttl,
-            paymentToken,
-            paymentAmount,
-            blueprintData,
-            bounds
-        );
+        requestId = _createServiceRequest(blueprintId, ttl, paymentToken, paymentAmount, blueprintData, bounds);
 
         _storeRequestOperators(requestId, operators, exposures);
         _storePermittedCallers(requestId, permittedCallers);
@@ -176,20 +191,10 @@ abstract contract Services is Base {
     }
 
     function _validateRequestConfig(uint64 blueprintId, bytes calldata config) private view {
-        SchemaLib.validatePayload(
-            _requestSchemas[blueprintId],
-            config,
-            Types.SchemaTarget.Request,
-            blueprintId,
-            0
-        );
+        SchemaLib.validatePayload(_requestSchemas[blueprintId], config, Types.SchemaTarget.Request, blueprintId, 0);
     }
 
-    function _validateRequestPaymentAsset(
-        address manager,
-        address paymentToken,
-        uint256 paymentAmount
-    ) private view {
+    function _validateRequestPaymentAsset(address manager, address paymentToken, uint256 paymentAmount) private view {
         if (manager == address(0) || paymentAmount == 0) {
             return;
         }
@@ -206,7 +211,10 @@ abstract contract Services is Base {
         uint64 blueprintId,
         address[] calldata operators,
         uint16[] memory exposures
-    ) private view {
+    )
+        private
+        view
+    {
         for (uint256 i = 0; i < operators.length; i++) {
             if (_operatorRegistrations[blueprintId][operators[i]].registeredAt == 0) {
                 revert Errors.OperatorNotRegistered(blueprintId, operators[i]);
@@ -224,11 +232,7 @@ abstract contract Services is Base {
         return bpConfig.minOperators > 0 ? bpConfig.minOperators : 1;
     }
 
-    function _validateOperatorBounds(
-        uint32 maxOperators,
-        uint32 operatorCount,
-        uint32 minOps
-    ) private pure {
+    function _validateOperatorBounds(uint32 maxOperators, uint32 operatorCount, uint32 minOps) private pure {
         if (operatorCount < minOps) {
             revert Errors.InsufficientOperators(minOps, operatorCount);
         }
@@ -237,11 +241,7 @@ abstract contract Services is Base {
         }
     }
 
-    function _storeRequestOperators(
-        uint64 requestId,
-        address[] calldata operators,
-        uint16[] memory exposures
-    ) private {
+    function _storeRequestOperators(uint64 requestId, address[] calldata operators, uint16[] memory exposures) private {
         for (uint256 i = 0; i < operators.length; i++) {
             _requestOperators[requestId].push(operators[i]);
             _requestExposures[requestId][operators[i]] = exposures[i];
@@ -259,7 +259,9 @@ abstract contract Services is Base {
         uint64 requestId,
         address[] calldata operators,
         bytes calldata config
-    ) private {
+    )
+        private
+    {
         if (manager == address(0)) {
             return;
         }
@@ -293,7 +295,9 @@ abstract contract Services is Base {
     function _storeSecurityRequirements(
         uint64 requestId,
         Types.AssetSecurityRequirement[] calldata requirements
-    ) private {
+    )
+        private
+    {
         for (uint256 i = 0; i < requirements.length; i++) {
             _requestSecurityRequirements[requestId].push(requirements[i]);
         }
@@ -302,17 +306,21 @@ abstract contract Services is Base {
     function _storeDefaultTntRequirement(uint64 requestId) private {
         if (_tntToken == address(0)) return;
 
-        _requestSecurityRequirements[requestId].push(Types.AssetSecurityRequirement({
-            asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: _tntToken }),
-            minExposureBps: _defaultTntMinExposureBps,
-            maxExposureBps: BPS_DENOMINATOR
-        }));
+        _requestSecurityRequirements[requestId].push(
+            Types.AssetSecurityRequirement({
+                asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: _tntToken }),
+                minExposureBps: _defaultTntMinExposureBps,
+                maxExposureBps: BPS_DENOMINATOR
+            })
+        );
     }
 
     function _storeSecurityRequirementsWithDefaultTnt(
         uint64 requestId,
         Types.AssetSecurityRequirement[] calldata requirements
-    ) private {
+    )
+        private
+    {
         if (_tntToken == address(0)) {
             _storeSecurityRequirements(requestId, requirements);
             return;
@@ -354,18 +362,17 @@ abstract contract Services is Base {
         existing.push(Types.AssetSecurityCommitment({ asset: req.asset, exposureBps: req.minExposureBps }));
     }
 
-    function _loadBlueprintRequestData(uint64 blueprintId)
-        private
-        view
-        returns (BlueprintRequestData memory data)
-    {
+    function _loadBlueprintRequestData(uint64 blueprintId) private view returns (BlueprintRequestData memory data) {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         if (!bp.active) revert Errors.BlueprintNotActive(blueprintId);
         data.manager = bp.manager;
         data.membership = bp.membership;
     }
 
-    function _computeRequestBounds(uint64 blueprintId, uint32 operatorCount)
+    function _computeRequestBounds(
+        uint64 blueprintId,
+        uint32 operatorCount
+    )
         private
         view
         returns (RequestBounds memory bounds)
@@ -384,7 +391,10 @@ abstract contract Services is Base {
         uint256 paymentAmount,
         BlueprintRequestData memory blueprintData,
         RequestBounds memory bounds
-    ) private returns (uint64 requestId) {
+    )
+        private
+        returns (uint64 requestId)
+    {
         requestId = _serviceRequestCount++;
         _serviceRequests[requestId] = Types.ServiceRequest({
             blueprintId: blueprintId,
@@ -412,9 +422,8 @@ abstract contract Services is Base {
         // TTL of 0 means no expiration
         if (req.ttl == 0) return false;
 
-        uint64 gracePeriod = _requestExpiryGracePeriod > 0
-            ? _requestExpiryGracePeriod
-            : ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD;
+        uint64 gracePeriod =
+            _requestExpiryGracePeriod > 0 ? _requestExpiryGracePeriod : ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD;
 
         uint64 expiryWithGrace = req.createdAt + req.ttl + gracePeriod;
         return block.timestamp > expiryWithGrace;
@@ -459,8 +468,7 @@ abstract contract Services is Base {
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
             );
         }
 
@@ -473,7 +481,11 @@ abstract contract Services is Base {
     function approveServiceWithCommitments(
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external whenNotPaused nonReentrant {
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -514,8 +526,7 @@ abstract contract Services is Base {
         uint8 stakingPercent = commitments.length > 0 ? uint8(commitments[0].exposureBps / 100) : 100;
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
             );
         }
 
@@ -528,11 +539,16 @@ abstract contract Services is Base {
     function _validateSecurityCommitments(
         Types.AssetSecurityRequirement[] storage requirements,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) internal view {
+    )
+        internal
+        view
+    {
         for (uint256 i = 0; i < commitments.length; i++) {
             for (uint256 j = i + 1; j < commitments.length; j++) {
-                if (commitments[i].asset.token == commitments[j].asset.token &&
-                    commitments[i].asset.kind == commitments[j].asset.kind) {
+                if (
+                    commitments[i].asset.token == commitments[j].asset.token
+                        && commitments[i].asset.kind == commitments[j].asset.kind
+                ) {
                     revert Errors.DuplicateAssetCommitment(uint8(commitments[i].asset.kind), commitments[i].asset.token);
                 }
             }
@@ -543,13 +559,16 @@ abstract contract Services is Base {
             bool found = false;
 
             for (uint256 j = 0; j < commitments.length; j++) {
-                if (commitments[j].asset.token == req.asset.token &&
-                    commitments[j].asset.kind == req.asset.kind) {
+                if (commitments[j].asset.token == req.asset.token && commitments[j].asset.kind == req.asset.kind) {
                     if (commitments[j].exposureBps < req.minExposureBps) {
-                        revert Errors.CommitmentBelowMinimum(req.asset.token, commitments[j].exposureBps, req.minExposureBps);
+                        revert Errors.CommitmentBelowMinimum(
+                            req.asset.token, commitments[j].exposureBps, req.minExposureBps
+                        );
                     }
                     if (commitments[j].exposureBps > req.maxExposureBps) {
-                        revert Errors.CommitmentAboveMaximum(req.asset.token, commitments[j].exposureBps, req.maxExposureBps);
+                        revert Errors.CommitmentAboveMaximum(
+                            req.asset.token, commitments[j].exposureBps, req.maxExposureBps
+                        );
                     }
                     found = true;
                     break;
@@ -586,10 +605,7 @@ abstract contract Services is Base {
 
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
         if (bp.manager != address(0)) {
-            _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onReject, (msg.sender, requestId))
-            );
+            _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onReject, (msg.sender, requestId)));
         }
     }
 
@@ -628,14 +644,13 @@ abstract contract Services is Base {
 
         // Refund remaining streamed payments to the service owner
         if (_serviceFeeDistributor != address(0)) {
-            try IServiceFeeDistributor(_serviceFeeDistributor).onServiceTerminated(serviceId, svc.owner) {} catch {}
+            try IServiceFeeDistributor(_serviceFeeDistributor).onServiceTerminated(serviceId, svc.owner) { } catch { }
         }
 
         Types.Blueprint storage bp = _blueprints[blueprintId];
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onServiceTermination, (serviceId, msg.sender))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onServiceTermination, (serviceId, msg.sender))
             );
         }
     }
@@ -691,11 +706,13 @@ abstract contract Services is Base {
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
         uint256 minStake = _staking.minOperatorStake();
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (bool useDefault, uint256 customMin) {
+            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (
+                bool useDefault, uint256 customMin
+            ) {
                 if (!useDefault && customMin > 0) {
                     minStake = customMin;
                 }
-            } catch {}
+            } catch { }
         }
         if (!_staking.meetsStakeRequirement(msg.sender, minStake)) {
             revert Errors.InsufficientStake(msg.sender, minStake, _staking.getOperatorStake(msg.sender));
@@ -707,14 +724,11 @@ abstract contract Services is Base {
                 if (!allowed) {
                     revert Errors.Unauthorized();
                 }
-            } catch {}
+            } catch { }
         }
 
         _serviceOperators[serviceId][msg.sender] = Types.ServiceOperator({
-            exposureBps: exposureBps,
-            joinedAt: uint64(block.timestamp),
-            leftAt: 0,
-            active: true
+            exposureBps: exposureBps, joinedAt: uint64(block.timestamp), leftAt: 0, active: true
         });
         _serviceOperatorSet[serviceId].add(msg.sender);
         svc.operatorCount++;
@@ -724,7 +738,7 @@ abstract contract Services is Base {
 
         // Register operator in heartbeat registry for liveness tracking
         if (_operatorStatusRegistry != address(0)) {
-            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, msg.sender) {} catch {}
+            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, msg.sender) { } catch { }
         }
 
         emit OperatorJoinedService(serviceId, msg.sender, exposureBps);
@@ -743,7 +757,11 @@ abstract contract Services is Base {
         uint64 serviceId,
         uint16 exposureBps,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external whenNotPaused nonReentrant {
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
         Types.Service storage svc = _getService(serviceId);
         if (svc.status != Types.ServiceStatus.Active) {
             revert Errors.ServiceNotActive(serviceId);
@@ -785,11 +803,13 @@ abstract contract Services is Base {
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
         uint256 minStake = _staking.minOperatorStake();
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (bool useDefault, uint256 customMin) {
+            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (
+                bool useDefault, uint256 customMin
+            ) {
                 if (!useDefault && customMin > 0) {
                     minStake = customMin;
                 }
-            } catch {}
+            } catch { }
         }
         if (!_staking.meetsStakeRequirement(msg.sender, minStake)) {
             revert Errors.InsufficientStake(msg.sender, minStake, _staking.getOperatorStake(msg.sender));
@@ -801,14 +821,11 @@ abstract contract Services is Base {
                 if (!allowed) {
                     revert Errors.Unauthorized();
                 }
-            } catch {}
+            } catch { }
         }
 
         _serviceOperators[serviceId][msg.sender] = Types.ServiceOperator({
-            exposureBps: exposureBps,
-            joinedAt: uint64(block.timestamp),
-            leftAt: 0,
-            active: true
+            exposureBps: exposureBps, joinedAt: uint64(block.timestamp), leftAt: 0, active: true
         });
         _serviceOperatorSet[serviceId].add(msg.sender);
         svc.operatorCount++;
@@ -818,7 +835,7 @@ abstract contract Services is Base {
 
         // Register operator in heartbeat registry for liveness tracking
         if (_operatorStatusRegistry != address(0)) {
-            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, msg.sender) {} catch {}
+            try IOperatorStatusRegistry(_operatorStatusRegistry).registerOperator(serviceId, msg.sender) { } catch { }
         }
 
         emit OperatorJoinedService(serviceId, msg.sender, exposureBps);
@@ -869,10 +886,7 @@ abstract contract Services is Base {
 
         // Store exit request
         _exitRequests[serviceId][msg.sender] = Types.ExitRequest({
-            serviceId: serviceId,
-            scheduledAt: uint64(block.timestamp),
-            executeAfter: executeAfter,
-            pending: true
+            serviceId: serviceId, scheduledAt: uint64(block.timestamp), executeAfter: executeAfter, pending: true
         });
 
         emit ExitScheduled(serviceId, msg.sender, executeAfter);
@@ -922,8 +936,7 @@ abstract contract Services is Base {
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onExitCanceled, (serviceId, msg.sender))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onExitCanceled, (serviceId, msg.sender))
             );
         }
     }
@@ -977,7 +990,9 @@ abstract contract Services is Base {
 
         // If exit queue is required, must use scheduleExit/executeExit
         if (exitConfig.exitQueueDuration > 0) {
-            revert Errors.ExitNotExecutable(serviceId, msg.sender, uint64(block.timestamp) + exitConfig.exitQueueDuration, uint64(block.timestamp));
+            revert Errors.ExitNotExecutable(
+                serviceId, msg.sender, uint64(block.timestamp) + exitConfig.exitQueueDuration, uint64(block.timestamp)
+            );
         }
 
         _executeLeave(serviceId, msg.sender);
@@ -1003,12 +1018,12 @@ abstract contract Services is Base {
                 if (!allowed) {
                     revert Errors.Unauthorized();
                 }
-            } catch {}
+            } catch { }
         }
 
         // Drip streaming payments BEFORE removing operator (ensures fair distribution)
         if (_serviceFeeDistributor != address(0)) {
-            try IServiceFeeDistributor(_serviceFeeDistributor).onOperatorLeaving(serviceId, operator) {} catch {}
+            try IServiceFeeDistributor(_serviceFeeDistributor).onOperatorLeaving(serviceId, operator) { } catch { }
         }
 
         opData.active = false;
@@ -1023,17 +1038,14 @@ abstract contract Services is Base {
 
         // Deregister operator from heartbeat registry
         if (_operatorStatusRegistry != address(0)) {
-            try IOperatorStatusRegistry(_operatorStatusRegistry).deregisterOperator(serviceId, operator) {} catch {}
+            try IOperatorStatusRegistry(_operatorStatusRegistry).deregisterOperator(serviceId, operator) { } catch { }
         }
 
         emit OperatorLeftService(serviceId, operator);
 
         // Notify manager of successful leave
         if (bp.manager != address(0)) {
-            _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onOperatorLeft, (serviceId, operator))
-            );
+            _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onOperatorLeft, (serviceId, operator)));
         }
     }
 
@@ -1060,7 +1072,7 @@ abstract contract Services is Base {
 
         // Drip streaming payments before removal
         if (_serviceFeeDistributor != address(0)) {
-            try IServiceFeeDistributor(_serviceFeeDistributor).onOperatorLeaving(serviceId, operator) {} catch {}
+            try IServiceFeeDistributor(_serviceFeeDistributor).onOperatorLeaving(serviceId, operator) { } catch { }
         }
 
         opData.active = false;
@@ -1079,24 +1091,25 @@ abstract contract Services is Base {
         emit OperatorLeftService(serviceId, operator);
 
         // Notify manager (it called us, but we still notify for consistency)
-        _tryCallManager(
-            bp.manager,
-            abi.encodeCall(IBlueprintServiceManager.onOperatorLeft, (serviceId, operator))
-        );
+        _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onOperatorLeft, (serviceId, operator)));
     }
 
     /// @notice Get exit configuration for a service
     /// @dev Checks manager hook first, falls back to protocol defaults
-    function _getExitConfig(uint64 blueprintId, uint64 serviceId) internal view returns (Types.ExitConfig memory config) {
+    function _getExitConfig(
+        uint64 blueprintId,
+        uint64 serviceId
+    )
+        internal
+        view
+        returns (Types.ExitConfig memory config)
+    {
         Types.Blueprint storage bp = _blueprints[blueprintId];
 
         // Check if manager provides custom exit config
         if (bp.manager != address(0)) {
             try IBlueprintServiceManager(bp.manager).getExitConfig(serviceId) returns (
-                bool useDefault,
-                uint64 minCommitmentDuration,
-                uint64 exitQueueDuration,
-                bool forceExitAllowed
+                bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed
             ) {
                 if (!useDefault) {
                     return Types.ExitConfig({
@@ -1105,7 +1118,7 @@ abstract contract Services is Base {
                         forceExitAllowed: forceExitAllowed
                     });
                 }
-            } catch {}
+            } catch { }
         }
 
         // Use protocol defaults
@@ -1151,7 +1164,14 @@ abstract contract Services is Base {
     }
 
     /// @notice Check if operator can schedule exit now
-    function canScheduleExit(uint64 serviceId, address operator) external view returns (bool canExit, string memory reason) {
+    function canScheduleExit(
+        uint64 serviceId,
+        address operator
+    )
+        external
+        view
+        returns (bool canExit, string memory reason)
+    {
         Types.Service storage svc = _services[serviceId];
         if (svc.membership != Types.MembershipModel.Dynamic) {
             return (false, "Not dynamic membership");

--- a/src/core/ServicesApprovals.sol
+++ b/src/core/ServicesApprovals.sol
@@ -61,8 +61,7 @@ abstract contract ServicesApprovals is Base {
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
             );
         }
 
@@ -75,7 +74,11 @@ abstract contract ServicesApprovals is Base {
     function approveServiceWithCommitments(
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external whenNotPaused nonReentrant {
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
         _approveServiceWithCommitmentsInternal(requestId, commitments, _emptyBlsPubkey());
     }
 
@@ -87,7 +90,11 @@ abstract contract ServicesApprovals is Base {
         uint64 requestId,
         uint8 stakingPercent,
         uint256[4] calldata blsPubkey
-    ) external whenNotPaused nonReentrant {
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -125,8 +132,7 @@ abstract contract ServicesApprovals is Base {
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
             );
         }
 
@@ -143,7 +149,11 @@ abstract contract ServicesApprovals is Base {
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments,
         uint256[4] calldata blsPubkey
-    ) external whenNotPaused nonReentrant {
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
         _approveServiceWithCommitmentsInternal(requestId, commitments, blsPubkey);
     }
 
@@ -152,7 +162,9 @@ abstract contract ServicesApprovals is Base {
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments,
         uint256[4] memory blsPubkey
-    ) private {
+    )
+        private
+    {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -195,8 +207,7 @@ abstract contract ServicesApprovals is Base {
         uint8 stakingPercent = commitments.length > 0 ? uint8(commitments[0].exposureBps / 100) : 100;
         if (bp.manager != address(0)) {
             _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onApprove, (msg.sender, requestId, stakingPercent))
             );
         }
 
@@ -226,11 +237,16 @@ abstract contract ServicesApprovals is Base {
     function _validateSecurityCommitments(
         Types.AssetSecurityRequirement[] storage requirements,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) internal view {
+    )
+        internal
+        view
+    {
         for (uint256 i = 0; i < commitments.length; i++) {
             for (uint256 j = i + 1; j < commitments.length; j++) {
-                if (commitments[i].asset.token == commitments[j].asset.token &&
-                    commitments[i].asset.kind == commitments[j].asset.kind) {
+                if (
+                    commitments[i].asset.token == commitments[j].asset.token
+                        && commitments[i].asset.kind == commitments[j].asset.kind
+                ) {
                     revert Errors.DuplicateAssetCommitment(uint8(commitments[i].asset.kind), commitments[i].asset.token);
                 }
             }
@@ -241,13 +257,16 @@ abstract contract ServicesApprovals is Base {
             bool found = false;
 
             for (uint256 j = 0; j < commitments.length; j++) {
-                if (commitments[j].asset.token == req.asset.token &&
-                    commitments[j].asset.kind == req.asset.kind) {
+                if (commitments[j].asset.token == req.asset.token && commitments[j].asset.kind == req.asset.kind) {
                     if (commitments[j].exposureBps < req.minExposureBps) {
-                        revert Errors.CommitmentBelowMinimum(req.asset.token, commitments[j].exposureBps, req.minExposureBps);
+                        revert Errors.CommitmentBelowMinimum(
+                            req.asset.token, commitments[j].exposureBps, req.minExposureBps
+                        );
                     }
                     if (commitments[j].exposureBps > req.maxExposureBps) {
-                        revert Errors.CommitmentAboveMaximum(req.asset.token, commitments[j].exposureBps, req.maxExposureBps);
+                        revert Errors.CommitmentAboveMaximum(
+                            req.asset.token, commitments[j].exposureBps, req.maxExposureBps
+                        );
                     }
                     found = true;
                     break;
@@ -284,10 +303,7 @@ abstract contract ServicesApprovals is Base {
 
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
         if (bp.manager != address(0)) {
-            _tryCallManager(
-                bp.manager,
-                abi.encodeCall(IBlueprintServiceManager.onReject, (msg.sender, requestId))
-            );
+            _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onReject, (msg.sender, requestId)));
         }
     }
 

--- a/src/core/ServicesRequests.sol
+++ b/src/core/ServicesRequests.sol
@@ -32,11 +32,7 @@ abstract contract ServicesRequests is Base {
     // ═══════════════════════════════════════════════════════════════════════════
 
     event ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
-    event ServiceRequestedWithSecurity(
-        uint64 indexed requestId,
-        uint64 indexed blueprintId,
-        address indexed requester
-    );
+    event ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE REQUESTS
@@ -51,7 +47,13 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceWithDefaultExposure(
             blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount
@@ -70,7 +72,13 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         if (operators.length != exposures.length) revert Errors.LengthMismatch();
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceInternal(
@@ -90,7 +98,13 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable whenNotPaused nonReentrant returns (uint64 requestId) {
+    )
+        external
+        payable
+        whenNotPaused
+        nonReentrant
+        returns (uint64 requestId)
+    {
         _validateSecurityRequirements(securityRequirements);
 
         requestId = _requestServiceWithDefaultExposure(
@@ -109,7 +123,10 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) private returns (uint64 requestId) {
+    )
+        private
+        returns (uint64 requestId)
+    {
         uint16[] memory exposures = _defaultExposures(operators.length);
         _validateRequestConfig(blueprintId, config);
         return _requestServiceInternal(
@@ -127,7 +144,10 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) internal returns (uint64 requestId) {
+    )
+        internal
+        returns (uint64 requestId)
+    {
         if (operators.length == 0) revert Errors.NoOperators();
 
         // Validate TTL bounds (M-1 fix)
@@ -142,14 +162,7 @@ abstract contract ServicesRequests is Base {
 
         RequestBounds memory bounds = _computeRequestBounds(blueprintId, uint32(operators.length));
 
-        requestId = _createServiceRequest(
-            blueprintId,
-            ttl,
-            paymentToken,
-            paymentAmount,
-            blueprintData,
-            bounds
-        );
+        requestId = _createServiceRequest(blueprintId, ttl, paymentToken, paymentAmount, blueprintData, bounds);
 
         _storeRequestOperators(requestId, operators, exposures);
         _storePermittedCallers(requestId, permittedCallers);
@@ -160,20 +173,10 @@ abstract contract ServicesRequests is Base {
     }
 
     function _validateRequestConfig(uint64 blueprintId, bytes calldata config) private view {
-        SchemaLib.validatePayload(
-            _requestSchemas[blueprintId],
-            config,
-            Types.SchemaTarget.Request,
-            blueprintId,
-            0
-        );
+        SchemaLib.validatePayload(_requestSchemas[blueprintId], config, Types.SchemaTarget.Request, blueprintId, 0);
     }
 
-    function _validateRequestPaymentAsset(
-        address manager,
-        address paymentToken,
-        uint256 paymentAmount
-    ) private view {
+    function _validateRequestPaymentAsset(address manager, address paymentToken, uint256 paymentAmount) private view {
         if (manager == address(0) || paymentAmount == 0) {
             return;
         }
@@ -190,7 +193,10 @@ abstract contract ServicesRequests is Base {
         uint64 blueprintId,
         address[] calldata operators,
         uint16[] memory exposures
-    ) private view {
+    )
+        private
+        view
+    {
         for (uint256 i = 0; i < operators.length; i++) {
             if (_operatorRegistrations[blueprintId][operators[i]].registeredAt == 0) {
                 revert Errors.OperatorNotRegistered(blueprintId, operators[i]);
@@ -208,11 +214,7 @@ abstract contract ServicesRequests is Base {
         return bpConfig.minOperators > 0 ? bpConfig.minOperators : 1;
     }
 
-    function _validateOperatorBounds(
-        uint32 maxOperators,
-        uint32 operatorCount,
-        uint32 minOps
-    ) private pure {
+    function _validateOperatorBounds(uint32 maxOperators, uint32 operatorCount, uint32 minOps) private pure {
         if (operatorCount < minOps) {
             revert Errors.InsufficientOperators(minOps, operatorCount);
         }
@@ -221,11 +223,7 @@ abstract contract ServicesRequests is Base {
         }
     }
 
-    function _storeRequestOperators(
-        uint64 requestId,
-        address[] calldata operators,
-        uint16[] memory exposures
-    ) private {
+    function _storeRequestOperators(uint64 requestId, address[] calldata operators, uint16[] memory exposures) private {
         for (uint256 i = 0; i < operators.length; i++) {
             _requestOperators[requestId].push(operators[i]);
             _requestExposures[requestId][operators[i]] = exposures[i];
@@ -243,7 +241,9 @@ abstract contract ServicesRequests is Base {
         uint64 requestId,
         address[] calldata operators,
         bytes calldata config
-    ) private {
+    )
+        private
+    {
         if (manager == address(0)) {
             return;
         }
@@ -277,7 +277,9 @@ abstract contract ServicesRequests is Base {
     function _storeSecurityRequirements(
         uint64 requestId,
         Types.AssetSecurityRequirement[] calldata requirements
-    ) private {
+    )
+        private
+    {
         for (uint256 i = 0; i < requirements.length; i++) {
             _requestSecurityRequirements[requestId].push(requirements[i]);
         }
@@ -286,17 +288,21 @@ abstract contract ServicesRequests is Base {
     function _storeDefaultTntRequirement(uint64 requestId) private {
         if (_tntToken == address(0)) return;
 
-        _requestSecurityRequirements[requestId].push(Types.AssetSecurityRequirement({
-            asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: _tntToken }),
-            minExposureBps: _defaultTntMinExposureBps,
-            maxExposureBps: BPS_DENOMINATOR
-        }));
+        _requestSecurityRequirements[requestId].push(
+            Types.AssetSecurityRequirement({
+                asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: _tntToken }),
+                minExposureBps: _defaultTntMinExposureBps,
+                maxExposureBps: BPS_DENOMINATOR
+            })
+        );
     }
 
     function _storeSecurityRequirementsWithDefaultTnt(
         uint64 requestId,
         Types.AssetSecurityRequirement[] calldata requirements
-    ) private {
+    )
+        private
+    {
         if (_tntToken == address(0)) {
             _storeSecurityRequirements(requestId, requirements);
             return;
@@ -317,18 +323,17 @@ abstract contract ServicesRequests is Base {
         }
     }
 
-    function _loadBlueprintRequestData(uint64 blueprintId)
-        private
-        view
-        returns (BlueprintRequestData memory data)
-    {
+    function _loadBlueprintRequestData(uint64 blueprintId) private view returns (BlueprintRequestData memory data) {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         if (!bp.active) revert Errors.BlueprintNotActive(blueprintId);
         data.manager = bp.manager;
         data.membership = bp.membership;
     }
 
-    function _computeRequestBounds(uint64 blueprintId, uint32 operatorCount)
+    function _computeRequestBounds(
+        uint64 blueprintId,
+        uint32 operatorCount
+    )
         private
         view
         returns (RequestBounds memory bounds)
@@ -347,7 +352,10 @@ abstract contract ServicesRequests is Base {
         uint256 paymentAmount,
         BlueprintRequestData memory blueprintData,
         RequestBounds memory bounds
-    ) private returns (uint64 requestId) {
+    )
+        private
+        returns (uint64 requestId)
+    {
         requestId = _serviceRequestCount++;
         _serviceRequests[requestId] = Types.ServiceRequest({
             blueprintId: blueprintId,

--- a/src/core/ServicesRequests.sol
+++ b/src/core/ServicesRequests.sol
@@ -59,6 +59,7 @@ abstract contract ServicesRequests is Base {
             blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount
         );
         _storeDefaultTntRequirement(requestId);
+        _storeDefaultResourceRequirements(requestId, blueprintId);
         return requestId;
     }
 
@@ -85,6 +86,7 @@ abstract contract ServicesRequests is Base {
             blueprintId, operators, exposures, config, permittedCallers, ttl, paymentToken, paymentAmount
         );
         _storeDefaultTntRequirement(requestId);
+        _storeDefaultResourceRequirements(requestId, blueprintId);
         return requestId;
     }
 
@@ -112,6 +114,7 @@ abstract contract ServicesRequests is Base {
         );
 
         _storeSecurityRequirementsWithDefaultTnt(requestId, securityRequirements);
+        _storeDefaultResourceRequirements(requestId, blueprintId);
         emit ServiceRequestedWithSecurity(requestId, blueprintId, msg.sender);
     }
 
@@ -371,6 +374,28 @@ abstract contract ServicesRequests is Base {
             maxOperators: bounds.maxOperators,
             rejected: false
         });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // SERVICE REQUESTS WITH RESOURCE REQUIREMENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Get resource requirements for a service request
+    function getServiceRequestResourceRequirements(uint64 requestId)
+        external
+        view
+        returns (Types.ResourceCommitment[] memory)
+    {
+        return _requestResourceRequirements[requestId];
+    }
+
+    /// @notice Copy blueprint default resource requirements to a request
+    function _storeDefaultResourceRequirements(uint64 requestId, uint64 blueprintId) internal {
+        Types.ResourceCommitment[] storage defaults = _blueprintResourceRequirements[blueprintId];
+        if (defaults.length == 0) return;
+        for (uint256 i = 0; i < defaults.length; i++) {
+            _requestResourceRequirements[requestId].push(defaults[i]);
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/exposure/ExposureCalculator.sol
+++ b/src/exposure/ExposureCalculator.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Types} from "../libraries/Types.sol";
-import {ExposureTypes} from "./ExposureTypes.sol";
-import {IPriceOracle} from "../oracles/interfaces/IPriceOracle.sol";
+import { Types } from "../libraries/Types.sol";
+import { ExposureTypes } from "./ExposureTypes.sol";
+import { IPriceOracle } from "../oracles/interfaces/IPriceOracle.sol";
 
 /// @title ExposureCalculator
 /// @notice Library for calculating operator exposure across multiple assets
@@ -20,7 +20,11 @@ library ExposureCalculator {
     function calculateExposedAmount(
         uint256 delegatedAmount,
         uint16 exposureBps
-    ) internal pure returns (uint256 exposedAmount) {
+    )
+        internal
+        pure
+        returns (uint256 exposedAmount)
+    {
         return (delegatedAmount * exposureBps) / ExposureTypes.BPS_DENOMINATOR;
     }
 
@@ -32,7 +36,11 @@ library ExposureCalculator {
     function calculateWeightedExposure(
         uint256[] memory delegations,
         uint16[] memory exposureBps
-    ) internal pure returns (uint16 weightedExposureBps) {
+    )
+        internal
+        pure
+        returns (uint16 weightedExposureBps)
+    {
         require(delegations.length == exposureBps.length, "Length mismatch");
 
         if (delegations.length == 0) return 0;
@@ -65,7 +73,11 @@ library ExposureCalculator {
         uint256[] memory delegations,
         uint16[] memory exposureBps,
         IPriceOracle oracle
-    ) internal view returns (uint16 weightedExposureBps, uint256 totalValueUsd) {
+    )
+        internal
+        view
+        returns (uint16 weightedExposureBps, uint256 totalValueUsd)
+    {
         require(tokens.length == delegations.length, "Length mismatch");
         require(delegations.length == exposureBps.length, "Length mismatch");
 
@@ -108,7 +120,11 @@ library ExposureCalculator {
         uint256 delegatedAmount,
         uint16 exposureBps,
         uint16 slashBps
-    ) internal pure returns (uint256 slashAmount) {
+    )
+        internal
+        pure
+        returns (uint256 slashAmount)
+    {
         uint256 exposedAmount = calculateExposedAmount(delegatedAmount, exposureBps);
         return (exposedAmount * slashBps) / ExposureTypes.BPS_DENOMINATOR;
     }
@@ -120,7 +136,11 @@ library ExposureCalculator {
     function calculateMaxSlashable(
         uint256 delegatedAmount,
         uint16 exposureBps
-    ) internal pure returns (uint256 maxSlashable) {
+    )
+        internal
+        pure
+        returns (uint256 maxSlashable)
+    {
         return calculateExposedAmount(delegatedAmount, exposureBps);
     }
 
@@ -140,7 +160,11 @@ library ExposureCalculator {
         uint16 exposureBps,
         uint256 totalReward,
         uint256 totalExposedValue
-    ) internal pure returns (uint256 rewardShare) {
+    )
+        internal
+        pure
+        returns (uint256 rewardShare)
+    {
         if (totalExposedValue == 0) return 0;
 
         uint256 exposedAmount = calculateExposedAmount(delegatedAmount, exposureBps);
@@ -154,7 +178,11 @@ library ExposureCalculator {
     function calculateTotalExposedValue(
         uint256[] memory delegations,
         uint16[] memory exposureBps
-    ) internal pure returns (uint256 totalExposed) {
+    )
+        internal
+        pure
+        returns (uint256 totalExposed)
+    {
         require(delegations.length == exposureBps.length, "Length mismatch");
 
         for (uint256 i = 0; i < delegations.length; i++) {
@@ -170,8 +198,7 @@ library ExposureCalculator {
     /// @param exposureBps Exposure to validate
     /// @return valid True if exposure is between MIN and MAX
     function isValidExposure(uint16 exposureBps) internal pure returns (bool valid) {
-        return exposureBps >= ExposureTypes.MIN_EXPOSURE_BPS &&
-               exposureBps <= ExposureTypes.MAX_EXPOSURE_BPS;
+        return exposureBps >= ExposureTypes.MIN_EXPOSURE_BPS && exposureBps <= ExposureTypes.MAX_EXPOSURE_BPS;
     }
 
     /// @notice Check if exposure is within specified bounds
@@ -179,11 +206,7 @@ library ExposureCalculator {
     /// @param minBps Minimum allowed exposure
     /// @param maxBps Maximum allowed exposure
     /// @return valid True if exposure is within bounds
-    function isWithinBounds(
-        uint16 exposureBps,
-        uint16 minBps,
-        uint16 maxBps
-    ) internal pure returns (bool valid) {
+    function isWithinBounds(uint16 exposureBps, uint16 minBps, uint16 maxBps) internal pure returns (bool valid) {
         return exposureBps >= minBps && exposureBps <= maxBps;
     }
 
@@ -217,7 +240,11 @@ library ExposureCalculator {
         uint256 delegatedAmount,
         uint16 exposureBps,
         uint64 serviceId
-    ) internal pure returns (ExposureTypes.CalculatedExposure memory exposure) {
+    )
+        internal
+        pure
+        returns (ExposureTypes.CalculatedExposure memory exposure)
+    {
         exposure.operator = operator;
         exposure.asset = asset;
         exposure.delegatedAmount = delegatedAmount;
@@ -235,7 +262,11 @@ library ExposureCalculator {
         ExposureTypes.CalculatedExposure[] memory exposures,
         address operator,
         uint64 serviceId
-    ) internal pure returns (ExposureTypes.AggregateExposure memory aggregate) {
+    )
+        internal
+        pure
+        returns (ExposureTypes.AggregateExposure memory aggregate)
+    {
         aggregate.operator = operator;
         aggregate.serviceId = serviceId;
         aggregate.perAsset = exposures;

--- a/src/exposure/ExposureTypes.sol
+++ b/src/exposure/ExposureTypes.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Types} from "../libraries/Types.sol";
+import { Types } from "../libraries/Types.sol";
 
 /// @title ExposureTypes
 /// @notice Type definitions for the exposure system
@@ -12,10 +12,10 @@ library ExposureTypes {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Basis points denominator (100% = 10000)
-    uint16 public constant BPS_DENOMINATOR = 10000;
+    uint16 public constant BPS_DENOMINATOR = 10_000;
 
     /// @notice Maximum exposure (100%)
-    uint16 public constant MAX_EXPOSURE_BPS = 10000;
+    uint16 public constant MAX_EXPOSURE_BPS = 10_000;
 
     /// @notice Minimum non-zero exposure (0.01%)
     uint16 public constant MIN_EXPOSURE_BPS = 1;
@@ -27,17 +27,17 @@ library ExposureTypes {
     /// @notice Operator's per-asset exposure limit
     /// @dev Operators can set maximum exposure % they're willing to commit per asset
     struct OperatorAssetExposureLimit {
-        Types.Asset asset;           // The asset
-        uint16 maxExposureBps;       // Maximum exposure operator will accept (0 = disabled)
-        uint16 defaultExposureBps;   // Default exposure if not specified (0 = use max)
-        bool enabled;                // Whether operator accepts this asset
+        Types.Asset asset; // The asset
+        uint16 maxExposureBps; // Maximum exposure operator will accept (0 = disabled)
+        uint16 defaultExposureBps; // Default exposure if not specified (0 = use max)
+        bool enabled; // Whether operator accepts this asset
     }
 
     /// @notice Full operator exposure configuration
     struct OperatorExposureConfig {
-        uint16 globalMaxExposureBps;     // Default max if no per-asset limit set
-        bool requireExplicitApproval;    // If true, operator must approve each asset
-        uint64 updatedAt;                // Last config update timestamp
+        uint16 globalMaxExposureBps; // Default max if no per-asset limit set
+        bool requireExplicitApproval; // If true, operator must approve each asset
+        uint64 updatedAt; // Last config update timestamp
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -48,18 +48,18 @@ library ExposureTypes {
     struct CalculatedExposure {
         address operator;
         Types.Asset asset;
-        uint256 delegatedAmount;      // Total delegated to operator for this asset
-        uint16 exposureBps;           // Committed exposure percentage
-        uint256 exposedAmount;        // delegatedAmount * exposureBps / 10000
-        uint64 serviceId;             // 0 if aggregate
+        uint256 delegatedAmount; // Total delegated to operator for this asset
+        uint16 exposureBps; // Committed exposure percentage
+        uint256 exposedAmount; // delegatedAmount * exposureBps / 10000
+        uint64 serviceId; // 0 if aggregate
     }
 
     /// @notice Aggregate exposure across multiple assets (for display/comparison)
     struct AggregateExposure {
         address operator;
         uint64 serviceId;
-        CalculatedExposure[] perAsset;  // Per-asset breakdown
-        uint256 totalExposedValue;       // Sum of all exposed amounts (in native units, not USD)
+        CalculatedExposure[] perAsset; // Per-asset breakdown
+        uint256 totalExposedValue; // Sum of all exposed amounts (in native units, not USD)
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -69,9 +69,9 @@ library ExposureTypes {
     /// @notice Result of validating a commitment
     struct CommitmentValidationResult {
         bool valid;
-        string reason;               // Empty if valid
-        Types.Asset asset;           // Asset that failed (if any)
-        uint256 requiredStake;       // Required delegation (if stake check failed)
-        uint256 actualStake;         // Actual delegation (if stake check failed)
+        string reason; // Empty if valid
+        Types.Asset asset; // Asset that failed (if any)
+        uint256 requiredStake; // Required delegation (if stake check failed)
+        uint256 actualStake; // Actual delegation (if stake check failed)
     }
 }

--- a/src/exposure/IExposureManager.sol
+++ b/src/exposure/IExposureManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Types} from "../libraries/Types.sol";
-import {ExposureTypes} from "./ExposureTypes.sol";
+import { Types } from "../libraries/Types.sol";
+import { ExposureTypes } from "./ExposureTypes.sol";
 
 /// @title IExposureManager
 /// @notice Interface for managing operator per-asset exposure limits
@@ -25,18 +25,12 @@ interface IExposureManager {
 
     /// @notice Emitted when operator sets per-asset exposure limit
     event AssetExposureLimitSet(
-        address indexed operator,
-        Types.Asset asset,
-        uint16 maxExposureBps,
-        uint16 defaultExposureBps,
-        bool enabled
+        address indexed operator, Types.Asset asset, uint16 maxExposureBps, uint16 defaultExposureBps, bool enabled
     );
 
     /// @notice Emitted when operator updates global config
     event OperatorExposureConfigUpdated(
-        address indexed operator,
-        uint16 globalMaxExposureBps,
-        bool requireExplicitApproval
+        address indexed operator, uint16 globalMaxExposureBps, bool requireExplicitApproval
     );
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -53,20 +47,16 @@ interface IExposureManager {
         uint16 maxExposureBps,
         uint16 defaultExposureBps,
         bool enabled
-    ) external;
+    )
+        external;
 
     /// @notice Batch set exposure limits for multiple assets
-    function batchSetAssetExposureLimits(
-        ExposureTypes.OperatorAssetExposureLimit[] calldata limits
-    ) external;
+    function batchSetAssetExposureLimits(ExposureTypes.OperatorAssetExposureLimit[] calldata limits) external;
 
     /// @notice Set global exposure configuration
     /// @param globalMaxExposureBps Default max for assets without explicit limit
     /// @param requireExplicitApproval If true, all assets must have explicit limits
-    function setOperatorExposureConfig(
-        uint16 globalMaxExposureBps,
-        bool requireExplicitApproval
-    ) external;
+    function setOperatorExposureConfig(uint16 globalMaxExposureBps, bool requireExplicitApproval) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VALIDATION
@@ -82,7 +72,10 @@ interface IExposureManager {
         address operator,
         Types.AssetSecurityRequirement[] calldata requirements,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external view returns (bool valid, ExposureTypes.CommitmentValidationResult memory result);
+    )
+        external
+        view
+        returns (bool valid, ExposureTypes.CommitmentValidationResult memory result);
 
     /// @notice Check if operator can accept a specific exposure for an asset
     /// @param operator The operator address
@@ -94,7 +87,10 @@ interface IExposureManager {
         address operator,
         Types.Asset calldata asset,
         uint16 exposureBps
-    ) external view returns (bool canAccept, uint16 effectiveLimit);
+    )
+        external
+        view
+        returns (bool canAccept, uint16 effectiveLimit);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EXPOSURE CALCULATION
@@ -110,7 +106,10 @@ interface IExposureManager {
         address operator,
         Types.Asset calldata asset,
         uint16 exposureBps
-    ) external view returns (uint256 delegatedAmount, uint256 exposedAmount);
+    )
+        external
+        view
+        returns (uint256 delegatedAmount, uint256 exposedAmount);
 
     /// @notice Get full exposure breakdown for an operator in a service
     /// @param operator The operator
@@ -119,7 +118,10 @@ interface IExposureManager {
     function getOperatorServiceExposure(
         address operator,
         uint64 serviceId
-    ) external view returns (ExposureTypes.AggregateExposure memory exposure);
+    )
+        external
+        view
+        returns (ExposureTypes.AggregateExposure memory exposure);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS
@@ -132,14 +134,18 @@ interface IExposureManager {
     function getAssetExposureLimit(
         address operator,
         Types.Asset calldata asset
-    ) external view returns (ExposureTypes.OperatorAssetExposureLimit memory limit);
+    )
+        external
+        view
+        returns (ExposureTypes.OperatorAssetExposureLimit memory limit);
 
     /// @notice Get operator's global exposure config
     /// @param operator The operator address
     /// @return config The exposure configuration
-    function getOperatorExposureConfig(
-        address operator
-    ) external view returns (ExposureTypes.OperatorExposureConfig memory config);
+    function getOperatorExposureConfig(address operator)
+        external
+        view
+        returns (ExposureTypes.OperatorExposureConfig memory config);
 
     /// @notice Get the effective exposure limit for an operator-asset pair
     /// @dev Returns per-asset limit if set, else global limit
@@ -150,5 +156,8 @@ interface IExposureManager {
     function getEffectiveExposureLimit(
         address operator,
         Types.Asset calldata asset
-    ) external view returns (uint16 effectiveLimit, bool isExplicit);
+    )
+        external
+        view
+        returns (uint16 effectiveLimit, bool isExplicit);
 }

--- a/src/extensions/BuybackBlueprintBase.sol
+++ b/src/extensions/BuybackBlueprintBase.sol
@@ -63,15 +63,15 @@ abstract contract BuybackBlueprintBase is TokenizedBlueprintBase {
     // ═══════════════════════════════════════════════════════════════════════════
 
     enum BuybackMode {
-        MANUAL,     // Buyback triggered manually
-        AUTO,       // Buyback on every payment
-        THRESHOLD   // Buyback when threshold reached
+        MANUAL, // Buyback triggered manually
+        AUTO, // Buyback on every payment
+        THRESHOLD // Buyback when threshold reached
     }
 
     enum TokenDestination {
-        BURN,       // Burn bought tokens
+        BURN, // Burn bought tokens
         DISTRIBUTE, // Add to staking rewards
-        TREASURY    // Send to treasury
+        TREASURY // Send to treasury
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -143,7 +143,9 @@ abstract contract BuybackBlueprintBase is TokenizedBlueprintBase {
         string memory symbol_,
         address _swapRouter,
         address _weth
-    ) TokenizedBlueprintBase(name_, symbol_) {
+    )
+        TokenizedBlueprintBase(name_, symbol_)
+    {
         swapRouter = ISwapRouter(_swapRouter);
         weth = IWETH(_weth);
     }
@@ -208,12 +210,12 @@ abstract contract BuybackBlueprintBase is TokenizedBlueprintBase {
         }
 
         // Wrap ETH to WETH
-        weth.deposit{value: ethAmount}();
+        weth.deposit{ value: ethAmount }();
         weth.approve(address(swapRouter), ethAmount);
 
         // Calculate minimum output with slippage protection
         uint256 expectedOut = _getExpectedOutput(ethAmount);
-        uint256 minOut = (expectedOut * (10000 - maxSlippageBps)) / 10000;
+        uint256 minOut = (expectedOut * (10_000 - maxSlippageBps)) / 10_000;
 
         // Execute swap: WETH -> Blueprint Token
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
@@ -275,11 +277,7 @@ abstract contract BuybackBlueprintBase is TokenizedBlueprintBase {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Configure buyback parameters
-    function _configureBuyback(
-        BuybackMode mode,
-        TokenDestination destination,
-        uint256 threshold
-    ) internal {
+    function _configureBuyback(BuybackMode mode, TokenDestination destination, uint256 threshold) internal {
         buybackMode = mode;
         tokenDestination = destination;
         buybackThreshold = threshold;
@@ -328,12 +326,11 @@ abstract contract BuybackBlueprintBase is TokenizedBlueprintBase {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Get buyback statistics
-    function buybackStats() external view returns (
-        uint256 pending,
-        uint256 totalSpent,
-        uint256 totalBought,
-        uint256 totalBurned
-    ) {
+    function buybackStats()
+        external
+        view
+        returns (uint256 pending, uint256 totalSpent, uint256 totalBought, uint256 totalBurned)
+    {
         return (pendingBuybackBalance, totalBuybackSpent, totalTokensBought, totalTokensBurned);
     }
 

--- a/src/extensions/TokenizedBlueprintBase.sol
+++ b/src/extensions/TokenizedBlueprintBase.sol
@@ -56,11 +56,11 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
     // ═══════════════════════════════════════════════════════════════════════════
 
     struct RewardState {
-        uint256 rewardPerTokenStored;      // Accumulated reward per staked token (scaled by 1e18)
-        uint256 lastUpdateTime;            // Last time reward was updated
-        uint256 rewardRate;                // Reward per second (for streaming mode)
-        uint256 periodFinish;              // When current reward period ends (for streaming)
-        uint256 pendingRewards;            // Undistributed rewards (for instant mode)
+        uint256 rewardPerTokenStored; // Accumulated reward per staked token (scaled by 1e18)
+        uint256 lastUpdateTime; // Last time reward was updated
+        uint256 rewardRate; // Reward per second (for streaming mode)
+        uint256 periodFinish; // When current reward period ends (for streaming)
+        uint256 pendingRewards; // Undistributed rewards (for instant mode)
     }
 
     /// @notice Reward state per token (address(0) = native ETH)
@@ -100,10 +100,7 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
     // CONSTRUCTOR
     // ═══════════════════════════════════════════════════════════════════════════
 
-    constructor(
-        string memory name_,
-        string memory symbol_
-    ) ERC20(name_, symbol_) {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
         // Native ETH is always a reward token
         _addRewardToken(address(0));
     }
@@ -114,13 +111,7 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
 
     /// @notice Direct all developer revenue to this contract
     /// @dev Override from BlueprintServiceManagerBase
-    function queryDeveloperPaymentAddress(uint64)
-        external
-        view
-        virtual
-        override
-        returns (address payable)
-    {
+    function queryDeveloperPaymentAddress(uint64) external view virtual override returns (address payable) {
         return payable(address(this));
     }
 
@@ -332,7 +323,7 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
 
     function _transferReward(address to, address token, uint256 amount) internal {
         if (token == address(0)) {
-            (bool success,) = to.call{value: amount}("");
+            (bool success,) = to.call{ value: amount }("");
             require(success, "ETH transfer failed");
         } else {
             IERC20(token).safeTransfer(to, amount);
@@ -381,7 +372,7 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
         if (streamingMode && state.rewardRate > 0) {
             // Annual reward / total staked * 10000 (for basis points)
             uint256 annualReward = state.rewardRate * 365 days;
-            apy = (annualReward * 10000) / totalStaked;
+            apy = (annualReward * 10_000) / totalStaked;
         }
         // For instant mode, APY depends on revenue frequency
     }

--- a/src/facets/staking/StakingAssetsFacet.sol
+++ b/src/facets/staking/StakingAssetsFacet.sol
@@ -96,10 +96,7 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
         require(adapter != address(0), "Invalid adapter");
 
         // Verify adapter supports the token
-        require(
-            IAssetAdapter(adapter).supportsAsset(token),
-            "Adapter doesn't support token"
-        );
+        require(IAssetAdapter(adapter).supportsAsset(token), "Adapter doesn't support token");
 
         _assetAdapters[token] = adapter;
         emit AdapterRegistered(token, adapter);
@@ -134,13 +131,13 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
         uint256 _minDelegation,
         uint256 _depositCap,
         uint16 _rewardMultiplierBps
-    ) external onlyRole(ASSET_MANAGER_ROLE) {
+    )
+        external
+        onlyRole(ASSET_MANAGER_ROLE)
+    {
         require(token != address(0), "Use native");
         require(adapter != address(0), "Invalid adapter");
-        require(
-            IAssetAdapter(adapter).supportsAsset(token),
-            "Adapter doesn't support token"
-        );
+        require(IAssetAdapter(adapter).supportsAsset(token), "Adapter doesn't support token");
 
         // Register adapter
         _assetAdapters[token] = adapter;
@@ -177,10 +174,7 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
 
         // Verify new adapter supports the token (if not removing)
         if (newAdapter != address(0)) {
-            require(
-                IAssetAdapter(newAdapter).supportsAsset(token),
-                "Adapter doesn't support token"
-            );
+            require(IAssetAdapter(newAdapter).supportsAsset(token), "Adapter doesn't support token");
         }
 
         _adapterMigrationInProgress[token] = true;
@@ -232,7 +226,11 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
     /// @param token The token address
     /// @return inProgress True if migration is in progress
     /// @return pendingAdapter The pending adapter address
-    function isAdapterMigrationInProgress(address token) external view returns (bool inProgress, address pendingAdapter) {
+    function isAdapterMigrationInProgress(address token)
+        external
+        view
+        returns (bool inProgress, address pendingAdapter)
+    {
         return (_adapterMigrationInProgress[token], _pendingAdapter[token]);
     }
 }

--- a/src/facets/staking/StakingDelegationsFacet.sol
+++ b/src/facets/staking/StakingDelegationsFacet.sol
@@ -123,7 +123,10 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         uint256 shares,
         uint64 requestedRound,
         address receiver
-    ) private returns (uint256 amountReturned) {
+    )
+        private
+        returns (uint256 amountReturned)
+    {
         if (receiver == address(0)) revert DelegationErrors.ZeroAddress();
         if (shares == 0) revert DelegationErrors.ZeroAmount();
 
@@ -138,10 +141,8 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         for (uint256 i = 0; i < requests.length; i++) {
             Types.BondLessRequest storage candidate = requests[i];
             if (
-                candidate.operator == operator &&
-                _assetHash(candidate.asset) == assetHash &&
-                candidate.shares == shares &&
-                candidate.requestedRound == requestedRound
+                candidate.operator == operator && _assetHash(candidate.asset) == assetHash && candidate.shares == shares
+                    && candidate.requestedRound == requestedRound
             ) {
                 requestIndex = i;
                 break;
@@ -179,7 +180,9 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         uint256 free = dep2.amount > locked ? dep2.amount - locked : 0;
 
         if (free < amountReturned) revert DelegationErrors.AmountLocked(locked, amountReturned);
-        if (available < amountReturned) revert DelegationErrors.InsufficientAvailableBalance(available, amountReturned);
+        if (available < amountReturned) {
+            revert DelegationErrors.InsufficientAvailableBalance(available, amountReturned);
+        }
 
         dep2.amount -= amountReturned;
         // Update deposit cap accounting on actual transfer (TVL decreases here).
@@ -198,7 +201,10 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         address operator,
         bytes32 assetHash,
         Types.BondLessRequest storage req
-    ) private returns (uint256 amountReturned) {
+    )
+        private
+        returns (uint256 amountReturned)
+    {
         bool updated = false;
         Types.BondInfoDelegator[] storage delegations = _delegations[delegator];
         for (uint256 j = 0; j < delegations.length; j++) {
@@ -226,9 +232,7 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
                             ? remainingShares
                             : (req.shares * currentBpShares) / totalBpShares;
                     } else {
-                        bpShare = k == blueprintIds.length - 1
-                            ? remainingShares
-                            : req.shares / blueprintIds.length;
+                        bpShare = k == blueprintIds.length - 1 ? remainingShares : req.shares / blueprintIds.length;
                     }
                     remainingShares = remainingShares > bpShare ? remainingShares - bpShare : 0;
                     blueprintShares[k] = bpShare;
@@ -285,7 +289,9 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         Types.BlueprintSelectionMode selectionMode,
         uint64[] memory blueprintIds,
         uint256[] memory blueprintShares
-    ) private {
+    )
+        private
+    {
         _onDelegationChanged(
             delegator,
             operator,

--- a/src/facets/staking/StakingViewsFacet.sol
+++ b/src/facets/staking/StakingViewsFacet.sol
@@ -65,15 +65,16 @@ contract StakingViewsFacet is StakingFacetBase, IFacetSelectors {
     function getOperatorDelegatedStakeForAsset(
         address operator,
         Types.Asset calldata asset
-    ) external view returns (uint256) {
+    )
+        external
+        view
+        returns (uint256)
+    {
         bytes32 assetHash = _assetHash(asset);
         return _getOperatorDelegatedStakeForAsset(operator, assetHash);
     }
 
-    function getOperatorStakeForAsset(
-        address operator,
-        Types.Asset calldata asset
-    ) external view returns (uint256) {
+    function getOperatorStakeForAsset(address operator, Types.Asset calldata asset) external view returns (uint256) {
         bytes32 assetHash = _assetHash(asset);
         uint256 delegated = _getOperatorDelegatedStakeForAsset(operator, assetHash);
         if (asset.kind == Types.AssetKind.Native && _operatorBondToken == address(0)) {
@@ -89,7 +90,11 @@ contract StakingViewsFacet is StakingFacetBase, IFacetSelectors {
         address operator,
         address token,
         uint256 amount
-    ) external view returns (uint256 shares) {
+    )
+        external
+        view
+        returns (uint256 shares)
+    {
         if (amount == 0) revert DelegationErrors.ZeroAmount();
         Types.Asset memory asset = token == address(0)
             ? Types.Asset(Types.AssetKind.Native, address(0))

--- a/src/facets/tangle/TangleBlueprintsManagementFacet.sol
+++ b/src/facets/tangle/TangleBlueprintsManagementFacet.sol
@@ -8,12 +8,14 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 /// @notice Facet for blueprint metadata and ownership
 contract TangleBlueprintsManagementFacet is BlueprintsManage, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](6);
+        selectorList = new bytes4[](8);
         selectorList[0] = this.getBlueprintDefinition.selector;
         selectorList[1] = this.updateBlueprint.selector;
         selectorList[2] = this.transferBlueprint.selector;
         selectorList[3] = this.deactivateBlueprint.selector;
         selectorList[4] = this.setJobEventRates.selector;
         selectorList[5] = this.getJobEventRate.selector;
+        selectorList[6] = bytes4(keccak256("setBlueprintResourceRequirements(uint64,(uint8,uint64)[])"));
+        selectorList[7] = bytes4(keccak256("getBlueprintResourceRequirements(uint64)"));
     }
 }

--- a/src/facets/tangle/TanglePaymentsFacet.sol
+++ b/src/facets/tangle/TanglePaymentsFacet.sol
@@ -40,7 +40,9 @@ contract TanglePaymentsFacet is Payments, IFacetSelectors {
         address token,
         uint256 amount,
         address[] calldata operators
-    ) external {
+    )
+        external
+    {
         if (msg.sender != address(this)) revert Errors.Unauthorized();
 
         // Compute effective exposures (with fallback to stored exposureBps)

--- a/src/facets/tangle/TangleQuotesExtensionFacet.sol
+++ b/src/facets/tangle/TangleQuotesExtensionFacet.sol
@@ -10,7 +10,11 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 contract TangleQuotesExtensionFacet is QuotesExtend, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
         selectorList = new bytes4[](1);
-        selectorList[0] = bytes4(keccak256("extendServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[]),bytes,address)[],uint64)"));
+        selectorList[0] = bytes4(
+            keccak256(
+                "extendServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],uint64)"
+            )
+        );
     }
 
     /// @notice Distribute extension payment as streaming (called from Quotes mixin)
@@ -22,19 +26,17 @@ contract TangleQuotesExtensionFacet is QuotesExtend, IFacetSelectors {
         address[] memory operators,
         uint64 startTime,
         uint64 endTime
-    ) internal override {
+    )
+        internal
+        override
+    {
         if (amount == 0) return;
 
-        // Payments currently distribute "immediate" amounts; streaming is handled by ServiceFeeDistributor/StreamingPaymentManager.
+        // Payments currently distribute "immediate" amounts; streaming is handled by
+        // ServiceFeeDistributor/StreamingPaymentManager.
         startTime;
         endTime;
 
-        ITanglePaymentsInternal(address(this)).distributePayment(
-            serviceId,
-            blueprintId,
-            address(0),
-            amount,
-            operators
-        );
+        ITanglePaymentsInternal(address(this)).distributePayment(serviceId, blueprintId, address(0), amount, operators);
     }
 }

--- a/src/facets/tangle/TangleQuotesFacet.sol
+++ b/src/facets/tangle/TangleQuotesFacet.sol
@@ -9,8 +9,13 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 /// @notice Facet for RFQ-based service creation
 contract TangleQuotesFacet is QuotesCreate, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](1);
-        selectorList[0] = bytes4(keccak256("createServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[]),bytes,address)[],bytes,address[],uint64)"));
+        selectorList = new bytes4[](2);
+        selectorList[0] = bytes4(
+            keccak256(
+                "createServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],bytes,address[],uint64)"
+            )
+        );
+        selectorList[1] = bytes4(keccak256("getServiceResourceCommitmentHash(uint64,address)"));
     }
 
     /// @notice Distribute quote payment (called from Quotes mixin)
@@ -20,13 +25,10 @@ contract TangleQuotesFacet is QuotesCreate, IFacetSelectors {
         uint64 blueprintId,
         uint256 amount,
         address[] memory operators
-    ) internal override {
-        ITanglePaymentsInternal(address(this)).distributePayment(
-            serviceId,
-            blueprintId,
-            address(0),
-            amount,
-            operators
-        );
+    )
+        internal
+        override
+    {
+        ITanglePaymentsInternal(address(this)).distributePayment(serviceId, blueprintId, address(0), amount, operators);
     }
 }

--- a/src/facets/tangle/TangleServicesRequestsFacet.sol
+++ b/src/facets/tangle/TangleServicesRequestsFacet.sol
@@ -14,7 +14,13 @@ contract TangleServicesRequestsFacet is ServicesRequests, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
         selectorList = new bytes4[](3);
         selectorList[0] = bytes4(keccak256("requestService(uint64,address[],bytes,address[],uint64,address,uint256)"));
-        selectorList[1] = bytes4(keccak256("requestServiceWithExposure(uint64,address[],uint16[],bytes,address[],uint64,address,uint256)"));
-        selectorList[2] = bytes4(keccak256("requestServiceWithSecurity(uint64,address[],((uint8,address),uint16,uint16)[],bytes,address[],uint64,address,uint256)"));
+        selectorList[1] = bytes4(
+            keccak256("requestServiceWithExposure(uint64,address[],uint16[],bytes,address[],uint64,address,uint256)")
+        );
+        selectorList[2] = bytes4(
+            keccak256(
+                "requestServiceWithSecurity(uint64,address[],((uint8,address),uint16,uint16)[],bytes,address[],uint64,address,uint256)"
+            )
+        );
     }
 }

--- a/src/facets/tangle/TangleServicesRequestsFacet.sol
+++ b/src/facets/tangle/TangleServicesRequestsFacet.sol
@@ -12,7 +12,7 @@ contract TangleServicesRequestsFacet is ServicesRequests, IFacetSelectors {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](3);
+        selectorList = new bytes4[](4);
         selectorList[0] = bytes4(keccak256("requestService(uint64,address[],bytes,address[],uint64,address,uint256)"));
         selectorList[1] = bytes4(
             keccak256("requestServiceWithExposure(uint64,address[],uint16[],bytes,address[],uint64,address,uint256)")
@@ -22,5 +22,6 @@ contract TangleServicesRequestsFacet is ServicesRequests, IFacetSelectors {
                 "requestServiceWithSecurity(uint64,address[],((uint8,address),uint16,uint16)[],bytes,address[],uint64,address,uint256)"
             )
         );
+        selectorList[3] = bytes4(keccak256("getServiceRequestResourceRequirements(uint64)"));
     }
 }

--- a/src/governance/GovernanceDeployer.sol
+++ b/src/governance/GovernanceDeployer.sol
@@ -49,7 +49,7 @@ contract GovernanceDeployer {
         // Token params
         address tokenAdmin;
         uint256 initialTokenSupply;
-        address existingToken;   // optional override to skip new TNT deployment
+        address existingToken; // optional override to skip new TNT deployment
         // Timelock params
         uint256 timelockDelay;
         // Governor params

--- a/src/governance/TangleGovernor.sol
+++ b/src/governance/TangleGovernor.sol
@@ -3,12 +3,24 @@ pragma solidity ^0.8.26;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { GovernorUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
-import { GovernorSettingsUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
-import { GovernorCountingSimpleUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
-import { GovernorVotesUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
-import { GovernorVotesQuorumFractionUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesQuorumFractionUpgradeable.sol";
-import { GovernorTimelockControlUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorTimelockControlUpgradeable.sol";
-import { TimelockControllerUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
+import {
+    GovernorSettingsUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
+import {
+    GovernorCountingSimpleUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorCountingSimpleUpgradeable.sol";
+import {
+    GovernorVotesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
+import {
+    GovernorVotesQuorumFractionUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesQuorumFractionUpgradeable.sol";
+import {
+    GovernorTimelockControlUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorTimelockControlUpgradeable.sol";
+import {
+    TimelockControllerUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import { Errors } from "../libraries/Errors.sol";
@@ -73,7 +85,10 @@ contract TangleGovernor is
         uint32 initialVotingPeriod,
         uint256 initialProposalThreshold,
         uint256 quorumPercent
-    ) public initializer {
+    )
+        public
+        initializer
+    {
         __Governor_init("TangleGovernor");
         __GovernorSettings_init(initialVotingDelay, initialVotingPeriod, initialProposalThreshold);
         __GovernorCountingSimple_init();
@@ -87,21 +102,11 @@ contract TangleGovernor is
     // REQUIRED OVERRIDES
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function votingDelay()
-        public
-        view
-        override(GovernorUpgradeable, GovernorSettingsUpgradeable)
-        returns (uint256)
-    {
+    function votingDelay() public view override(GovernorUpgradeable, GovernorSettingsUpgradeable) returns (uint256) {
         return super.votingDelay();
     }
 
-    function votingPeriod()
-        public
-        view
-        override(GovernorUpgradeable, GovernorSettingsUpgradeable)
-        returns (uint256)
-    {
+    function votingPeriod() public view override(GovernorUpgradeable, GovernorSettingsUpgradeable) returns (uint256) {
         return super.votingPeriod();
     }
 
@@ -155,7 +160,11 @@ contract TangleGovernor is
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) public override returns (uint256) {
+    )
+        public
+        override
+        returns (uint256)
+    {
         // M-14 FIX: Validate proposal action count
         if (targets.length == 0) revert Errors.InvalidState();
         if (targets.length > MAX_PROPOSAL_ACTIONS) revert Errors.InvalidState();
@@ -195,7 +204,10 @@ contract TangleGovernor is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal override(GovernorUpgradeable, GovernorTimelockControlUpgradeable) {
+    )
+        internal
+        override(GovernorUpgradeable, GovernorTimelockControlUpgradeable)
+    {
         // M-16 FIX: OpenZeppelin's GovernorTimelockControlUpgradeable already validates:
         // - Proposal must be in executable state
         // - Timelock operation must exist and be ready

--- a/src/governance/TangleTimelock.sol
+++ b/src/governance/TangleTimelock.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import { TimelockControllerUpgradeable } from "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
+import {
+    TimelockControllerUpgradeable
+} from "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -53,7 +55,11 @@ contract TangleTimelock is Initializable, TimelockControllerUpgradeable, UUPSUpg
         address[] memory proposers,
         address[] memory executors,
         address admin
-    ) public override initializer {
+    )
+        public
+        override
+        initializer
+    {
         // M-16 FIX: Use custom errors for gas efficiency
         if (minDelay < MIN_DELAY) revert DelayTooShort(minDelay, MIN_DELAY);
         if (minDelay > MAX_DELAY) revert DelayTooLong(minDelay, MAX_DELAY);

--- a/src/governance/TangleToken.sol
+++ b/src/governance/TangleToken.sol
@@ -2,9 +2,15 @@
 pragma solidity ^0.8.26;
 
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
-import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
-import { ERC20VotesUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {
+    ERC20BurnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import {
+    ERC20PermitUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import {
+    ERC20VotesUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 import { NoncesUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -122,19 +128,18 @@ contract TangleToken is
     // REQUIRED OVERRIDES
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function _update(address from, address to, uint256 value)
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    )
         internal
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
     {
         super._update(from, to, value);
     }
 
-    function nonces(address owner)
-        public
-        view
-        override(ERC20PermitUpgradeable, NoncesUpgradeable)
-        returns (uint256)
-    {
+    function nonces(address owner) public view override(ERC20PermitUpgradeable, NoncesUpgradeable) returns (uint256) {
         return super.nonces(owner);
     }
 

--- a/src/governance/lockups/TNTCliffLock.sol
+++ b/src/governance/lockups/TNTCliffLock.sol
@@ -16,7 +16,9 @@ contract TNTCliffLock {
     error NotUnlocked(uint64 unlockTimestamp, uint64 nowTimestamp);
     error ZeroAddress();
 
-    event Initialized(address indexed token, address indexed beneficiary, uint64 unlockTimestamp, address indexed delegatee);
+    event Initialized(
+        address indexed token, address indexed beneficiary, uint64 unlockTimestamp, address indexed delegatee
+    );
     event Withdrawn(address indexed token, address indexed beneficiary, address indexed to, uint256 amount);
     event Delegated(address indexed token, address indexed beneficiary, address indexed delegatee);
 

--- a/src/governance/lockups/TNTLockFactory.sol
+++ b/src/governance/lockups/TNTLockFactory.sol
@@ -10,13 +10,23 @@ contract TNTLockFactory {
     // forge-lint: disable-next-line(screaming-snake-case-immutable)
     address public immutable implementation;
 
-    event LockCreated(address indexed token, address indexed beneficiary, address lock, uint64 unlockTimestamp, address delegatee);
+    event LockCreated(
+        address indexed token, address indexed beneficiary, address lock, uint64 unlockTimestamp, address delegatee
+    );
 
     constructor() {
         implementation = address(new TNTCliffLock());
     }
 
-    function predictLockAddress(address token, address beneficiary, uint64 unlockTimestamp) public view returns (address) {
+    function predictLockAddress(
+        address token,
+        address beneficiary,
+        uint64 unlockTimestamp
+    )
+        public
+        view
+        returns (address)
+    {
         bytes32 salt = keccak256(abi.encode(token, beneficiary, unlockTimestamp));
         return Clones.predictDeterministicAddress(implementation, salt, address(this));
     }
@@ -26,7 +36,10 @@ contract TNTLockFactory {
         address beneficiary,
         uint64 unlockTimestamp,
         address delegatee
-    ) external returns (address lock) {
+    )
+        external
+        returns (address lock)
+    {
         bytes32 salt = keccak256(abi.encode(token, beneficiary, unlockTimestamp));
         lock = Clones.predictDeterministicAddress(implementation, salt, address(this));
         if (lock.code.length == 0) {

--- a/src/interfaces/IBlueprintHook.sol
+++ b/src/interfaces/IBlueprintHook.sol
@@ -27,7 +27,9 @@ interface IBlueprintHook {
         uint64 blueprintId,
         address operator,
         bytes calldata data
-    ) external returns (bool accept);
+    )
+        external
+        returns (bool accept);
 
     /// @notice Called when an operator unregisters
     function onOperatorUnregister(uint64 blueprintId, address operator) external;
@@ -44,7 +46,10 @@ interface IBlueprintHook {
         address requester,
         address[] calldata operators,
         bytes calldata config
-    ) external payable returns (bool accept);
+    )
+        external
+        payable
+        returns (bool accept);
 
     /// @notice Called when an operator approves a service request
     function onServiceApprove(uint64 requestId, address operator, uint8 stakingPercent) external;
@@ -58,7 +63,8 @@ interface IBlueprintHook {
         uint64 requestId,
         address owner,
         address[] calldata operators
-    ) external;
+    )
+        external;
 
     /// @notice Called when service is terminated
     function onServiceTerminated(uint64 serviceId, address owner) external;
@@ -81,7 +87,10 @@ interface IBlueprintHook {
         uint8 jobIndex,
         address caller,
         bytes calldata inputs
-    ) external payable returns (bool accept);
+    )
+        external
+        payable
+        returns (bool accept);
 
     /// @notice Called when an operator submits a result
     /// @return accept True to accept result
@@ -90,7 +99,9 @@ interface IBlueprintHook {
         uint64 callId,
         address operator,
         bytes calldata result
-    ) external returns (bool accept);
+    )
+        external
+        returns (bool accept);
 
     /// @notice Called when a job is marked complete
     function onJobCompleted(uint64 serviceId, uint64 callId, uint32 resultCount) external;
@@ -106,7 +117,9 @@ interface IBlueprintHook {
         address operator,
         uint256 amount,
         bytes32 evidence
-    ) external returns (bool approve);
+    )
+        external
+        returns (bool approve);
 
     /// @notice Called after a slash is applied
     function onSlashApplied(uint64 serviceId, address operator, uint256 amount) external;
@@ -134,33 +147,37 @@ interface IBlueprintHook {
     /// @notice Get the aggregation threshold configuration for a job
     /// @return thresholdBps Threshold in basis points (6700 = 67%)
     /// @return thresholdType 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake)
-    function getAggregationThreshold(uint64 serviceId, uint8 jobIndex)
+    function getAggregationThreshold(
+        uint64 serviceId,
+        uint8 jobIndex
+    )
         external
         view
         returns (uint16 thresholdBps, uint8 thresholdType);
 
     /// @notice Called when an aggregated result is submitted
-    function onAggregatedResult(
-        uint64 serviceId,
-        uint64 callId,
-        uint256 signerBitmap,
-        bytes calldata output
-    ) external;
+    function onAggregatedResult(uint64 serviceId, uint64 callId, uint256 signerBitmap, bytes calldata output) external;
 }
 
 /// @title BlueprintHookBase
 /// @notice Base implementation with sensible defaults
 /// @dev For full features, extend BlueprintServiceManagerBase instead
 abstract contract BlueprintHookBase is IBlueprintHook {
-    function onBlueprintCreated(uint64, address) external virtual {}
+    function onBlueprintCreated(uint64, address) external virtual { }
 
     function onOperatorRegister(uint64, address, bytes calldata) external virtual returns (bool) {
         return true;
     }
 
-    function onOperatorUnregister(uint64, address) external virtual {}
+    function onOperatorUnregister(uint64, address) external virtual { }
 
-    function onServiceRequest(uint64, uint64, address, address[] calldata, bytes calldata)
+    function onServiceRequest(
+        uint64,
+        uint64,
+        address,
+        address[] calldata,
+        bytes calldata
+    )
         external
         payable
         virtual
@@ -169,13 +186,13 @@ abstract contract BlueprintHookBase is IBlueprintHook {
         return true;
     }
 
-    function onServiceApprove(uint64, address, uint8) external virtual {}
+    function onServiceApprove(uint64, address, uint8) external virtual { }
 
-    function onServiceReject(uint64, address) external virtual {}
+    function onServiceReject(uint64, address) external virtual { }
 
-    function onServiceActivated(uint64, uint64, address, address[] calldata) external virtual {}
+    function onServiceActivated(uint64, uint64, address, address[] calldata) external virtual { }
 
-    function onServiceTerminated(uint64, address) external virtual {}
+    function onServiceTerminated(uint64, address) external virtual { }
 
     function canJoin(uint64, address, uint16) external view virtual returns (bool) {
         return true;
@@ -185,12 +202,7 @@ abstract contract BlueprintHookBase is IBlueprintHook {
         return true;
     }
 
-    function onJobSubmitted(uint64, uint64, uint8, address, bytes calldata)
-        external
-        payable
-        virtual
-        returns (bool)
-    {
+    function onJobSubmitted(uint64, uint64, uint8, address, bytes calldata) external payable virtual returns (bool) {
         return true;
     }
 
@@ -198,13 +210,13 @@ abstract contract BlueprintHookBase is IBlueprintHook {
         return true;
     }
 
-    function onJobCompleted(uint64, uint64, uint32) external virtual {}
+    function onJobCompleted(uint64, uint64, uint32) external virtual { }
 
     function onSlashProposed(uint64, address, uint256, bytes32) external virtual returns (bool) {
         return true;
     }
 
-    function onSlashApplied(uint64, address, uint256) external virtual {}
+    function onSlashApplied(uint64, address, uint256) external virtual { }
 
     function getDeveloperPaymentAddress(uint64) external view virtual returns (address payable) {
         return payable(address(0));
@@ -227,5 +239,5 @@ abstract contract BlueprintHookBase is IBlueprintHook {
         return (6700, 0); // 67% count-based by default
     }
 
-    function onAggregatedResult(uint64, uint64, uint256, bytes calldata) external virtual {}
+    function onAggregatedResult(uint64, uint64, uint256, bytes calldata) external virtual { }
 }

--- a/src/interfaces/IBlueprintServiceManager.sol
+++ b/src/interfaces/IBlueprintServiceManager.sol
@@ -79,12 +79,10 @@ interface IBlueprintServiceManager {
     /// @return minCommitmentDuration Minimum time operator must stay after joining (seconds)
     /// @return exitQueueDuration Time between scheduling exit and completing it (seconds)
     /// @return forceExitAllowed Whether service owner can force-exit operators
-    function getExitConfig(uint64 serviceId) external view returns (
-        bool useDefault,
-        uint64 minCommitmentDuration,
-        uint64 exitQueueDuration,
-        bool forceExitAllowed
-    );
+    function getExitConfig(uint64 serviceId)
+        external
+        view
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE LIFECYCLE
@@ -107,7 +105,9 @@ interface IBlueprintServiceManager {
         uint64 ttl,
         address paymentAsset,
         uint256 paymentAmount
-    ) external payable;
+    )
+        external
+        payable;
 
     /// @notice Called when an operator approves a service request
     /// @param operator The approving operator
@@ -134,7 +134,8 @@ interface IBlueprintServiceManager {
         address owner,
         address[] calldata permittedCallers,
         uint64 ttl
-    ) external;
+    )
+        external;
 
     /// @notice Called when service is terminated
     /// @param serviceId The service ID
@@ -210,7 +211,9 @@ interface IBlueprintServiceManager {
         address operator,
         bytes calldata inputs,
         bytes calldata outputs
-    ) external payable;
+    )
+        external
+        payable;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SLASHING
@@ -293,7 +296,10 @@ interface IBlueprintServiceManager {
     /// @param jobIndex The job index
     /// @return thresholdBps Threshold in basis points (6700 = 67%)
     /// @return thresholdType 0 = CountBased (% of operators), 1 = StakeWeighted (% of total stake)
-    function getAggregationThreshold(uint64 serviceId, uint8 jobIndex)
+    function getAggregationThreshold(
+        uint64 serviceId,
+        uint8 jobIndex
+    )
         external
         view
         returns (uint16 thresholdBps, uint8 thresholdType);
@@ -315,7 +321,8 @@ interface IBlueprintServiceManager {
         uint256 signerBitmap,
         uint256[2] calldata aggregatedSignature,
         uint256[4] calldata aggregatedPubkey
-    ) external;
+    )
+        external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // STAKE REQUIREMENTS

--- a/src/interfaces/IERC7540.sol
+++ b/src/interfaces/IERC7540.sol
@@ -9,11 +9,7 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 interface IERC7540Deposit {
     /// @notice Emitted when a deposit request is created
     event DepositRequest(
-        address indexed controller,
-        address indexed owner,
-        uint256 indexed requestId,
-        address sender,
-        uint256 assets
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
     );
 
     /// @notice Request an asynchronous deposit
@@ -21,29 +17,19 @@ interface IERC7540Deposit {
     /// @param controller Address that controls the request
     /// @param owner Address that owns the assets
     /// @return requestId Unique identifier for this request
-    function requestDeposit(
-        uint256 assets,
-        address controller,
-        address owner
-    ) external returns (uint256 requestId);
+    function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256 requestId);
 
     /// @notice Get pending deposit request amount
     /// @param requestId The request identifier
     /// @param controller The controller address
     /// @return assets Amount of assets pending
-    function pendingDepositRequest(
-        uint256 requestId,
-        address controller
-    ) external view returns (uint256 assets);
+    function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
 
     /// @notice Get claimable deposit request amount
     /// @param requestId The request identifier
     /// @param controller The controller address
     /// @return assets Amount of assets claimable
-    function claimableDepositRequest(
-        uint256 requestId,
-        address controller
-    ) external view returns (uint256 assets);
+    function claimableDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
 }
 
 /// @title IERC7540Redeem
@@ -52,11 +38,7 @@ interface IERC7540Deposit {
 interface IERC7540Redeem {
     /// @notice Emitted when a redeem request is created
     event RedeemRequest(
-        address indexed controller,
-        address indexed owner,
-        uint256 indexed requestId,
-        address sender,
-        uint256 shares
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
     );
 
     /// @notice Request an asynchronous redemption
@@ -64,61 +46,41 @@ interface IERC7540Redeem {
     /// @param controller Address that controls the request
     /// @param owner Address that owns the shares
     /// @return requestId Unique identifier for this request
-    function requestRedeem(
-        uint256 shares,
-        address controller,
-        address owner
-    ) external returns (uint256 requestId);
+    function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId);
 
     /// @notice Get pending redeem request amount
     /// @param requestId The request identifier
     /// @param controller The controller address
     /// @return shares Amount of shares pending
-    function pendingRedeemRequest(
-        uint256 requestId,
-        address controller
-    ) external view returns (uint256 shares);
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
 
     /// @notice Get claimable redeem request amount
     /// @param requestId The request identifier
     /// @param controller The controller address
     /// @return shares Amount of shares claimable
-    function claimableRedeemRequest(
-        uint256 requestId,
-        address controller
-    ) external view returns (uint256 shares);
+    function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
 }
 
 /// @title IERC7540Operator
 /// @notice Interface for operator management in ERC7540
 interface IERC7540Operator {
     /// @notice Emitted when operator approval changes
-    event OperatorSet(
-        address indexed controller,
-        address indexed operator,
-        bool approved
-    );
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
 
     /// @notice Check if operator is approved for controller
     /// @param controller The controller address
     /// @param operator The operator address
     /// @return status True if approved
-    function isOperator(
-        address controller,
-        address operator
-    ) external view returns (bool status);
+    function isOperator(address controller, address operator) external view returns (bool status);
 
     /// @notice Grant or revoke operator permissions
     /// @param operator The operator address
     /// @param approved True to approve, false to revoke
     /// @return success True if successful
-    function setOperator(
-        address operator,
-        bool approved
-    ) external returns (bool success);
+    function setOperator(address operator, bool approved) external returns (bool success);
 }
 
 /// @title IERC7540
 /// @notice Full ERC7540 interface combining deposit, redeem, and operator management
 /// @dev Extends ERC4626 with asynchronous request patterns
-interface IERC7540 is IERC4626, IERC7540Deposit, IERC7540Redeem, IERC7540Operator {}
+interface IERC7540 is IERC4626, IERC7540Deposit, IERC7540Redeem, IERC7540Operator { }

--- a/src/interfaces/IMasterBlueprintServiceManager.sol
+++ b/src/interfaces/IMasterBlueprintServiceManager.sol
@@ -8,9 +8,5 @@ interface IMasterBlueprintServiceManager {
     /// @param blueprintId The newly assigned blueprint ID
     /// @param owner The blueprint owner
     /// @param encodedDefinition ABI-encoded blueprint definition data
-    function onBlueprintCreated(
-        uint64 blueprintId,
-        address owner,
-        bytes calldata encodedDefinition
-    ) external;
+    function onBlueprintCreated(uint64 blueprintId, address owner, bytes calldata encodedDefinition) external;
 }

--- a/src/interfaces/IMetricsRecorder.sol
+++ b/src/interfaces/IMetricsRecorder.sol
@@ -14,24 +14,14 @@ interface IMetricsRecorder {
     /// @param operator The operator receiving delegation
     /// @param asset The asset being staked (address(0) for native)
     /// @param amount The amount staked
-    function recordStake(
-        address delegator,
-        address operator,
-        address asset,
-        uint256 amount
-    ) external;
+    function recordStake(address delegator, address operator, address asset, uint256 amount) external;
 
     /// @notice Record an unstake event
     /// @param delegator The delegator address
     /// @param operator The operator losing delegation
     /// @param asset The asset being unstaked
     /// @param amount The amount unstaked
-    function recordUnstake(
-        address delegator,
-        address operator,
-        address asset,
-        uint256 amount
-    ) external;
+    function recordUnstake(address delegator, address operator, address asset, uint256 amount) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // OPERATOR METRICS
@@ -41,43 +31,26 @@ interface IMetricsRecorder {
     /// @param operator The operator address
     /// @param asset The asset staked
     /// @param amount Initial stake amount
-    function recordOperatorRegistered(
-        address operator,
-        address asset,
-        uint256 amount
-    ) external;
+    function recordOperatorRegistered(address operator, address asset, uint256 amount) external;
 
     /// @notice Record operator heartbeat (liveness proof)
     /// @param operator The operator address
     /// @param serviceId The service ID
     /// @param timestamp Block timestamp of heartbeat
-    function recordHeartbeat(
-        address operator,
-        uint64 serviceId,
-        uint64 timestamp
-    ) external;
+    function recordHeartbeat(address operator, uint64 serviceId, uint64 timestamp) external;
 
     /// @notice Record job completion by operator
     /// @param operator The operator address
     /// @param serviceId The service ID
     /// @param jobCallId The job call ID
     /// @param success Whether the job succeeded
-    function recordJobCompletion(
-        address operator,
-        uint64 serviceId,
-        uint64 jobCallId,
-        bool success
-    ) external;
+    function recordJobCompletion(address operator, uint64 serviceId, uint64 jobCallId, bool success) external;
 
     /// @notice Record operator slashing (negative metric)
     /// @param operator The operator address
     /// @param serviceId The service ID
     /// @param amount Amount slashed
-    function recordSlash(
-        address operator,
-        uint64 serviceId,
-        uint256 amount
-    ) external;
+    function recordSlash(address operator, uint64 serviceId, uint256 amount) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE METRICS
@@ -88,30 +61,18 @@ interface IMetricsRecorder {
     /// @param blueprintId The blueprint ID
     /// @param owner The service owner
     /// @param operatorCount Number of operators
-    function recordServiceCreated(
-        uint64 serviceId,
-        uint64 blueprintId,
-        address owner,
-        uint256 operatorCount
-    ) external;
+    function recordServiceCreated(uint64 serviceId, uint64 blueprintId, address owner, uint256 operatorCount) external;
 
     /// @notice Record service termination
     /// @param serviceId The service ID
     /// @param duration How long the service ran (seconds)
-    function recordServiceTerminated(
-        uint64 serviceId,
-        uint256 duration
-    ) external;
+    function recordServiceTerminated(uint64 serviceId, uint256 duration) external;
 
     /// @notice Record a job call on a service
     /// @param serviceId The service ID
     /// @param caller Who initiated the job
     /// @param jobCallId The job call ID
-    function recordJobCall(
-        uint64 serviceId,
-        address caller,
-        uint64 jobCallId
-    ) external;
+    function recordJobCall(uint64 serviceId, address caller, uint64 jobCallId) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // PAYMENT/FEE METRICS
@@ -122,12 +83,7 @@ interface IMetricsRecorder {
     /// @param serviceId The service ID
     /// @param token The payment token (address(0) for native)
     /// @param amount The amount paid
-    function recordPayment(
-        address payer,
-        uint64 serviceId,
-        address token,
-        uint256 amount
-    ) external;
+    function recordPayment(address payer, uint64 serviceId, address token, uint256 amount) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // BLUEPRINT METRICS
@@ -136,17 +92,10 @@ interface IMetricsRecorder {
     /// @notice Record blueprint creation
     /// @param blueprintId The blueprint ID
     /// @param developer The developer address
-    function recordBlueprintCreated(
-        uint64 blueprintId,
-        address developer
-    ) external;
+    function recordBlueprintCreated(uint64 blueprintId, address developer) external;
 
     /// @notice Record operator registration to a blueprint
     /// @param blueprintId The blueprint ID
     /// @param operator The operator address
-    function recordBlueprintRegistration(
-        uint64 blueprintId,
-        address operator
-    ) external;
-
+    function recordBlueprintRegistration(uint64 blueprintId, address operator) external;
 }

--- a/src/interfaces/IMultiAssetDelegation.sol
+++ b/src/interfaces/IMultiAssetDelegation.sol
@@ -58,14 +58,12 @@ interface IMultiAssetDelegation {
         uint64 readyRound
     );
     event DelegatorUnstakeExecuted(
-        address indexed delegator,
-        address indexed operator,
-        address indexed token,
-        uint256 shares,
-        uint256 amount
+        address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 amount
     );
     event BlueprintAddedToDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId);
-    event BlueprintRemovedFromDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId);
+    event BlueprintRemovedFromDelegation(
+        address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId
+    );
 
     event Slashed(
         address indexed operator,
@@ -165,7 +163,9 @@ interface IMultiAssetDelegation {
         uint256 amount,
         Types.BlueprintSelectionMode selectionMode,
         uint64[] calldata blueprintIds
-    ) external payable;
+    )
+        external
+        payable;
     function delegate(address operator, uint256 amount) external;
     function delegateWithOptions(
         address operator,
@@ -173,7 +173,8 @@ interface IMultiAssetDelegation {
         uint256 amount,
         Types.BlueprintSelectionMode selectionMode,
         uint64[] calldata blueprintIds
-    ) external;
+    )
+        external;
     function scheduleDelegatorUnstake(address operator, address token, uint256 amount) external;
     function undelegate(address operator, uint256 amount) external;
     function executeDelegatorUnstake() external;
@@ -192,7 +193,9 @@ interface IMultiAssetDelegation {
         uint256 shares,
         uint64 requestedRound,
         address receiver
-    ) external returns (uint256 amount);
+    )
+        external
+        returns (uint256 amount);
     function addBlueprintToDelegation(uint256 delegationIndex, uint64 blueprintId) external;
     function removeBlueprintFromDelegation(uint256 delegationIndex, uint64 blueprintId) external;
 
@@ -206,7 +209,9 @@ interface IMultiAssetDelegation {
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
     function slashForService(
         address operator,
         uint64 blueprintId,
@@ -214,13 +219,17 @@ interface IMultiAssetDelegation {
         Types.AssetSecurityCommitment[] calldata commitments,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
     function slash(
         address operator,
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
     function advanceRound() external;
     function snapshotOperator(address operator) external;
 
@@ -234,7 +243,8 @@ interface IMultiAssetDelegation {
         uint256 minDelegation,
         uint256 depositCap,
         uint16 rewardMultiplierBps
-    ) external;
+    )
+        external;
     function disableAsset(address token) external;
     function getAssetConfig(address token) external view returns (Types.AssetConfig memory);
     function registerAdapter(address token, address adapter) external;
@@ -247,7 +257,8 @@ interface IMultiAssetDelegation {
         uint256 minDelegation,
         uint256 depositCap,
         uint16 rewardMultiplierBps
-    ) external;
+    )
+        external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS
@@ -258,7 +269,13 @@ interface IMultiAssetDelegation {
     function getOperatorStake(address operator) external view returns (uint256);
     function getOperatorSelfStake(address operator) external view returns (uint256);
     function getOperatorDelegatedStake(address operator) external view returns (uint256);
-    function getOperatorDelegatedStakeForAsset(address operator, Types.Asset calldata asset) external view returns (uint256);
+    function getOperatorDelegatedStakeForAsset(
+        address operator,
+        Types.Asset calldata asset
+    )
+        external
+        view
+        returns (uint256);
     function getOperatorStakeForAsset(address operator, Types.Asset calldata asset) external view returns (uint256);
     function getDelegation(address delegator, address operator) external view returns (uint256);
     function getTotalDelegation(address delegator) external view returns (uint256 total);
@@ -276,7 +293,14 @@ interface IMultiAssetDelegation {
     function getDelegations(address delegator) external view returns (Types.BondInfoDelegator[] memory);
     function getDelegationBlueprints(address delegator, uint256 idx) external view returns (uint64[] memory);
     function getPendingUnstakes(address delegator) external view returns (Types.BondLessRequest[] memory);
-    function previewDelegatorUnstakeShares(address operator, address token, uint256 amount) external view returns (uint256);
+    function previewDelegatorUnstakeShares(
+        address operator,
+        address token,
+        uint256 amount
+    )
+        external
+        view
+        returns (uint256);
     /// @notice Get the operator's reward pool for the bond asset
     function getOperatorRewardPool(address operator) external view returns (Types.OperatorRewardPool memory);
     function getOperatorDelegators(address operator) external view returns (address[] memory);
@@ -285,7 +309,10 @@ interface IMultiAssetDelegation {
     function serviceFeeDistributor() external view returns (address);
     function getSlashImpact(address operator, uint64 slashIndex, address delegator) external view returns (uint256);
     function getSlashCount(address operator) external view returns (uint64);
-    function getSlashRecord(address operator, uint64 slashIndex)
+    function getSlashRecord(
+        address operator,
+        uint64 slashIndex
+    )
         external
         view
         returns (SlashingManager.SlashRecord memory);
@@ -322,7 +349,12 @@ interface IMultiAssetDelegation {
     function cancelCommissionChange() external;
     function getPendingCommissionChange() external view returns (uint16 pendingBps, uint64 executeAfter);
     function setOperatorBondToken(address token) external;
-    function setDelays(uint64 delegationBondLessDelay, uint64 leaveDelegatorsDelay, uint64 leaveOperatorsDelay) external;
+    function setDelays(
+        uint64 delegationBondLessDelay,
+        uint64 leaveDelegatorsDelay,
+        uint64 leaveOperatorsDelay
+    )
+        external;
     function setRewardsManager(address manager) external;
     function setServiceFeeDistributor(address distributor) external;
     function pause() external;

--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -17,29 +17,21 @@ interface IRewardsManager {
         address asset,
         uint256 amount,
         uint16 lockMultiplierBps
-    ) external;
+    )
+        external;
 
     /// @notice Records an undelegation
     /// @param delegator The account making the undelegation
     /// @param operator The operator being undelegated from
     /// @param asset The asset being undelegated
     /// @param amount The amount being undelegated
-    function recordUndelegate(
-        address delegator,
-        address operator,
-        address asset,
-        uint256 amount
-    ) external;
+    function recordUndelegate(address delegator, address operator, address asset, uint256 amount) external;
 
     /// @notice Records a service reward for an operator
     /// @param operator The operator receiving the reward
     /// @param asset The reward asset
     /// @param amount The reward amount
-    function recordServiceReward(
-        address operator,
-        address asset,
-        uint256 amount
-    ) external;
+    function recordServiceReward(address operator, address asset, uint256 amount) external;
 
     /// @notice Get remaining deposit capacity for an asset vault
     /// @param asset The asset to query

--- a/src/interfaces/IServiceFeeDistributor.sol
+++ b/src/interfaces/IServiceFeeDistributor.sol
@@ -13,7 +13,9 @@ interface IServiceFeeDistributor {
         address operator,
         address paymentToken,
         uint256 amount
-    ) external payable;
+    )
+        external
+        payable;
 
     /// @notice Distribute inflation-funded restaker rewards using service exposure weights
     /// @dev Intended for InflationPool; rewards are paid in the provided token (TNT).
@@ -23,14 +25,12 @@ interface IServiceFeeDistributor {
         address operator,
         address paymentToken,
         uint256 amount
-    ) external payable;
+    )
+        external
+        payable;
 
     /// @notice Claim rewards for a specific delegator position and token
-    function claimFor(
-        address token,
-        address operator,
-        Types.Asset calldata asset
-    ) external returns (uint256 amount);
+    function claimFor(address token, address operator, Types.Asset calldata asset) external returns (uint256 amount);
 
     /// @notice Claim all pending rewards across all positions for a token
     function claimAll(address token) external returns (uint256 totalAmount);
@@ -52,7 +52,10 @@ interface IServiceFeeDistributor {
         address delegator,
         address operator,
         bytes32 assetHash
-    ) external view returns (uint8 mode, uint256 principal, uint256 score);
+    )
+        external
+        view
+        returns (uint8 mode, uint256 principal, uint256 score);
 
     /// @notice Return reward tokens ever distributed for an operator
     function operatorRewardTokens(address operator) external view returns (address[] memory tokens);
@@ -68,14 +71,11 @@ interface IServiceFeeDistributor {
         // Per-blueprint amount deltas (must align with blueprintIds for Fixed mode).
         uint256[] calldata blueprintAmounts,
         uint16 lockMultiplierBps
-    ) external;
+    )
+        external;
 
     /// @notice Apply a slash factor to All-mode exposure for an operator/asset
-    function onAllModeSlashed(
-        address operator,
-        Types.Asset calldata asset,
-        uint16 slashBps
-    ) external;
+    function onAllModeSlashed(address operator, Types.Asset calldata asset, uint16 slashBps) external;
 
     /// @notice Apply a slash factor to Fixed-mode exposure for a blueprint/operator/asset
     function onFixedModeSlashed(
@@ -83,7 +83,8 @@ interface IServiceFeeDistributor {
         uint64 blueprintId,
         Types.Asset calldata asset,
         uint16 slashBps
-    ) external;
+    )
+        external;
 
     /// @notice Update fixed-mode blueprint set after a rebalance
     /// @dev blueprintAmounts are post-rebalance amounts, ordered to match blueprintIds.
@@ -93,13 +94,17 @@ interface IServiceFeeDistributor {
         Types.Asset calldata asset,
         uint64[] calldata blueprintIds,
         uint256[] calldata blueprintAmounts
-    ) external;
+    )
+        external;
 
     function getPoolScore(
         address operator,
         uint64 blueprintId,
         Types.Asset calldata asset
-    ) external view returns (uint256 allScore, uint256 fixedScore);
+    )
+        external
+        view
+        returns (uint256 allScore, uint256 fixedScore);
 
     /// @notice Get USD-weighted exposure for an operator/service
     /// @dev Returns total USD exposure across All+Fixed pools for the service.
@@ -107,7 +112,10 @@ interface IServiceFeeDistributor {
         uint64 serviceId,
         uint64 blueprintId,
         address operator
-    ) external view returns (uint256 totalUsdExposure);
+    )
+        external
+        view
+        returns (uint256 totalUsdExposure);
 
     /// @notice Called when an operator is about to leave a service
     /// @dev Drips all active streams for the operator BEFORE they're removed

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -18,12 +18,7 @@ interface IStaking {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Emitted when an operator is slashed
-    event OperatorSlashed(
-        address indexed operator,
-        uint64 indexed serviceId,
-        uint16 slashBps,
-        bytes32 evidence
-    );
+    event OperatorSlashed(address indexed operator, uint64 indexed serviceId, uint16 slashBps, bytes32 evidence);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // OPERATOR QUERIES
@@ -61,16 +56,16 @@ interface IStaking {
     function getOperatorDelegatedStakeForAsset(
         address operator,
         Types.Asset calldata asset
-    ) external view returns (uint256);
+    )
+        external
+        view
+        returns (uint256);
 
     /// @notice Get total stake (self + delegated) for a specific asset
     /// @param operator The operator address
     /// @param asset The asset to query
     /// @return Total stake for the asset
-    function getOperatorStakeForAsset(
-        address operator,
-        Types.Asset calldata asset
-    ) external view returns (uint256);
+    function getOperatorStakeForAsset(address operator, Types.Asset calldata asset) external view returns (uint256);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // DELEGATOR QUERIES
@@ -119,7 +114,9 @@ interface IStaking {
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
 
     /// @notice Slash an operator for a specific service, only slashing committed assets
     /// @dev Only slashes assets the operator committed to this service, proportionally
@@ -137,7 +134,9 @@ interface IStaking {
         Types.AssetSecurityCommitment[] calldata commitments,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
 
     /// @notice Slash an operator's native stake for consensus violations (affects all native delegators)
     /// @dev Only callable by authorized slashers (e.g., Tangle core contract)
@@ -151,7 +150,9 @@ interface IStaking {
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed);
+    )
+        external
+        returns (uint256 actualSlashed);
 
     /// @notice Check if an address is authorized to call slash()
     /// @param account The address to check
@@ -192,7 +193,6 @@ interface IStaking {
     /// @param operator The operator to query
     /// @return count Number of pending slashes
     function getPendingSlashCount(address operator) external view returns (uint64);
-
 }
 
 /// @title IStakingAdmin

--- a/src/interfaces/IStreamingPaymentAdapter.sol
+++ b/src/interfaces/IStreamingPaymentAdapter.sol
@@ -21,33 +21,16 @@ interface IStreamingPaymentAdapter {
     );
 
     /// @notice Emitted when a stream is updated
-    event StreamUpdated(
-        uint64 indexed serviceId,
-        uint256 indexed streamId,
-        uint256 newRatePerSecond
-    );
+    event StreamUpdated(uint64 indexed serviceId, uint256 indexed streamId, uint256 newRatePerSecond);
 
     /// @notice Emitted when a stream is cancelled
-    event StreamCancelled(
-        uint64 indexed serviceId,
-        uint256 indexed streamId,
-        uint256 refundedAmount
-    );
+    event StreamCancelled(uint64 indexed serviceId, uint256 indexed streamId, uint256 refundedAmount);
 
     /// @notice Emitted when funds are withdrawn from a stream
-    event StreamWithdrawn(
-        uint64 indexed serviceId,
-        uint256 indexed streamId,
-        uint256 amount,
-        address recipient
-    );
+    event StreamWithdrawn(uint64 indexed serviceId, uint256 indexed streamId, uint256 amount, address recipient);
 
     /// @notice Emitted when a stream is settled and distributed
-    event StreamSettled(
-        uint64 indexed serviceId,
-        uint256 indexed streamId,
-        uint256 amount
-    );
+    event StreamSettled(uint64 indexed serviceId, uint256 indexed streamId, uint256 amount);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // STREAM MANAGEMENT
@@ -66,15 +49,15 @@ interface IStreamingPaymentAdapter {
         uint256 totalAmount,
         uint64 durationSeconds,
         uint64 cliffSeconds
-    ) external payable returns (uint256 streamId);
+    )
+        external
+        payable
+        returns (uint256 streamId);
 
     /// @notice Update the rate of an existing stream
     /// @param streamId The stream ID to update
     /// @param newRatePerSecond New streaming rate
-    function updateStreamRate(
-        uint256 streamId,
-        uint256 newRatePerSecond
-    ) external;
+    function updateStreamRate(uint256 streamId, uint256 newRatePerSecond) external;
 
     /// @notice Cancel a stream and refund remaining balance
     /// @param streamId The stream ID to cancel
@@ -174,7 +157,10 @@ interface ISuperfluidAdapter is IStreamingPaymentAdapter {
     /// @param token The super token
     /// @return availableBalance Current available balance
     /// @return deposit Required deposit/buffer
-    function getRealtimeBalance(address account, address token)
+    function getRealtimeBalance(
+        address account,
+        address token
+    )
         external
         view
         returns (int256 availableBalance, uint256 deposit);
@@ -207,15 +193,15 @@ interface ISuperfluidAdapter is IStreamingPaymentAdapter {
 interface ISablierAdapter is IStreamingPaymentAdapter {
     /// @notice Stream type for Sablier
     enum StreamType {
-        Linear,       // Linear vesting over time
-        Dynamic,      // Custom curve with segments
-        Tranched      // Fixed payment tranches
+        Linear, // Linear vesting over time
+        Dynamic, // Custom curve with segments
+        Tranched // Fixed payment tranches
     }
 
     /// @notice Segment for dynamic streams
     struct Segment {
         uint128 amount;
-        uint64 exponent;  // Curve exponent (scaled by 1e18)
+        uint64 exponent; // Curve exponent (scaled by 1e18)
         uint40 timestamp;
     }
 
@@ -232,7 +218,9 @@ interface ISablierAdapter is IStreamingPaymentAdapter {
         uint128 totalAmount,
         uint40 durationSeconds,
         uint40 cliffSeconds
-    ) external returns (uint256 streamId);
+    )
+        external
+        returns (uint256 streamId);
 
     /// @notice Create a dynamic stream with custom curve
     /// @param serviceId The Tangle service ID
@@ -245,7 +233,9 @@ interface ISablierAdapter is IStreamingPaymentAdapter {
         address token,
         uint128 totalAmount,
         Segment[] calldata segments
-    ) external returns (uint256 streamId);
+    )
+        external
+        returns (uint256 streamId);
 
     /// @notice Check if a stream is cancelable
     /// @param streamId The stream ID

--- a/src/interfaces/IStreamingPaymentManager.sol
+++ b/src/interfaces/IStreamingPaymentManager.sol
@@ -13,17 +13,17 @@ interface IStreamingPaymentManager {
         uint256 amount,
         uint64 startTime,
         uint64 endTime
-    ) external payable;
+    )
+        external
+        payable;
 
     /// @notice Drip a specific stream and return chunk info
-    function dripAndGetChunk(uint64 serviceId, address operator)
+    function dripAndGetChunk(
+        uint64 serviceId,
+        address operator
+    )
         external
-        returns (
-            uint256 amount,
-            uint256 durationSeconds,
-            uint64 blueprintId,
-            address paymentToken
-        );
+        returns (uint256 amount, uint256 durationSeconds, uint64 blueprintId, address paymentToken);
 
     /// @notice Drip all active streams for an operator
     function dripOperatorStreams(address operator)
@@ -46,7 +46,10 @@ interface IStreamingPaymentManager {
     function getOperatorActiveStreams(address operator) external view returns (uint64[] memory);
 
     /// @notice Get streaming payment details
-    function getStreamingPayment(uint64 serviceId, address operator)
+    function getStreamingPayment(
+        uint64 serviceId,
+        address operator
+    )
         external
         view
         returns (

--- a/src/interfaces/ITangle.sol
+++ b/src/interfaces/ITangle.sol
@@ -13,13 +13,7 @@ import { ITangleRewards } from "./ITangleRewards.sol";
 /// @notice Core interface for Tangle Protocol v2
 /// @dev Consolidates all sub-interfaces into a single entry point.
 ///      Inherits from focused sub-interfaces for modularity.
-interface ITangle is
-    ITangleBlueprints,
-    ITangleOperators,
-    ITangleServices,
-    ITangleJobs,
-    ITangleRewards
-{
+interface ITangle is ITangleBlueprints, ITangleOperators, ITangleServices, ITangleJobs, ITangleRewards {
     // This interface consolidates all sub-interfaces.
     // See individual interfaces for documentation:
     // - ITangleBlueprints: Blueprint CRUD operations
@@ -29,7 +23,8 @@ interface ITangle is
     // - ITangleRewards: Reward distribution and claiming
     //
     // ITangleSlashing is implemented separately for clarity
-}
+
+    }
 
 /// @title ITangleAdmin
 /// @notice Admin functions for Tangle protocol
@@ -47,7 +42,10 @@ interface ITangleAdmin {
     function setPaymentSplit(Types.PaymentSplit calldata split) external;
 
     /// @notice Get the current payment split
-    function paymentSplit() external view returns (uint16 developerBps, uint16 protocolBps, uint16 operatorBps, uint16 stakerBps);
+    function paymentSplit()
+        external
+        view
+        returns (uint16 developerBps, uint16 protocolBps, uint16 operatorBps, uint16 stakerBps);
 
     /// @notice Pause the protocol
     function pause() external;
@@ -121,4 +119,4 @@ interface ITangleAdmin {
 
 /// @title ITangleFull
 /// @notice Complete Tangle interface including admin and slashing
-interface ITangleFull is ITangle, ITangleSlashing, ITangleAdmin {}
+interface ITangleFull is ITangle, ITangleSlashing, ITangleAdmin { }

--- a/src/interfaces/ITangleBlueprints.sol
+++ b/src/interfaces/ITangleBlueprints.sol
@@ -81,4 +81,23 @@ interface ITangleBlueprints {
 
     /// @notice Get the effective event rate for a specific job type
     function getJobEventRate(uint64 blueprintId, uint8 jobIndex) external view returns (uint256 rate);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // RESOURCE REQUIREMENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event BlueprintResourceRequirementsSet(uint64 indexed blueprintId, uint256 count);
+
+    /// @notice Set default resource requirements for a blueprint (owner only)
+    function setBlueprintResourceRequirements(
+        uint64 blueprintId,
+        Types.ResourceCommitment[] calldata requirements
+    )
+        external;
+
+    /// @notice Get default resource requirements for a blueprint
+    function getBlueprintResourceRequirements(uint64 blueprintId)
+        external
+        view
+        returns (Types.ResourceCommitment[] memory);
 }

--- a/src/interfaces/ITangleGovernance.sol
+++ b/src/interfaces/ITangleGovernance.sol
@@ -31,7 +31,9 @@ interface ITangleGovernance {
         uint256[] memory values,
         bytes[] memory calldatas,
         string memory description
-    ) external returns (uint256 proposalId);
+    )
+        external
+        returns (uint256 proposalId);
 
     /// @notice Queue a successful proposal for execution
     /// @param targets Contract addresses to call
@@ -44,7 +46,9 @@ interface ITangleGovernance {
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) external returns (uint256 proposalId);
+    )
+        external
+        returns (uint256 proposalId);
 
     /// @notice Execute a queued proposal
     /// @param targets Contract addresses to call
@@ -57,7 +61,10 @@ interface ITangleGovernance {
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) external payable returns (uint256 proposalId);
+    )
+        external
+        payable
+        returns (uint256 proposalId);
 
     /// @notice Cancel a proposal
     /// @param targets Contract addresses to call
@@ -70,7 +77,9 @@ interface ITangleGovernance {
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) external returns (uint256 proposalId);
+    )
+        external
+        returns (uint256 proposalId);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VOTING
@@ -91,7 +100,9 @@ interface ITangleGovernance {
         uint256 proposalId,
         uint8 support,
         string calldata reason
-    ) external returns (uint256 weight);
+    )
+        external
+        returns (uint256 weight);
 
     /// @notice Cast a vote using EIP-712 signature
     /// @param proposalId The proposal to vote on
@@ -104,7 +115,9 @@ interface ITangleGovernance {
         uint8 support,
         address voter,
         bytes memory signature
-    ) external returns (uint256 weight);
+    )
+        external
+        returns (uint256 weight);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS
@@ -160,14 +173,7 @@ interface ITangleToken {
     function delegate(address delegatee) external;
 
     /// @notice Delegate using EIP-712 signature
-    function delegateBySig(
-        address delegatee,
-        uint256 nonce,
-        uint256 expiry,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
+    function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external;
 
     /// @notice Standard ERC20 functions
     function totalSupply() external view returns (uint256);

--- a/src/interfaces/ITangleOperators.sol
+++ b/src/interfaces/ITangleOperators.sol
@@ -19,10 +19,7 @@ interface ITangleOperators {
     /// @param ecdsaPublicKey The ECDSA public key for gossip network identity
     /// @param rpcAddress The operator's RPC endpoint
     event OperatorRegistered(
-        uint64 indexed blueprintId,
-        address indexed operator,
-        bytes ecdsaPublicKey,
-        string rpcAddress
+        uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress
     );
 
     event OperatorUnregistered(uint64 indexed blueprintId, address indexed operator);
@@ -33,10 +30,7 @@ interface ITangleOperators {
     /// @param ecdsaPublicKey The updated ECDSA public key (may be empty if unchanged)
     /// @param rpcAddress The updated RPC endpoint (may be empty if unchanged)
     event OperatorPreferencesUpdated(
-        uint64 indexed blueprintId,
-        address indexed operator,
-        bytes ecdsaPublicKey,
-        string rpcAddress
+        uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress
     );
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -52,11 +46,7 @@ interface ITangleOperators {
     ///        This key is used for signing/verifying messages in the P2P gossip network
     ///        and may differ from the wallet key (msg.sender)
     /// @param rpcAddress The operator's RPC endpoint URL
-    function registerOperator(
-        uint64 blueprintId,
-        bytes calldata ecdsaPublicKey,
-        string calldata rpcAddress
-    ) external;
+    function registerOperator(uint64 blueprintId, bytes calldata ecdsaPublicKey, string calldata rpcAddress) external;
 
     /// @notice Register as operator providing blueprint-specific registration inputs
     /// @param registrationInputs Encoded payload validated by blueprint's schema
@@ -65,7 +55,8 @@ interface ITangleOperators {
         bytes calldata ecdsaPublicKey,
         string calldata rpcAddress,
         bytes calldata registrationInputs
-    ) external;
+    )
+        external;
 
     /// @notice Unregister from a blueprint
     function unregisterOperator(uint64 blueprintId) external;
@@ -78,7 +69,8 @@ interface ITangleOperators {
         uint64 blueprintId,
         bytes calldata ecdsaPublicKey,
         string calldata rpcAddress
-    ) external;
+    )
+        external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS
@@ -88,20 +80,23 @@ interface ITangleOperators {
     function getOperatorRegistration(
         uint64 blueprintId,
         address operator
-    ) external view returns (Types.OperatorRegistration memory);
+    )
+        external
+        view
+        returns (Types.OperatorRegistration memory);
 
     /// @notice Get operator preferences for a blueprint (includes ECDSA public key)
     function getOperatorPreferences(
         uint64 blueprintId,
         address operator
-    ) external view returns (Types.OperatorPreferences memory);
+    )
+        external
+        view
+        returns (Types.OperatorPreferences memory);
 
     /// @notice Get operator's ECDSA public key for gossip network identity
     /// @dev Returns the key used for signing/verifying gossip messages
-    function getOperatorPublicKey(
-        uint64 blueprintId,
-        address operator
-    ) external view returns (bytes memory);
+    function getOperatorPublicKey(uint64 blueprintId, address operator) external view returns (bytes memory);
 
     /// @notice Check if operator is registered for a blueprint
     function isOperatorRegistered(uint64 blueprintId, address operator) external view returns (bool);

--- a/src/interfaces/ITanglePaymentsInternal.sol
+++ b/src/interfaces/ITanglePaymentsInternal.sol
@@ -16,7 +16,8 @@ interface ITanglePaymentsInternal {
         address token,
         uint256 amount,
         address[] calldata operators
-    ) external;
+    )
+        external;
 
     function depositToEscrow(uint64 serviceId, address token, uint256 amount) external;
 }

--- a/src/interfaces/ITangleSecurityView.sol
+++ b/src/interfaces/ITangleSecurityView.sol
@@ -16,7 +16,10 @@ interface ITangleSecurityView {
         address operator,
         Types.AssetKind kind,
         address token
-    ) external view returns (uint16);
+    )
+        external
+        view
+        returns (uint16);
 
     function treasury() external view returns (address payable);
 

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -78,6 +78,12 @@ interface ITangleServices {
         payable
         returns (uint64 requestId);
 
+    /// @notice Get resource requirements for a service request
+    function getServiceRequestResourceRequirements(uint64 requestId)
+        external
+        view
+        returns (Types.ResourceCommitment[] memory);
+
     /// @notice Approve a service request (as operator) - simple version
     function approveService(uint64 requestId, uint8 stakingPercent) external;
 

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -13,11 +13,7 @@ interface ITangleServices {
 
     event ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
 
-    event ServiceRequestedWithSecurity(
-        uint64 indexed requestId,
-        uint64 indexed blueprintId,
-        address indexed requester
-    );
+    event ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
 
     event ServiceApproved(uint64 indexed requestId, address indexed operator);
 
@@ -46,7 +42,10 @@ interface ITangleServices {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable returns (uint64 requestId);
+    )
+        external
+        payable
+        returns (uint64 requestId);
 
     /// @notice Request a service with explicit exposure commitments
     function requestServiceWithExposure(
@@ -58,7 +57,10 @@ interface ITangleServices {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable returns (uint64 requestId);
+    )
+        external
+        payable
+        returns (uint64 requestId);
 
     /// @notice Request a service with multi-asset security requirements
     /// @dev Each operator must provide security commitments matching these requirements when approving
@@ -71,7 +73,10 @@ interface ITangleServices {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount
-    ) external payable returns (uint64 requestId);
+    )
+        external
+        payable
+        returns (uint64 requestId);
 
     /// @notice Approve a service request (as operator) - simple version
     function approveService(uint64 requestId, uint8 stakingPercent) external;
@@ -81,17 +86,14 @@ interface ITangleServices {
     function approveServiceWithCommitments(
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external;
+    )
+        external;
 
     /// @notice Approve a service request with BLS public key for aggregated signature verification
     /// @param requestId The service request ID
     /// @param stakingPercent The staking percentage (0-100)
     /// @param blsPubkey The operator's BLS G2 public key [x0, x1, y0, y1]
-    function approveServiceWithBls(
-        uint64 requestId,
-        uint8 stakingPercent,
-        uint256[4] calldata blsPubkey
-    ) external;
+    function approveServiceWithBls(uint64 requestId, uint8 stakingPercent, uint256[4] calldata blsPubkey) external;
 
     /// @notice Approve a service request with both security commitments and BLS public key
     /// @param requestId The service request ID
@@ -101,7 +103,8 @@ interface ITangleServices {
         uint64 requestId,
         Types.AssetSecurityCommitment[] calldata commitments,
         uint256[4] calldata blsPubkey
-    ) external;
+    )
+        external;
 
     /// @notice Reject a service request (as operator)
     function rejectService(uint64 requestId) external;
@@ -123,14 +126,19 @@ interface ITangleServices {
         bytes calldata config,
         address[] calldata permittedCallers,
         uint64 ttl
-    ) external payable returns (uint64 serviceId);
+    )
+        external
+        payable
+        returns (uint64 serviceId);
 
     /// @notice Extend a service using pre-signed operator quotes
     function extendServiceFromQuotes(
         uint64 serviceId,
         Types.SignedQuote[] calldata quotes,
         uint64 extensionDuration
-    ) external payable;
+    )
+        external
+        payable;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE MANAGEMENT FUNCTIONS
@@ -157,7 +165,8 @@ interface ITangleServices {
         uint64 serviceId,
         uint16 exposureBps,
         Types.AssetSecurityCommitment[] calldata commitments
-    ) external;
+    )
+        external;
 
     /// @notice Leave an active service (Dynamic membership only)
     function leaveService(uint64 serviceId) external;
@@ -211,7 +220,10 @@ interface ITangleServices {
         returns (Types.AssetSecurityRequirement[] memory);
 
     /// @notice Get security commitments for a service request by operator
-    function getServiceRequestSecurityCommitments(uint64 requestId, address operator)
+    function getServiceRequestSecurityCommitments(
+        uint64 requestId,
+        address operator
+    )
         external
         view
         returns (Types.AssetSecurityCommitment[] memory);
@@ -226,10 +238,7 @@ interface ITangleServices {
     function isServiceOperator(uint64 serviceId, address operator) external view returns (bool);
 
     /// @notice Get operator info for a service
-    function getServiceOperator(uint64 serviceId, address operator)
-        external
-        view
-        returns (Types.ServiceOperator memory);
+    function getServiceOperator(uint64 serviceId, address operator) external view returns (Types.ServiceOperator memory);
 
     /// @notice Get the list of operators for a service
     function getServiceOperators(uint64 serviceId) external view returns (address[] memory);
@@ -253,10 +262,19 @@ interface ITangleServices {
     function getExitConfig(uint64 serviceId) external view returns (Types.ExitConfig memory);
 
     /// @notice Check if operator can schedule exit now
-    function canScheduleExit(uint64 serviceId, address operator) external view returns (bool canExit, string memory reason);
+    function canScheduleExit(
+        uint64 serviceId,
+        address operator
+    )
+        external
+        view
+        returns (bool canExit, string memory reason);
 
     /// @notice Get persisted security commitments for an active service by operator
-    function getServiceSecurityCommitments(uint64 serviceId, address operator)
+    function getServiceSecurityCommitments(
+        uint64 serviceId,
+        address operator
+    )
         external
         view
         returns (Types.AssetSecurityCommitment[] memory);
@@ -273,5 +291,17 @@ interface ITangleServices {
     /// @param serviceId The service ID
     /// @param operator The operator address
     /// @return blsPubkey The BLS G2 public key [x0, x1, y0, y1], all zeros if not registered
-    function getOperatorBlsPubkey(uint64 serviceId, address operator) external view returns (uint256[4] memory blsPubkey);
+    function getOperatorBlsPubkey(
+        uint64 serviceId,
+        address operator
+    )
+        external
+        view
+        returns (uint256[4] memory blsPubkey);
+
+    /// @notice Get the resource commitment hash for an operator in a service
+    /// @param serviceId The service ID
+    /// @param operator The operator address
+    /// @return The keccak256 of EIP-712-hashed ResourceCommitment[] (bytes32(0) if none)
+    function getServiceResourceCommitmentHash(uint64 serviceId, address operator) external view returns (bytes32);
 }

--- a/src/interfaces/ITangleSlashing.sol
+++ b/src/interfaces/ITangleSlashing.sol
@@ -10,12 +10,7 @@ interface ITangleSlashing {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event SlashProposed(
-        uint64 indexed serviceId,
-        address indexed operator,
-        uint16 slashBps,
-        bytes32 evidence
-    );
+    event SlashProposed(uint64 indexed serviceId, address indexed operator, uint16 slashBps, bytes32 evidence);
 
     event SlashExecuted(uint64 indexed serviceId, address indexed operator, uint256 amount);
 
@@ -34,7 +29,9 @@ interface ITangleSlashing {
         address operator,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint64 slashId);
+    )
+        external
+        returns (uint64 slashId);
 
     /// @notice Dispute a slash proposal
     function disputeSlash(uint64 slashId, string calldata reason) external;

--- a/src/libraries/BN254.sol
+++ b/src/libraries/BN254.sol
@@ -13,11 +13,11 @@ library BN254 {
 
     /// @notice The prime field modulus for BN254
     uint256 internal constant P_MOD =
-        21888242871839275222246405745257275088696311157297823662689037894645226208583;
+        21_888_242_871_839_275_222_246_405_745_257_275_088_696_311_157_297_823_662_689_037_894_645_226_208_583;
 
     /// @notice The group order for BN254
     uint256 internal constant R_MOD =
-        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+        21_888_242_871_839_275_222_246_405_745_257_275_088_548_364_400_416_034_343_698_204_186_575_808_495_617;
 
     /// @notice G1 generator x coordinate
     uint256 internal constant G1_X = 1;
@@ -27,15 +27,15 @@ library BN254 {
 
     /// @notice G2 generator x coordinates (x = x0 * i + x1)
     uint256 internal constant G2_X0 =
-        11559732032986387107991004021392285783925812861821192530917403151452391805634;
+        11_559_732_032_986_387_107_991_004_021_392_285_783_925_812_861_821_192_530_917_403_151_452_391_805_634;
     uint256 internal constant G2_X1 =
-        10857046999023057135944570762232829481370756359578518086990519993285655852781;
+        10_857_046_999_023_057_135_944_570_762_232_829_481_370_756_359_578_518_086_990_519_993_285_655_852_781;
 
     /// @notice G2 generator y coordinates (y = y0 * i + y1)
     uint256 internal constant G2_Y0 =
-        4082367875863433681332203403145435568316851327593401208105741076214120093531;
+        4_082_367_875_863_433_681_332_203_403_145_435_568_316_851_327_593_401_208_105_741_076_214_120_093_531;
     uint256 internal constant G2_Y1 =
-        8495653923123431417604973247489272438418190587263600148770280649306958101930;
+        8_495_653_923_123_431_417_604_973_247_489_272_438_418_190_587_263_600_148_770_280_649_306_958_101_930;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // ERRORS
@@ -85,7 +85,11 @@ library BN254 {
     function addG1(
         Types.BN254G1Point memory p1,
         Types.BN254G1Point memory p2
-    ) internal view returns (Types.BN254G1Point memory r) {
+    )
+        internal
+        view
+        returns (Types.BN254G1Point memory r)
+    {
         uint256[4] memory input;
         input[0] = p1.x;
         input[1] = p1.y;
@@ -107,10 +111,7 @@ library BN254 {
     /// @param p The point to multiply
     /// @param s The scalar
     /// @return r The product s * p
-    function scalarMulG1(
-        Types.BN254G1Point memory p,
-        uint256 s
-    ) internal view returns (Types.BN254G1Point memory r) {
+    function scalarMulG1(Types.BN254G1Point memory p, uint256 s) internal view returns (Types.BN254G1Point memory r) {
         uint256[3] memory input;
         input[0] = p.x;
         input[1] = p.y;
@@ -149,15 +150,17 @@ library BN254 {
     function addG2(
         Types.BN254G2Point memory p1,
         Types.BN254G2Point memory p2
-    ) internal pure returns (Types.BN254G2Point memory r) {
+    )
+        internal
+        pure
+        returns (Types.BN254G2Point memory r)
+    {
         // Handle point at infinity cases
         if (isG2Infinity(p1)) return p2;
         if (isG2Infinity(p2)) return p1;
 
         // Check if points are the same (need to double)
-        if (
-            p1.x[0] == p2.x[0] && p1.x[1] == p2.x[1] && p1.y[0] == p2.y[0] && p1.y[1] == p2.y[1]
-        ) {
+        if (p1.x[0] == p2.x[0] && p1.x[1] == p2.x[1] && p1.y[0] == p2.y[0] && p1.y[1] == p2.y[1]) {
             return doubleG2(p1);
         }
 
@@ -251,35 +254,20 @@ library BN254 {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Add two Fp2 elements: (a0 + a1*i) + (b0 + b1*i)
-    function fp2Add(
-        uint256 a0,
-        uint256 a1,
-        uint256 b0,
-        uint256 b1
-    ) internal pure returns (uint256 c0, uint256 c1) {
+    function fp2Add(uint256 a0, uint256 a1, uint256 b0, uint256 b1) internal pure returns (uint256 c0, uint256 c1) {
         c0 = addmod(a0, b0, P_MOD);
         c1 = addmod(a1, b1, P_MOD);
     }
 
     /// @notice Subtract two Fp2 elements: (a0 + a1*i) - (b0 + b1*i)
-    function fp2Sub(
-        uint256 a0,
-        uint256 a1,
-        uint256 b0,
-        uint256 b1
-    ) internal pure returns (uint256 c0, uint256 c1) {
+    function fp2Sub(uint256 a0, uint256 a1, uint256 b0, uint256 b1) internal pure returns (uint256 c0, uint256 c1) {
         c0 = addmod(a0, P_MOD - (b0 % P_MOD), P_MOD);
         c1 = addmod(a1, P_MOD - (b1 % P_MOD), P_MOD);
     }
 
     /// @notice Multiply two Fp2 elements: (a0 + a1*i) * (b0 + b1*i)
     /// @dev Using i^2 = -1: result = (a0*b0 - a1*b1) + (a0*b1 + a1*b0)*i
-    function fp2Mul(
-        uint256 a0,
-        uint256 a1,
-        uint256 b0,
-        uint256 b1
-    ) internal pure returns (uint256 c0, uint256 c1) {
+    function fp2Mul(uint256 a0, uint256 a1, uint256 b0, uint256 b1) internal pure returns (uint256 c0, uint256 c1) {
         uint256 a0b0 = mulmod(a0, b0, P_MOD);
         uint256 a1b1 = mulmod(a1, b1, P_MOD);
         uint256 a0b1 = mulmod(a0, b1, P_MOD);
@@ -292,11 +280,7 @@ library BN254 {
     }
 
     /// @notice Multiply Fp2 element by a scalar
-    function fp2MulScalar(
-        uint256 a0,
-        uint256 a1,
-        uint256 s
-    ) internal pure returns (uint256 c0, uint256 c1) {
+    function fp2MulScalar(uint256 a0, uint256 a1, uint256 s) internal pure returns (uint256 c0, uint256 c1) {
         c0 = mulmod(a0, s, P_MOD);
         c1 = mulmod(a1, s, P_MOD);
     }
@@ -324,21 +308,13 @@ library BN254 {
     }
 
     /// @notice Divide two Fp2 elements: a / b = a * b^(-1)
-    function fp2Div(
-        uint256 a0,
-        uint256 a1,
-        uint256 b0,
-        uint256 b1
-    ) internal pure returns (uint256 c0, uint256 c1) {
+    function fp2Div(uint256 a0, uint256 a1, uint256 b0, uint256 b1) internal pure returns (uint256 c0, uint256 c1) {
         (uint256 bInv0, uint256 bInv1) = fp2Inverse(b0, b1);
         return fp2Mul(a0, a1, bInv0, bInv1);
     }
 
     /// @notice Compare two G2 points for equality
-    function g2Eq(
-        Types.BN254G2Point memory p1,
-        Types.BN254G2Point memory p2
-    ) internal pure returns (bool) {
+    function g2Eq(Types.BN254G2Point memory p1, Types.BN254G2Point memory p2) internal pure returns (bool) {
         return p1.x[0] == p2.x[0] && p1.x[1] == p2.x[1] && p1.y[0] == p2.y[0] && p1.y[1] == p2.y[1];
     }
 
@@ -351,10 +327,7 @@ library BN254 {
     /// @param p1 Array of G1 points
     /// @param p2 Array of G2 points
     /// @return True if the pairing equation holds
-    function pairing(
-        Types.BN254G1Point[] memory p1,
-        Types.BN254G2Point[] memory p2
-    ) internal view returns (bool) {
+    function pairing(Types.BN254G1Point[] memory p1, Types.BN254G2Point[] memory p2) internal view returns (bool) {
         require(p1.length == p2.length, "BN254: pairing length mismatch");
         uint256 elements = p1.length;
         uint256 inputSize = elements * 6;
@@ -382,14 +355,7 @@ library BN254 {
         // Output: Single uint256 (1 = pairing valid, 0 = invalid) = 0x20 bytes
         // sub(gas(), 2000) reserves gas for post-call operations
         assembly {
-            success := staticcall(
-                sub(gas(), 2000),
-                8,
-                add(input, 0x20),
-                mul(inputSize, 0x20),
-                result,
-                0x20
-            )
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), result, 0x20)
         }
         if (!success) revert PairingFailed();
         return result[0] == 1;
@@ -402,7 +368,11 @@ library BN254 {
         Types.BN254G2Point memory b,
         Types.BN254G1Point memory c,
         Types.BN254G2Point memory d
-    ) internal view returns (bool) {
+    )
+        internal
+        view
+        returns (bool)
+    {
         Types.BN254G1Point[] memory p1 = new Types.BN254G1Point[](2);
         Types.BN254G2Point[] memory p2 = new Types.BN254G2Point[](2);
         p1[0] = a;
@@ -446,7 +416,11 @@ library BN254 {
         bytes memory message,
         Types.BN254G1Point memory signature,
         Types.BN254G2Point memory pubkey
-    ) internal view returns (bool) {
+    )
+        internal
+        view
+        returns (bool)
+    {
         Types.BN254G1Point memory msgPoint = hashToG1(message);
         Types.BN254G2Point memory g2 = Types.BN254G2Point([G2_X0, G2_X1], [G2_Y0, G2_Y1]);
         return pairingCheck(signature, g2, msgPoint, pubkey);
@@ -462,7 +436,11 @@ library BN254 {
         bytes memory message,
         Types.BN254G1Point memory aggregatedSignature,
         Types.BN254G2Point memory aggregatedPubkey
-    ) internal view returns (bool) {
+    )
+        internal
+        view
+        returns (bool)
+    {
         return verifyBls(message, aggregatedSignature, aggregatedPubkey);
     }
 

--- a/src/libraries/SlashingLib.sol
+++ b/src/libraries/SlashingLib.sol
@@ -32,10 +32,10 @@ library SlashingLib {
     // ═══════════════════════════════════════════════════════════════════════════
 
     enum SlashStatus {
-        Pending,    // Waiting for dispute window to pass
-        Disputed,   // Under dispute review
-        Executed,   // Slash was executed
-        Cancelled   // Slash was cancelled (dispute successful or admin override)
+        Pending, // Waiting for dispute window to pass
+        Disputed, // Under dispute review
+        Executed, // Slash was executed
+        Cancelled // Slash was cancelled (dispute successful or admin override)
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -44,29 +44,29 @@ library SlashingLib {
 
     /// @notice Pending slash proposal
     struct SlashProposal {
-        uint64 serviceId;           // Service where violation occurred
-        address operator;           // Operator to be slashed
-        address proposer;           // Who proposed the slash
-        uint16 slashBps;            // Original slash percentage (bps)
-        uint16 effectiveSlashBps;   // Slash percentage after exposure scaling
-        bytes32 evidence;           // Evidence hash (IPFS or other)
-        uint64 proposedAt;          // When slash was proposed
-        uint64 executeAfter;        // When slash can be executed
-        SlashStatus status;         // Current status
-        string disputeReason;       // Reason if disputed
+        uint64 serviceId; // Service where violation occurred
+        address operator; // Operator to be slashed
+        address proposer; // Who proposed the slash
+        uint16 slashBps; // Original slash percentage (bps)
+        uint16 effectiveSlashBps; // Slash percentage after exposure scaling
+        bytes32 evidence; // Evidence hash (IPFS or other)
+        uint64 proposedAt; // When slash was proposed
+        uint64 executeAfter; // When slash can be executed
+        SlashStatus status; // Current status
+        string disputeReason; // Reason if disputed
     }
 
     /// @notice Slashing configuration
     struct SlashConfig {
-        uint64 disputeWindow;       // Time before slash can be executed
-        bool instantSlashEnabled;   // Allow immediate slashing (for emergencies)
-        uint16 maxSlashBps;         // Maximum slash as % of stake (default 10000 = 100%)
+        uint64 disputeWindow; // Time before slash can be executed
+        bool instantSlashEnabled; // Allow immediate slashing (for emergencies)
+        uint16 maxSlashBps; // Maximum slash as % of stake (default 10000 = 100%)
     }
 
     /// @notice Slashing state storage
     struct SlashState {
-        uint64 nextSlashId;         // Auto-incrementing slash ID
-        SlashConfig config;         // Slashing configuration
+        uint64 nextSlashId; // Auto-incrementing slash ID
+        SlashConfig config; // Slashing configuration
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -84,30 +84,15 @@ library SlashingLib {
         uint64 executeAfter
     );
 
-    event SlashDisputed(
-        uint64 indexed slashId,
-        address indexed disputer,
-        string reason
-    );
+    event SlashDisputed(uint64 indexed slashId, address indexed disputer, string reason);
 
     event SlashExecuted(
-        uint64 indexed slashId,
-        uint64 indexed serviceId,
-        address indexed operator,
-        uint256 actualSlashed
+        uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, uint256 actualSlashed
     );
 
-    event SlashCancelled(
-        uint64 indexed slashId,
-        address indexed canceller,
-        string reason
-    );
+    event SlashCancelled(uint64 indexed slashId, address indexed canceller, string reason);
 
-    event SlashConfigUpdated(
-        uint64 disputeWindow,
-        bool instantSlashEnabled,
-        uint16 maxSlashBps
-    );
+    event SlashConfigUpdated(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
@@ -133,7 +118,9 @@ library SlashingLib {
         uint64 disputeWindow,
         bool instantSlashEnabled,
         uint16 maxSlashBps
-    ) internal {
+    )
+        internal
+    {
         if (disputeWindow < MIN_DISPUTE_WINDOW || disputeWindow > MAX_DISPUTE_WINDOW) {
             revert Errors.InvalidSlashConfig();
         }
@@ -142,9 +129,7 @@ library SlashingLib {
         }
 
         state.config = SlashConfig({
-            disputeWindow: disputeWindow,
-            instantSlashEnabled: instantSlashEnabled,
-            maxSlashBps: maxSlashBps
+            disputeWindow: disputeWindow, instantSlashEnabled: instantSlashEnabled, maxSlashBps: maxSlashBps
         });
 
         emit SlashConfigUpdated(disputeWindow, instantSlashEnabled, maxSlashBps);
@@ -158,10 +143,7 @@ library SlashingLib {
     /// @param slashBps Base slash percentage
     /// @param exposureBps Operator's exposure in basis points
     /// @return Effective slash percentage
-    function calculateEffectiveSlashBps(
-        uint16 slashBps,
-        uint16 exposureBps
-    ) internal pure returns (uint16) {
+    function calculateEffectiveSlashBps(uint16 slashBps, uint16 exposureBps) internal pure returns (uint16) {
         return uint16((uint256(slashBps) * exposureBps) / BPS_DENOMINATOR);
     }
 
@@ -169,10 +151,7 @@ library SlashingLib {
     /// @param slashBps Proposed slash percentage
     /// @param maxSlashBps Maximum slash percentage
     /// @return Capped slash percentage
-    function capSlashBps(
-        uint16 slashBps,
-        uint16 maxSlashBps
-    ) internal pure returns (uint16) {
+    function capSlashBps(uint16 slashBps, uint16 maxSlashBps) internal pure returns (uint16) {
         return slashBps > maxSlashBps ? maxSlashBps : slashBps;
     }
 
@@ -201,7 +180,10 @@ library SlashingLib {
         uint16 exposureBps,
         bytes32 evidence,
         bool instant
-    ) internal returns (uint64 slashId) {
+    )
+        internal
+        returns (uint64 slashId)
+    {
         if (slashBps == 0) revert Errors.InvalidSlashAmount();
         if (operator == address(0)) revert Errors.ZeroAddress();
 
@@ -235,16 +217,7 @@ library SlashingLib {
             disputeReason: ""
         });
 
-        emit SlashProposed(
-            slashId,
-            serviceId,
-            operator,
-            proposer,
-            slashBps,
-            effectiveSlashBps,
-            evidence,
-            executeAfter
-        );
+        emit SlashProposed(slashId, serviceId, operator, proposer, slashBps, effectiveSlashBps, evidence, executeAfter);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -261,7 +234,9 @@ library SlashingLib {
         uint64 slashId,
         address disputer,
         string memory reason
-    ) internal {
+    )
+        internal
+    {
         SlashProposal storage proposal = proposals[slashId];
 
         if (proposal.operator == address(0)) {
@@ -299,8 +274,7 @@ library SlashingLib {
         // M-6 FIX: Add buffer to protect against timestamp manipulation
         // Miners can adjust block.timestamp within ~15 seconds, so we require
         // the timestamp to exceed executeAfter + buffer
-        return proposal.status == SlashStatus.Pending &&
-               block.timestamp >= proposal.executeAfter + TIMESTAMP_BUFFER;
+        return proposal.status == SlashStatus.Pending && block.timestamp >= proposal.executeAfter + TIMESTAMP_BUFFER;
     }
 
     /// @notice Mark a slash as executed
@@ -312,7 +286,10 @@ library SlashingLib {
         mapping(uint64 => SlashProposal) storage proposals,
         uint64 slashId,
         uint256 actualSlashed
-    ) internal returns (SlashProposal storage proposal) {
+    )
+        internal
+        returns (SlashProposal storage proposal)
+    {
         proposal = proposals[slashId];
 
         if (proposal.operator == address(0)) {
@@ -325,12 +302,7 @@ library SlashingLib {
 
         proposal.status = SlashStatus.Executed;
 
-        emit SlashExecuted(
-            slashId,
-            proposal.serviceId,
-            proposal.operator,
-            actualSlashed
-        );
+        emit SlashExecuted(slashId, proposal.serviceId, proposal.operator, actualSlashed);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -347,7 +319,9 @@ library SlashingLib {
         uint64 slashId,
         address canceller,
         string memory reason
-    ) internal {
+    )
+        internal
+    {
         SlashProposal storage proposal = proposals[slashId];
 
         if (proposal.operator == address(0)) {
@@ -382,12 +356,15 @@ library SlashingLib {
         address operator,
         uint64 fromId,
         uint64 toId
-    ) internal view returns (uint64[] memory ids) {
+    )
+        internal
+        view
+        returns (uint64[] memory ids)
+    {
         // First pass: count matching
         uint64 count = 0;
         for (uint64 i = fromId; i < toId; i++) {
-            if (proposals[i].operator == operator &&
-                proposals[i].status == SlashStatus.Pending) {
+            if (proposals[i].operator == operator && proposals[i].status == SlashStatus.Pending) {
                 count++;
             }
         }
@@ -396,11 +373,9 @@ library SlashingLib {
         ids = new uint64[](count);
         uint64 idx = 0;
         for (uint64 i = fromId; i < toId && idx < count; i++) {
-            if (proposals[i].operator == operator &&
-                proposals[i].status == SlashStatus.Pending) {
+            if (proposals[i].operator == operator && proposals[i].status == SlashStatus.Pending) {
                 ids[idx++] = i;
             }
         }
     }
-
 }

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -539,11 +539,11 @@ library Types {
     // RFQ (Request For Quote) - SIGNED PRICE QUOTES
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Resource pricing for a quote
-    struct ResourcePricing {
-        string kind; // Resource type (CPU, MemoryMB, StorageMB, GPU, etc.)
-        uint64 count; // Quantity
-        uint256 pricePerUnit; // Price per unit in payment token
+    /// @notice Resource commitment from an operator (part of signed quote)
+    /// @dev kind: 0=CPU, 1=MemoryMB, 2=StorageMB, 3=NetworkEgressMB, 4=NetworkIngressMB, 5=GPU
+    struct ResourceCommitment {
+        uint8 kind; // Resource type
+        uint64 count; // Quantity of the resource
     }
 
     /// @notice Quote details from an operator
@@ -554,6 +554,7 @@ library Types {
         uint64 timestamp; // When quote was generated
         uint64 expiry; // Quote expiry timestamp
         AssetSecurityCommitment[] securityCommitments; // Operator's security commitments
+        ResourceCommitment[] resourceCommitments; // Operator's resource commitments
     }
 
     /// @notice Signed quote from an operator

--- a/src/oracles/ChainlinkOracle.sol
+++ b/src/oracles/ChainlinkOracle.sol
@@ -1,20 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IPriceOracle, IPriceOracleAdmin} from "./interfaces/IPriceOracle.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import { IPriceOracle, IPriceOracleAdmin } from "./interfaces/IPriceOracle.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title AggregatorV3Interface
 /// @notice Chainlink price feed interface
 interface AggregatorV3Interface {
     function decimals() external view returns (uint8);
-    function latestRoundData() external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    );
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 }
 
 /// @title IERC20Decimals
@@ -127,7 +124,12 @@ contract ChainlinkOracle is IPriceOracle, IPriceOracleAdmin, Ownable {
     function batchToUSD(
         address[] calldata tokens,
         uint256[] calldata amounts
-    ) external view override returns (uint256 totalUsd) {
+    )
+        external
+        view
+        override
+        returns (uint256 totalUsd)
+    {
         require(tokens.length == amounts.length, "Length mismatch");
 
         for (uint256 i = 0; i < tokens.length; i++) {
@@ -208,13 +210,7 @@ contract ChainlinkOracle is IPriceOracle, IPriceOracleAdmin, Ownable {
 
         AggregatorV3Interface aggregator = AggregatorV3Interface(feed);
 
-        try aggregator.latestRoundData() returns (
-            uint80,
-            int256 answer,
-            uint256,
-            uint256 updatedAt,
-            uint80
-        ) {
+        try aggregator.latestRoundData() returns (uint80, int256 answer, uint256, uint256 updatedAt, uint80) {
             // Validate price
             if (answer <= 0) {
                 revert InvalidPrice(token, answer);

--- a/src/oracles/interfaces/IPriceOracle.sol
+++ b/src/oracles/interfaces/IPriceOracle.sol
@@ -31,10 +31,10 @@ interface IPriceOracle {
 
     /// @notice Price data with metadata
     struct PriceData {
-        uint256 price;          // Price in USD with 18 decimals
-        uint256 updatedAt;      // Timestamp of last update
-        uint8 decimals;         // Decimals of the underlying token
-        bool isValid;           // Whether price is considered valid
+        uint256 price; // Price in USD with 18 decimals
+        uint256 updatedAt; // Timestamp of last update
+        uint8 decimals; // Decimals of the underlying token
+        bool isValid; // Whether price is considered valid
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -80,10 +80,7 @@ interface IPriceOracle {
     /// @param amounts Array of amounts in each token's native decimals
     /// @return totalUsd Total USD value with 18 decimals
     // forge-lint: disable-next-line(mixed-case-function)
-    function batchToUSD(
-        address[] calldata tokens,
-        uint256[] calldata amounts
-    ) external view returns (uint256 totalUsd);
+    function batchToUSD(address[] calldata tokens, uint256[] calldata amounts) external view returns (uint256 totalUsd);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // CONFIGURATION

--- a/src/rewards/StreamingPaymentManager.sol
+++ b/src/rewards/StreamingPaymentManager.sol
@@ -63,24 +63,12 @@ contract StreamingPaymentManager is
         uint64 endTime
     );
 
-    event StreamingDrip(
-        uint64 indexed serviceId,
-        address indexed operator,
-        uint256 amount,
-        uint256 totalDistributed
-    );
+    event StreamingDrip(uint64 indexed serviceId, address indexed operator, uint256 amount, uint256 totalDistributed);
 
-    event StreamingPaymentCompleted(
-        uint64 indexed serviceId,
-        address indexed operator,
-        uint256 totalAmount
-    );
+    event StreamingPaymentCompleted(uint64 indexed serviceId, address indexed operator, uint256 totalAmount);
 
     event StreamingPaymentCancelled(
-        uint64 indexed serviceId,
-        address indexed operator,
-        uint256 refundedAmount,
-        address refundRecipient
+        uint64 indexed serviceId, address indexed operator, uint256 refundedAmount, address refundRecipient
     );
 
     event TangleConfigured(address indexed tangle);
@@ -102,11 +90,7 @@ contract StreamingPaymentManager is
         _disableInitializers();
     }
 
-    function initialize(
-        address admin,
-        address tangle_,
-        address distributor_
-    ) external initializer {
+    function initialize(address admin, address tangle_, address distributor_) external initializer {
         __UUPSUpgradeable_init();
         __AccessControl_init();
         __ReentrancyGuard_init();
@@ -147,7 +131,12 @@ contract StreamingPaymentManager is
         uint256 amount,
         uint64 startTime,
         uint64 endTime
-    ) external payable override onlyRole(DISTRIBUTOR_ROLE) {
+    )
+        external
+        payable
+        override
+        onlyRole(DISTRIBUTOR_ROLE)
+    {
         if (amount == 0) return;
         if (endTime <= startTime) return;
 
@@ -236,16 +225,14 @@ contract StreamingPaymentManager is
 
     /// @notice Drip a specific stream and return chunk info for distribution
     /// @dev Called by ServiceFeeDistributor to get the drip amount. Transfers dripped tokens to caller.
-    function dripAndGetChunk(uint64 serviceId, address operator)
+    function dripAndGetChunk(
+        uint64 serviceId,
+        address operator
+    )
         external
         override
         onlyRole(DISTRIBUTOR_ROLE)
-        returns (
-            uint256 amount,
-            uint256 durationSeconds,
-            uint64 blueprintId,
-            address paymentToken
-        )
+        returns (uint256 amount, uint256 durationSeconds, uint64 blueprintId, address paymentToken)
     {
         StreamingPayment storage p = streamingPayments[serviceId][operator];
         blueprintId = p.blueprintId;
@@ -299,18 +286,13 @@ contract StreamingPaymentManager is
         }
     }
 
-
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE TERMINATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Called when a service is terminated - refunds remaining payments
     /// @dev Can be called by either Tangle directly or via ServiceFeeDistributor
-    function onServiceTerminated(uint64 serviceId, address refundRecipient)
-        external
-        override
-        nonReentrant
-    {
+    function onServiceTerminated(uint64 serviceId, address refundRecipient) external override nonReentrant {
         if (msg.sender != tangle && msg.sender != distributor) revert NotAuthorized();
         if (refundRecipient == address(0)) return;
 
@@ -351,7 +333,10 @@ contract StreamingPaymentManager is
         return _operatorActiveStreams[operator];
     }
 
-    function getStreamingPayment(uint64 serviceId, address operator)
+    function getStreamingPayment(
+        uint64 serviceId,
+        address operator
+    )
         external
         view
         override
@@ -411,7 +396,11 @@ contract StreamingPaymentManager is
     /// @dev Useful for keepers to check if drip operations are worthwhile
     /// @param operator The operator to check
     /// @return totalPending Total drippable amount, streamCount Number of active streams
-    function pendingDripForOperator(address operator) external view returns (uint256 totalPending, uint256 streamCount) {
+    function pendingDripForOperator(address operator)
+        external
+        view
+        returns (uint256 totalPending, uint256 streamCount)
+    {
         uint64[] storage streams = _operatorActiveStreams[operator];
         streamCount = streams.length;
 
@@ -474,8 +463,8 @@ contract StreamingPaymentManager is
         }
     }
 
-    function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) {}
+    function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) { }
 
     /// @notice Receive ETH for native token streams
-    receive() external payable {}
+    receive() external payable { }
 }

--- a/src/rewards/TangleMetrics.sol
+++ b/src/rewards/TangleMetrics.sol
@@ -10,12 +10,7 @@ import { IMetricsRecorder } from "../interfaces/IMetricsRecorder.sol";
 /// @title TangleMetrics
 /// @notice Lightweight protocol activity recorder for reward distribution
 /// @dev Records events and maintains minimal aggregates for RewardVaults
-contract TangleMetrics is
-    Initializable,
-    UUPSUpgradeable,
-    AccessControlUpgradeable,
-    IMetricsRecorder
-{
+contract TangleMetrics is Initializable, UUPSUpgradeable, AccessControlUpgradeable, IMetricsRecorder {
     // ═══════════════════════════════════════════════════════════════════════════
     // ROLES
     // ═══════════════════════════════════════════════════════════════════════════
@@ -29,46 +24,19 @@ contract TangleMetrics is
 
     // Staking
     event Staked(
-        address indexed delegator,
-        address indexed operator,
-        address indexed asset,
-        uint256 amount,
-        uint256 timestamp
+        address indexed delegator, address indexed operator, address indexed asset, uint256 amount, uint256 timestamp
     );
     event Unstaked(
-        address indexed delegator,
-        address indexed operator,
-        address indexed asset,
-        uint256 amount,
-        uint256 timestamp
+        address indexed delegator, address indexed operator, address indexed asset, uint256 amount, uint256 timestamp
     );
 
     // Operators
-    event OperatorRegistered(
-        address indexed operator,
-        address indexed asset,
-        uint256 amount,
-        uint256 timestamp
-    );
-    event HeartbeatReceived(
-        address indexed operator,
-        uint64 indexed serviceId,
-        uint64 timestamp,
-        uint256 blockNumber
-    );
+    event OperatorRegistered(address indexed operator, address indexed asset, uint256 amount, uint256 timestamp);
+    event HeartbeatReceived(address indexed operator, uint64 indexed serviceId, uint64 timestamp, uint256 blockNumber);
     event JobCompleted(
-        address indexed operator,
-        uint64 indexed serviceId,
-        uint64 jobCallId,
-        bool success,
-        uint256 timestamp
+        address indexed operator, uint64 indexed serviceId, uint64 jobCallId, bool success, uint256 timestamp
     );
-    event OperatorSlashed(
-        address indexed operator,
-        uint64 indexed serviceId,
-        uint256 amount,
-        uint256 timestamp
-    );
+    event OperatorSlashed(address indexed operator, uint64 indexed serviceId, uint256 amount, uint256 timestamp);
 
     // Services
     event ServiceCreated(
@@ -78,38 +46,17 @@ contract TangleMetrics is
         uint256 operatorCount,
         uint256 timestamp
     );
-    event ServiceTerminated(
-        uint64 indexed serviceId,
-        uint256 duration,
-        uint256 timestamp
-    );
-    event JobCalled(
-        uint64 indexed serviceId,
-        address indexed caller,
-        uint64 jobCallId,
-        uint256 timestamp
-    );
+    event ServiceTerminated(uint64 indexed serviceId, uint256 duration, uint256 timestamp);
+    event JobCalled(uint64 indexed serviceId, address indexed caller, uint64 jobCallId, uint256 timestamp);
 
     // Payments
     event PaymentRecorded(
-        address indexed payer,
-        uint64 indexed serviceId,
-        address indexed token,
-        uint256 amount,
-        uint256 timestamp
+        address indexed payer, uint64 indexed serviceId, address indexed token, uint256 amount, uint256 timestamp
     );
 
     // Blueprints
-    event BlueprintCreated(
-        uint64 indexed blueprintId,
-        address indexed developer,
-        uint256 timestamp
-    );
-    event BlueprintRegistration(
-        uint64 indexed blueprintId,
-        address indexed operator,
-        uint256 timestamp
-    );
+    event BlueprintCreated(uint64 indexed blueprintId, address indexed developer, uint256 timestamp);
+    event BlueprintRegistration(uint64 indexed blueprintId, address indexed operator, uint256 timestamp);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // AGGREGATE STORAGE - Minimal state for reward calculations
@@ -217,7 +164,10 @@ contract TangleMetrics is
         address operator,
         address asset,
         uint256 amount
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         totalStakedByAsset[asset] += amount;
         delegatorStakeByAsset[delegator][asset] += amount;
         operatorTotalStake[operator] += amount;
@@ -231,7 +181,10 @@ contract TangleMetrics is
         address operator,
         address asset,
         uint256 amount
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         totalStakedByAsset[asset] -= amount;
         delegatorStakeByAsset[delegator][asset] -= amount;
         operatorTotalStake[operator] -= amount;
@@ -248,7 +201,10 @@ contract TangleMetrics is
         address operator,
         address asset,
         uint256 amount
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         totalStakedByAsset[asset] += amount;
         operatorTotalStake[operator] += amount;
 
@@ -256,11 +212,7 @@ contract TangleMetrics is
     }
 
     /// @inheritdoc IMetricsRecorder
-    function recordHeartbeat(
-        address operator,
-        uint64 serviceId,
-        uint64 timestamp
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordHeartbeat(address operator, uint64 serviceId, uint64 timestamp) external onlyRole(RECORDER_ROLE) {
         operatorHeartbeats[operator]++;
         operatorLastHeartbeat[operator] = timestamp;
 
@@ -273,7 +225,10 @@ contract TangleMetrics is
         uint64 serviceId,
         uint64 jobCallId,
         bool success
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         operatorJobsCompleted[operator]++;
         if (success) {
             operatorJobsSuccessful[operator]++;
@@ -283,11 +238,7 @@ contract TangleMetrics is
     }
 
     /// @inheritdoc IMetricsRecorder
-    function recordSlash(
-        address operator,
-        uint64 serviceId,
-        uint256 amount
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordSlash(address operator, uint64 serviceId, uint256 amount) external onlyRole(RECORDER_ROLE) {
         emit OperatorSlashed(operator, serviceId, amount, block.timestamp);
     }
 
@@ -301,7 +252,10 @@ contract TangleMetrics is
         uint64 blueprintId,
         address owner,
         uint256 operatorCount
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         totalServicesCreated++;
 
         // Track service to blueprint mapping
@@ -320,19 +274,12 @@ contract TangleMetrics is
     }
 
     /// @inheritdoc IMetricsRecorder
-    function recordServiceTerminated(
-        uint64 serviceId,
-        uint256 duration
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordServiceTerminated(uint64 serviceId, uint256 duration) external onlyRole(RECORDER_ROLE) {
         emit ServiceTerminated(serviceId, duration, block.timestamp);
     }
 
     /// @inheritdoc IMetricsRecorder
-    function recordJobCall(
-        uint64 serviceId,
-        address caller,
-        uint64 jobCallId
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordJobCall(uint64 serviceId, address caller, uint64 jobCallId) external onlyRole(RECORDER_ROLE) {
         totalJobsCalled++;
 
         // Update blueprint and developer job counts
@@ -359,7 +306,10 @@ contract TangleMetrics is
         uint64 serviceId,
         address token,
         uint256 amount
-    ) external onlyRole(RECORDER_ROLE) {
+    )
+        external
+        onlyRole(RECORDER_ROLE)
+    {
         totalFeesPaid[payer] += amount;
         totalPaymentsRecorded++;
 
@@ -382,10 +332,7 @@ contract TangleMetrics is
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @inheritdoc IMetricsRecorder
-    function recordBlueprintCreated(
-        uint64 blueprintId,
-        address developer
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordBlueprintCreated(uint64 blueprintId, address developer) external onlyRole(RECORDER_ROLE) {
         // Store blueprint developer
         blueprintDeveloper[blueprintId] = developer;
 
@@ -396,10 +343,7 @@ contract TangleMetrics is
     }
 
     /// @inheritdoc IMetricsRecorder
-    function recordBlueprintRegistration(
-        uint64 blueprintId,
-        address operator
-    ) external onlyRole(RECORDER_ROLE) {
+    function recordBlueprintRegistration(uint64 blueprintId, address operator) external onlyRole(RECORDER_ROLE) {
         // Increment operator count for this blueprint
         blueprintOperatorCount[blueprintId]++;
 
@@ -418,7 +362,7 @@ contract TangleMetrics is
     function getOperatorSuccessRate(address operator) external view returns (uint256) {
         uint256 completed = operatorJobsCompleted[operator];
         if (completed == 0) return 0;
-        return (operatorJobsSuccessful[operator] * 10000) / completed;
+        return (operatorJobsSuccessful[operator] * 10_000) / completed;
     }
 
     /// @notice Check if operator heartbeat is recent
@@ -435,13 +379,11 @@ contract TangleMetrics is
     /// @return jobCount Number of jobs completed
     /// @return operatorCount Number of operators registered
     /// @return totalFees Total fees earned
-    function getBlueprintStats(uint64 blueprintId) external view returns (
-        address developer,
-        uint256 serviceCount,
-        uint256 jobCount,
-        uint256 operatorCount,
-        uint256 totalFees
-    ) {
+    function getBlueprintStats(uint64 blueprintId)
+        external
+        view
+        returns (address developer, uint256 serviceCount, uint256 jobCount, uint256 operatorCount, uint256 totalFees)
+    {
         return (
             blueprintDeveloper[blueprintId],
             blueprintServiceCount[blueprintId],
@@ -457,12 +399,11 @@ contract TangleMetrics is
     /// @return serviceCount Total services across all blueprints
     /// @return jobCount Total jobs across all blueprints
     /// @return totalFees Total fees earned across all blueprints
-    function getDeveloperStats(address developer) external view returns (
-        uint256 blueprintCount,
-        uint256 serviceCount,
-        uint256 jobCount,
-        uint256 totalFees
-    ) {
+    function getDeveloperStats(address developer)
+        external
+        view
+        returns (uint256 blueprintCount, uint256 serviceCount, uint256 jobCount, uint256 totalFees)
+    {
         return (
             developerBlueprintCount[developer],
             developerTotalServices[developer],
@@ -475,5 +416,5 @@ contract TangleMetrics is
     // UPGRADES
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) {}
+    function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) { }
 }

--- a/src/staking/DelegationStorage.sol
+++ b/src/staking/DelegationStorage.sol
@@ -17,7 +17,7 @@ abstract contract DelegationStorage {
     // ═══════════════════════════════════════════════════════════════════════════
 
     uint256 public constant PRECISION = 1e18;
-    uint256 public constant BPS_DENOMINATOR = 10000;
+    uint256 public constant BPS_DENOMINATOR = 10_000;
 
     // C-1 FIX: Virtual shares/assets offset to prevent first depositor inflation attack.
     // Following OpenZeppelin ERC4626 pattern. The offset makes it economically infeasible
@@ -34,11 +34,11 @@ abstract contract DelegationStorage {
     uint64 public constant LOCK_SIX_MONTHS = 180 days;
 
     // Lock multipliers in BPS (10000 = 1x)
-    uint16 public constant MULTIPLIER_NONE = 10000;
-    uint16 public constant MULTIPLIER_ONE_MONTH = 11000;
-    uint16 public constant MULTIPLIER_TWO_MONTHS = 12000;
-    uint16 public constant MULTIPLIER_THREE_MONTHS = 13000;
-    uint16 public constant MULTIPLIER_SIX_MONTHS = 16000;
+    uint16 public constant MULTIPLIER_NONE = 10_000;
+    uint16 public constant MULTIPLIER_ONE_MONTH = 11_000;
+    uint16 public constant MULTIPLIER_TWO_MONTHS = 12_000;
+    uint16 public constant MULTIPLIER_THREE_MONTHS = 13_000;
+    uint16 public constant MULTIPLIER_SIX_MONTHS = 16_000;
 
     // M-9 FIX: Minimum lock amount to prevent lock multiplier bypass via small deposits
     // Set to 0.01 ETH (1e16 wei) equivalent to prevent dust attacks while remaining accessible
@@ -222,7 +222,8 @@ abstract contract DelegationStorage {
 
     /// @notice Track shares per blueprint for Fixed mode delegations
     /// @dev delegator => operator => assetHash => blueprintId => shares
-    mapping(address => mapping(address => mapping(bytes32 => mapping(uint64 => uint256)))) internal _delegatorBlueprintShares;
+    mapping(address => mapping(address => mapping(bytes32 => mapping(uint64 => uint256)))) internal
+        _delegatorBlueprintShares;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EXTERNAL INTEGRATIONS
@@ -266,11 +267,9 @@ abstract contract DelegationStorage {
 
     function _validateLockMultiplier(Types.LockMultiplier multiplier) internal pure {
         if (
-            multiplier == Types.LockMultiplier.None ||
-            multiplier == Types.LockMultiplier.OneMonth ||
-            multiplier == Types.LockMultiplier.TwoMonths ||
-            multiplier == Types.LockMultiplier.ThreeMonths ||
-            multiplier == Types.LockMultiplier.SixMonths
+            multiplier == Types.LockMultiplier.None || multiplier == Types.LockMultiplier.OneMonth
+                || multiplier == Types.LockMultiplier.TwoMonths || multiplier == Types.LockMultiplier.ThreeMonths
+                || multiplier == Types.LockMultiplier.SixMonths
         ) {
             return;
         }
@@ -294,7 +293,11 @@ abstract contract DelegationStorage {
         uint256 originalAmount,
         uint256 snapshotFactor,
         uint256 currentFactor
-    ) internal pure returns (uint256 effectiveAmount) {
+    )
+        internal
+        pure
+        returns (uint256 effectiveAmount)
+    {
         if (snapshotFactor == 0 || currentFactor >= snapshotFactor) {
             return originalAmount; // No slash occurred since request
         }

--- a/src/staking/DepositManager.sol
+++ b/src/staking/DepositManager.sol
@@ -19,18 +19,8 @@ abstract contract DepositManager is DelegationStorage {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event Deposited(
-        address indexed delegator,
-        address indexed token,
-        uint256 amount,
-        Types.LockMultiplier lock
-    );
-    event WithdrawScheduled(
-        address indexed delegator,
-        address indexed token,
-        uint256 amount,
-        uint64 readyRound
-    );
+    event Deposited(address indexed delegator, address indexed token, uint256 amount, Types.LockMultiplier lock);
+    event WithdrawScheduled(address indexed delegator, address indexed token, uint256 amount, uint64 readyRound);
     event Withdrawn(address indexed delegator, address indexed token, uint256 amount);
     event ExpiredLocksHarvested(address indexed delegator, address indexed token, uint256 count, uint256 totalAmount);
 
@@ -40,21 +30,13 @@ abstract contract DepositManager is DelegationStorage {
 
     /// @notice Deposit native token
     function _depositNative() internal {
-        _depositAsset(
-            Types.Asset(Types.AssetKind.Native, address(0)),
-            msg.value,
-            Types.LockMultiplier.None
-        );
+        _depositAsset(Types.Asset(Types.AssetKind.Native, address(0)), msg.value, Types.LockMultiplier.None);
     }
 
     /// @notice Deposit native token with lock
     /// @param lockMultiplier Lock duration for bonus multiplier
     function _depositNativeWithLock(Types.LockMultiplier lockMultiplier) internal {
-        _depositAsset(
-            Types.Asset(Types.AssetKind.Native, address(0)),
-            msg.value,
-            lockMultiplier
-        );
+        _depositAsset(Types.Asset(Types.AssetKind.Native, address(0)), msg.value, lockMultiplier);
     }
 
     /// @notice Deposit ERC20 token
@@ -64,30 +46,18 @@ abstract contract DepositManager is DelegationStorage {
         if (token == address(0)) revert DelegationErrors.AssetNotEnabled(address(0));
 
         uint256 shares = _handleErc20Deposit(token, amount);
-        _depositAsset(
-            Types.Asset(Types.AssetKind.ERC20, token),
-            shares,
-            Types.LockMultiplier.None
-        );
+        _depositAsset(Types.Asset(Types.AssetKind.ERC20, token), shares, Types.LockMultiplier.None);
     }
 
     /// @notice Deposit ERC20 token with lock
     /// @param token Token address
     /// @param amount Amount to deposit
     /// @param lockMultiplier Lock duration for bonus multiplier
-    function _depositErc20WithLock(
-        address token,
-        uint256 amount,
-        Types.LockMultiplier lockMultiplier
-    ) internal {
+    function _depositErc20WithLock(address token, uint256 amount, Types.LockMultiplier lockMultiplier) internal {
         if (token == address(0)) revert DelegationErrors.AssetNotEnabled(address(0));
 
         uint256 shares = _handleErc20Deposit(token, amount);
-        _depositAsset(
-            Types.Asset(Types.AssetKind.ERC20, token),
-            shares,
-            lockMultiplier
-        );
+        _depositAsset(Types.Asset(Types.AssetKind.ERC20, token), shares, lockMultiplier);
     }
 
     /// @notice Handle ERC20 deposit through adapter or directly
@@ -114,11 +84,7 @@ abstract contract DepositManager is DelegationStorage {
     }
 
     /// @notice Internal deposit logic
-    function _depositAsset(
-        Types.Asset memory asset,
-        uint256 amount,
-        Types.LockMultiplier lockMultiplier
-    ) internal {
+    function _depositAsset(Types.Asset memory asset, uint256 amount, Types.LockMultiplier lockMultiplier) internal {
         if (amount == 0) revert DelegationErrors.ZeroAmount();
 
         bytes32 assetHash = _assetHash(asset);
@@ -145,11 +111,11 @@ abstract contract DepositManager is DelegationStorage {
                 revert DelegationErrors.BelowMinimumLockAmount(MIN_LOCK_AMOUNT, amount);
             }
             uint64 lockDuration = _getLockDuration(lockMultiplier);
-            _depositLocks[msg.sender][assetHash].push(Types.LockInfo({
-                amount: amount,
-                multiplier: lockMultiplier,
-                expiryBlock: uint64(block.number) + lockDuration
-            }));
+            _depositLocks[msg.sender][assetHash].push(
+                Types.LockInfo({
+                    amount: amount, multiplier: lockMultiplier, expiryBlock: uint64(block.number) + lockDuration
+                })
+            );
         }
 
         emit Deposited(msg.sender, asset.token, amount, lockMultiplier);
@@ -186,11 +152,9 @@ abstract contract DepositManager is DelegationStorage {
 
         dep.amount -= amount;
 
-        _withdrawRequests[msg.sender].push(Types.WithdrawRequest({
-            asset: asset,
-            amount: amount,
-            requestedRound: currentRound
-        }));
+        _withdrawRequests[msg.sender].push(
+            Types.WithdrawRequest({ asset: asset, amount: amount, requestedRound: currentRound })
+        );
 
         emit WithdrawScheduled(msg.sender, token, amount, currentRound + leaveDelegatorsDelay);
     }
@@ -217,7 +181,9 @@ abstract contract DepositManager is DelegationStorage {
                 totalWithdrawn += requests[i].amount;
                 readyCount++;
             }
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
 
         // Remove processed requests from storage while preserving FIFO semantics
@@ -230,7 +196,9 @@ abstract contract DepositManager is DelegationStorage {
                     }
                     writeIndex++;
                 }
-                unchecked { ++i; }
+                unchecked {
+                    ++i;
+                }
             }
             while (requests.length > writeIndex) {
                 requests.pop();
@@ -254,7 +222,9 @@ abstract contract DepositManager is DelegationStorage {
                 config.currentDeposits = 0;
             }
             emit Withdrawn(msg.sender, readyAssets[i].token, readyAmounts[i]);
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -265,10 +235,7 @@ abstract contract DepositManager is DelegationStorage {
     /// @notice Get deposit for a delegator and token
     /// @param delegator Delegator address
     /// @param token Token address (address(0) for native)
-    function _getDeposit(
-        address delegator,
-        address token
-    ) internal view returns (Types.Deposit memory) {
+    function _getDeposit(address delegator, address token) internal view returns (Types.Deposit memory) {
         Types.Asset memory asset = token == address(0)
             ? Types.Asset(Types.AssetKind.Native, address(0))
             : Types.Asset(Types.AssetKind.ERC20, token);
@@ -278,35 +245,29 @@ abstract contract DepositManager is DelegationStorage {
     /// @notice Get locked amount for a delegator and asset
     /// @param delegator Delegator address
     /// @param assetHash Hash of the asset
-    function _getLockedAmount(
-        address delegator,
-        bytes32 assetHash
-    ) internal view returns (uint256 locked) {
+    function _getLockedAmount(address delegator, bytes32 assetHash) internal view returns (uint256 locked) {
         Types.LockInfo[] storage locks = _depositLocks[delegator][assetHash];
         uint256 locksLength = locks.length;
         for (uint256 i = 0; i < locksLength;) {
             if (locks[i].expiryBlock > block.number) {
                 locked += locks[i].amount;
             }
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
     }
 
     /// @notice Get pending withdrawals for a delegator
     /// @param delegator Delegator address
-    function _getPendingWithdrawals(
-        address delegator
-    ) internal view returns (Types.WithdrawRequest[] memory) {
+    function _getPendingWithdrawals(address delegator) internal view returns (Types.WithdrawRequest[] memory) {
         return _withdrawRequests[delegator];
     }
 
     /// @notice Get lock info for a delegator and token
     /// @param delegator Delegator address
     /// @param token Token address
-    function _getLocks(
-        address delegator,
-        address token
-    ) internal view returns (Types.LockInfo[] memory) {
+    function _getLocks(address delegator, address token) internal view returns (Types.LockInfo[] memory) {
         Types.Asset memory asset = token == address(0)
             ? Types.Asset(Types.AssetKind.Native, address(0))
             : Types.Asset(Types.AssetKind.ERC20, token);
@@ -356,7 +317,10 @@ abstract contract DepositManager is DelegationStorage {
     function _harvestExpiredLocks(
         address delegator,
         Types.Asset memory asset
-    ) internal returns (uint256 count, uint256 totalAmount) {
+    )
+        internal
+        returns (uint256 count, uint256 totalAmount)
+    {
         bytes32 assetHash = _assetHash(asset);
         Types.LockInfo[] storage locks = _depositLocks[delegator][assetHash];
 

--- a/src/staking/LiquidDelegationFactory.sol
+++ b/src/staking/LiquidDelegationFactory.sol
@@ -77,7 +77,10 @@ contract LiquidDelegationFactory is Ownable {
         address operator,
         address asset,
         uint64[] calldata blueprintIds
-    ) external returns (address vault) {
+    )
+        external
+        returns (address vault)
+    {
         // Verify operator is active
         if (!staking.isOperatorActive(operator)) {
             revert OperatorNotActive();
@@ -92,21 +95,10 @@ contract LiquidDelegationFactory is Ownable {
         }
 
         // Generate name and symbol
-        (string memory name, string memory symbol) = _generateTokenMetadata(
-            operator,
-            asset,
-            blueprintIds
-        );
+        (string memory name, string memory symbol) = _generateTokenMetadata(operator, asset, blueprintIds);
 
         // Deploy vault
-        vault = address(new LiquidDelegationVault(
-            staking,
-            operator,
-            IERC20(asset),
-            blueprintIds,
-            name,
-            symbol
-        ));
+        vault = address(new LiquidDelegationVault(staking, operator, IERC20(asset), blueprintIds, name, symbol));
 
         // Register vault
         vaults[vaultKey] = vault;
@@ -118,10 +110,7 @@ contract LiquidDelegationFactory is Ownable {
     }
 
     /// @notice Create a vault for all blueprints (convenience function)
-    function createAllBlueprintsVault(
-        address operator,
-        address asset
-    ) external returns (address vault) {
+    function createAllBlueprintsVault(address operator, address asset) external returns (address vault) {
         return this.createVault(operator, asset, new uint64[](0));
     }
 
@@ -134,17 +123,17 @@ contract LiquidDelegationFactory is Ownable {
         address operator,
         address asset,
         uint64[] calldata blueprintIds
-    ) public pure returns (bytes32) {
+    )
+        public
+        pure
+        returns (bytes32)
+    {
         // forge-lint: disable-next-line(asm-keccak256)
         return keccak256(abi.encode(operator, asset, blueprintIds));
     }
 
     /// @notice Get vault for a specific configuration
-    function getVault(
-        address operator,
-        address asset,
-        uint64[] calldata blueprintIds
-    ) external view returns (address) {
+    function getVault(address operator, address asset, uint64[] calldata blueprintIds) external view returns (address) {
         return vaults[computeVaultKey(operator, asset, blueprintIds)];
     }
 
@@ -192,7 +181,11 @@ contract LiquidDelegationFactory is Ownable {
         address operator,
         address asset,
         uint64[] calldata blueprintIds
-    ) internal view returns (string memory name, string memory symbol) {
+    )
+        internal
+        view
+        returns (string memory name, string memory symbol)
+    {
         // Get operator short address (last 4 bytes)
         bytes memory opBytes = abi.encodePacked(operator);
         string memory opShort = _toHexString(opBytes, 18, 20); // Last 2 bytes = 4 hex chars
@@ -221,24 +214,10 @@ contract LiquidDelegationFactory is Ownable {
         }
 
         // Generate name: "Liquid Delegation ETH Op-0x1234 All"
-        name = string(abi.encodePacked(
-            "Liquid Delegation ",
-            assetSymbol,
-            " Op-0x",
-            opShort,
-            " ",
-            bpSuffix
-        ));
+        name = string(abi.encodePacked("Liquid Delegation ", assetSymbol, " Op-0x", opShort, " ", bpSuffix));
 
         // Generate symbol: "ldETH-0x1234-All"
-        symbol = string(abi.encodePacked(
-            "ld",
-            assetSymbol,
-            "-0x",
-            opShort,
-            "-",
-            bpSuffix
-        ));
+        symbol = string(abi.encodePacked("ld", assetSymbol, "-0x", opShort, "-", bpSuffix));
     }
 
     /// @notice Convert bytes to hex string (partial)

--- a/src/staking/LiquidDelegationVault.sol
+++ b/src/staking/LiquidDelegationVault.sol
@@ -268,10 +268,7 @@ contract LiquidDelegationVault is ERC20, IERC7540Deposit, IERC7540Redeem, IERC75
         // Create request record
         requestId = _nextRequestId[controller]++;
         _redeemRequests[controller][requestId] = RedeemRequestData({
-            shares: shares,
-            unstakeShares: unstakeShares,
-            requestedRound: requestRound,
-            claimed: false
+            shares: shares, unstakeShares: unstakeShares, requestedRound: requestRound, claimed: false
         });
 
         emit RedeemRequest(controller, owner, requestId, msg.sender, shares);
@@ -354,11 +351,7 @@ contract LiquidDelegationVault is ERC20, IERC7540Deposit, IERC7540Redeem, IERC75
 
         // Execute the exact bond-less request and withdraw the resulting assets directly to the receiver.
         assets = staking.executeDelegatorUnstakeAndWithdraw(
-            operator,
-            address(asset),
-            req.unstakeShares,
-            req.requestedRound,
-            receiver
+            operator, address(asset), req.unstakeShares, req.requestedRound, receiver
         );
 
         emit Withdraw(msg.sender, receiver, controller, assets, shares);

--- a/src/staking/MultiAssetDelegation.sol
+++ b/src/staking/MultiAssetDelegation.sol
@@ -124,7 +124,7 @@ contract MultiAssetDelegation is
         _delegateTo(facet);
     }
 
-    receive() external payable {}
+    receive() external payable { }
 
     /// @notice Delegate call to target facet using low-level assembly
     /// @dev Assembly is used here for gas efficiency and to properly forward
@@ -143,7 +143,7 @@ contract MultiAssetDelegation is
             returndatacopy(0, 0, returndatasize())
             // Branch based on call result
             switch result
-            case 0 { revert(0, returndatasize()) }  // Call failed: revert with return data
+            case 0 { revert(0, returndatasize()) } // Call failed: revert with return data
             default { return(0, returndatasize()) } // Call succeeded: return with return data
         }
     }

--- a/src/staking/OperatorManager.sol
+++ b/src/staking/OperatorManager.sol
@@ -56,10 +56,7 @@ abstract contract OperatorManager is DelegationStorage {
 
         _operators.add(msg.sender);
         _operatorMetadata[msg.sender] = Types.OperatorMetadata({
-            stake: msg.value,
-            delegationCount: 0,
-            status: Types.OperatorStatus.Active,
-            leavingRound: 0
+            stake: msg.value, delegationCount: 0, status: Types.OperatorStatus.Active, leavingRound: 0
         });
 
         emit OperatorRegistered(msg.sender, msg.value);
@@ -89,10 +86,7 @@ abstract contract OperatorManager is DelegationStorage {
 
         _operators.add(msg.sender);
         _operatorMetadata[msg.sender] = Types.OperatorMetadata({
-            stake: amount,
-            delegationCount: 0,
-            status: Types.OperatorStatus.Active,
-            leavingRound: 0
+            stake: amount, delegationCount: 0, status: Types.OperatorStatus.Active, leavingRound: 0
         });
 
         emit OperatorRegistered(msg.sender, amount);
@@ -156,10 +150,8 @@ abstract contract OperatorManager is DelegationStorage {
             revert DelegationErrors.InsufficientStake(minStake, availableStake - amount);
         }
 
-        _operatorBondLessRequests[msg.sender] = Types.OperatorBondLessRequest({
-            amount: pendingUnstake + amount,
-            requestedRound: currentRound
-        });
+        _operatorBondLessRequests[msg.sender] =
+            Types.OperatorBondLessRequest({ amount: pendingUnstake + amount, requestedRound: currentRound });
 
         emit OperatorUnstakeScheduled(msg.sender, amount, currentRound + delegationBondLessDelay);
     }
@@ -207,9 +199,8 @@ abstract contract OperatorManager is DelegationStorage {
         // M-10 FIX: Check for active services via Tangle core
         if (_tangleCore != address(0)) {
             // Query Tangle for operator's total active service count
-            (bool success, bytes memory data) = _tangleCore.staticcall(
-                abi.encodeWithSignature("getOperatorTotalActiveServices(address)", msg.sender)
-            );
+            (bool success, bytes memory data) =
+                _tangleCore.staticcall(abi.encodeWithSignature("getOperatorTotalActiveServices(address)", msg.sender));
             if (success && data.length >= 32) {
                 uint256 activeServices = abi.decode(data, (uint256));
                 if (activeServices > 0) {
@@ -289,8 +280,7 @@ abstract contract OperatorManager is DelegationStorage {
 
     /// @notice Check if operator is active (registered and not leaving)
     function _isOperatorActive(address operator) internal view returns (bool) {
-        return _operators.contains(operator) &&
-               _operatorMetadata[operator].status == Types.OperatorStatus.Active;
+        return _operators.contains(operator) && _operatorMetadata[operator].status == Types.OperatorStatus.Active;
     }
 
     /// @notice Get operator self-stake
@@ -353,7 +343,9 @@ abstract contract OperatorManager is DelegationStorage {
         for (uint256 i = 0; i < delegators.length;) {
             _operatorDelegationWhitelist[msg.sender][delegators[i]] = approved;
             emit OperatorWhitelistUpdated(msg.sender, delegators[i], approved);
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/src/staking/SlashingManager.sol
+++ b/src/staking/SlashingManager.sol
@@ -170,7 +170,10 @@ abstract contract SlashingManager is RewardsManager {
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) internal returns (uint256 actualSlashed) {
+    )
+        internal
+        returns (uint256 actualSlashed)
+    {
         if (slashBps == 0) return 0;
         if (slashBps > BPS_DENOMINATOR) revert DelegationErrors.InvalidSlashBps(slashBps);
         Types.OperatorMetadata storage meta = _operatorMetadata[operator];
@@ -189,15 +192,7 @@ abstract contract SlashingManager is RewardsManager {
             Types.Asset memory asset = Types.Asset(Types.AssetKind.Native, address(0));
             bytes32 assetHash = _assetHash(asset);
             totalSlashed += _slashBlueprintPoolsForAsset(
-                operator,
-                blueprintId,
-                serviceId,
-                asset,
-                assetHash,
-                bondHash,
-                slashBps,
-                evidence,
-                meta
+                operator, blueprintId, serviceId, asset, assetHash, bondHash, slashBps, evidence, meta
             );
             if (totalSlashed > 0) slashed = true;
         }
@@ -208,21 +203,15 @@ abstract contract SlashingManager is RewardsManager {
             Types.Asset memory asset = Types.Asset(Types.AssetKind.ERC20, token);
             bytes32 assetHash = _assetHash(asset);
             uint256 assetSlashed = _slashBlueprintPoolsForAsset(
-                operator,
-                blueprintId,
-                serviceId,
-                asset,
-                assetHash,
-                bondHash,
-                slashBps,
-                evidence,
-                meta
+                operator, blueprintId, serviceId, asset, assetHash, bondHash, slashBps, evidence, meta
             );
             if (assetSlashed > 0) {
                 totalSlashed += assetSlashed;
                 slashed = true;
             }
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
 
         if (!slashed) return 0;
@@ -255,7 +244,10 @@ abstract contract SlashingManager is RewardsManager {
         Types.AssetSecurityCommitment[] calldata commitments,
         uint16 slashBps,
         bytes32 evidence
-    ) internal returns (uint256 actualSlashed) {
+    )
+        internal
+        returns (uint256 actualSlashed)
+    {
         if (slashBps == 0) return 0;
         if (slashBps > BPS_DENOMINATOR) revert DelegationErrors.InvalidSlashBps(slashBps);
         Types.OperatorMetadata storage meta = _operatorMetadata[operator];
@@ -282,7 +274,9 @@ abstract contract SlashingManager is RewardsManager {
                 effectiveBps = 1;
             }
             if (effectiveBps == 0) {
-                unchecked { ++i; }
+                unchecked {
+                    ++i;
+                }
                 continue;
             }
 
@@ -299,7 +293,9 @@ abstract contract SlashingManager is RewardsManager {
                 meta
             );
             totalSlashed += assetSlashed;
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
 
         if (totalSlashed == 0) return 0;
@@ -327,7 +323,10 @@ abstract contract SlashingManager is RewardsManager {
         uint64 serviceId,
         uint16 slashBps,
         bytes32 evidence
-    ) internal returns (uint256 actualSlashed) {
+    )
+        internal
+        returns (uint256 actualSlashed)
+    {
         if (slashBps == 0) return 0;
         if (slashBps > BPS_DENOMINATOR) revert DelegationErrors.InvalidSlashBps(slashBps);
         if (!_operators.contains(operator)) {
@@ -370,9 +369,13 @@ abstract contract SlashingManager is RewardsManager {
             // Collect callback data instead of making external call during iteration
             if (fixedHasDelegators && actualFixedSlash > 0) {
                 callbackBlueprintIds[callbackCount] = blueprintId;
-                unchecked { ++callbackCount; }
+                unchecked {
+                    ++callbackCount;
+                }
             }
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
 
         if (totalSlashed == 0) return 0;
@@ -394,11 +397,16 @@ abstract contract SlashingManager is RewardsManager {
         // H-6 FIX: Execute all callbacks AFTER state updates complete
         if (_serviceFeeDistributor != address(0)) {
             if (allHasDelegators && actualAllSlash > 0) {
-                try IServiceFeeDistributor(_serviceFeeDistributor).onAllModeSlashed(operator, asset, slashBps) {} catch {}
+                try IServiceFeeDistributor(_serviceFeeDistributor).onAllModeSlashed(operator, asset, slashBps) { }
+                    catch { }
             }
             for (uint256 i = 0; i < callbackCount;) {
-                try IServiceFeeDistributor(_serviceFeeDistributor).onFixedModeSlashed(operator, callbackBlueprintIds[i], asset, slashBps) {} catch {}
-                unchecked { ++i; }
+                try IServiceFeeDistributor(_serviceFeeDistributor)
+                    .onFixedModeSlashed(operator, callbackBlueprintIds[i], asset, slashBps) { }
+                    catch { }
+                unchecked {
+                    ++i;
+                }
             }
         }
 
@@ -424,10 +432,7 @@ abstract contract SlashingManager is RewardsManager {
     }
 
     /// @notice Slash operator's self-stake
-    function _slashOperatorStake(
-        address operator,
-        uint256 amount
-    ) internal returns (uint256 slashed) {
+    function _slashOperatorStake(address operator, uint256 amount) internal returns (uint256 slashed) {
         Types.OperatorMetadata storage meta = _operatorMetadata[operator];
 
         if (meta.stake >= amount) {
@@ -448,11 +453,7 @@ abstract contract SlashingManager is RewardsManager {
     /// @param operator Operator whose pool to slash
     /// @param amount Amount to slash from the pool
     /// @return slashed Actual amount slashed
-    function _slashAllModePool(
-        address operator,
-        bytes32 assetHash,
-        uint256 amount
-    ) internal returns (uint256 slashed) {
+    function _slashAllModePool(address operator, bytes32 assetHash, uint256 amount) internal returns (uint256 slashed) {
         Types.OperatorRewardPool storage pool = _rewardPools[operator][assetHash];
 
         if (pool.totalAssets == 0 || amount == 0) {
@@ -483,7 +484,10 @@ abstract contract SlashingManager is RewardsManager {
         uint64 blueprintId,
         bytes32 assetHash,
         uint256 amount
-    ) internal returns (uint256 slashed) {
+    )
+        internal
+        returns (uint256 slashed)
+    {
         Types.OperatorRewardPool storage pool = _blueprintPools[operator][blueprintId][assetHash];
 
         if (pool.totalAssets == 0 || amount == 0) {
@@ -512,7 +516,10 @@ abstract contract SlashingManager is RewardsManager {
         uint16 slashBps,
         bytes32 evidence,
         Types.OperatorMetadata storage meta
-    ) internal returns (uint256 assetSlashed) {
+    )
+        internal
+        returns (uint256 assetSlashed)
+    {
         Types.OperatorRewardPool storage allPool = _rewardPools[operator][assetHash];
         Types.OperatorRewardPool storage bpPool = _blueprintPools[operator][blueprintId][assetHash];
         bool allHasDelegators = allPool.totalShares > 0;
@@ -554,10 +561,13 @@ abstract contract SlashingManager is RewardsManager {
 
         if (_serviceFeeDistributor != address(0)) {
             if (allHasDelegators && actualAllModeSlash > 0) {
-                try IServiceFeeDistributor(_serviceFeeDistributor).onAllModeSlashed(operator, asset, slashBps) {} catch {}
+                try IServiceFeeDistributor(_serviceFeeDistributor).onAllModeSlashed(operator, asset, slashBps) { }
+                    catch { }
             }
             if (fixedHasDelegators && actualFixedModeSlash > 0) {
-                try IServiceFeeDistributor(_serviceFeeDistributor).onFixedModeSlashed(operator, blueprintId, asset, slashBps) {} catch {}
+                try IServiceFeeDistributor(_serviceFeeDistributor)
+                    .onFixedModeSlashed(operator, blueprintId, asset, slashBps) { }
+                    catch { }
             }
         }
 
@@ -587,7 +597,11 @@ abstract contract SlashingManager is RewardsManager {
         address operator,
         uint64 slashId,
         address delegator
-    ) external view returns (uint256 lostAmount) {
+    )
+        external
+        view
+        returns (uint256 lostAmount)
+    {
         SlashRecord memory record = slashHistory[operator][slashId];
         if (record.round == 0) return 0; // Slash doesn't exist
 
@@ -605,7 +619,11 @@ abstract contract SlashingManager is RewardsManager {
         address delegator,
         address operator,
         bytes32 assetHash
-    ) internal view returns (uint256 totalShares) {
+    )
+        internal
+        view
+        returns (uint256 totalShares)
+    {
         Types.BondInfoDelegator[] storage delegations = _delegations[delegator];
         uint256 delegationsLength = delegations.length;
         for (uint256 i = 0; i < delegationsLength;) {
@@ -613,7 +631,9 @@ abstract contract SlashingManager is RewardsManager {
             if (d.operator == operator && _assetHash(d.asset) == assetHash) {
                 totalShares += d.shares;
             }
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -623,10 +643,7 @@ abstract contract SlashingManager is RewardsManager {
     }
 
     /// @notice Get slash record details
-    function getSlashRecord(
-        address operator,
-        uint64 slashId
-    ) external view returns (SlashRecord memory) {
+    function getSlashRecord(address operator, uint64 slashId) external view returns (SlashRecord memory) {
         return slashHistory[operator][slashId];
     }
 
@@ -672,16 +689,12 @@ abstract contract SlashingManager is RewardsManager {
             : _assetHash(Types.Asset(Types.AssetKind.ERC20, _operatorBondToken));
 
         _atStake[currentRound][operator] = Types.OperatorSnapshot({
-            stake: meta.stake,
-            totalDelegated: _getOperatorDelegatedStakeForAsset(operator, bondHash)
+            stake: meta.stake, totalDelegated: _getOperatorDelegatedStakeForAsset(operator, bondHash)
         });
     }
 
     /// @notice Get snapshot for an operator at a specific round
-    function getSnapshot(
-        uint64 round,
-        address operator
-    ) public view returns (Types.OperatorSnapshot memory) {
+    function getSnapshot(uint64 round, address operator) public view returns (Types.OperatorSnapshot memory) {
         return _atStake[round][operator];
     }
 
@@ -717,5 +730,4 @@ abstract contract SlashingManager is RewardsManager {
         }
         return false;
     }
-
 }

--- a/src/staking/StakingFacetBase.sol
+++ b/src/staking/StakingFacetBase.sol
@@ -18,4 +18,5 @@ abstract contract StakingFacetBase is
     DepositManager
 {
     // Intentionally empty.
-}
+
+    }

--- a/src/staking/adapters/AssetAdapterFactory.sol
+++ b/src/staking/adapters/AssetAdapterFactory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IAssetAdapter} from "./IAssetAdapter.sol";
-import {StandardAssetAdapter} from "./StandardAssetAdapter.sol";
-import {RebasingAssetAdapter} from "./RebasingAssetAdapter.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import { IAssetAdapter } from "./IAssetAdapter.sol";
+import { StandardAssetAdapter } from "./StandardAssetAdapter.sol";
+import { RebasingAssetAdapter } from "./RebasingAssetAdapter.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title AssetAdapterFactory
 /// @notice Factory for deploying and registering asset adapters
@@ -15,8 +15,8 @@ contract AssetAdapterFactory is Ownable {
     // ═══════════════════════════════════════════════════════════════════════════
 
     enum AdapterType {
-        Standard,  // Normal ERC-20 (wstETH, cbETH, rETH, WETH, etc.)
-        Rebasing   // Rebasing tokens (stETH, etc.)
+        Standard, // Normal ERC-20 (wstETH, cbETH, rETH, WETH, etc.)
+        Rebasing // Rebasing tokens (stETH, etc.)
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -39,11 +39,7 @@ contract AssetAdapterFactory is Ownable {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event AdapterDeployed(
-        address indexed token,
-        address indexed adapter,
-        AdapterType adapterType
-    );
+    event AdapterDeployed(address indexed token, address indexed adapter, AdapterType adapterType);
 
     event DelegationManagerSet(address indexed oldManager, address indexed newManager);
 
@@ -62,7 +58,7 @@ contract AssetAdapterFactory is Ownable {
 
     /// @notice Create factory
     /// @param _owner Owner address
-    constructor(address _owner) Ownable(_owner) {}
+    constructor(address _owner) Ownable(_owner) { }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // ADMIN FUNCTIONS
@@ -84,18 +80,12 @@ contract AssetAdapterFactory is Ownable {
     /// @param token The ERC-20 token address
     /// @param adapterType The type of adapter to deploy
     /// @return adapter The deployed adapter address
-    function deployAdapter(
-        address token,
-        AdapterType adapterType
-    ) external onlyOwner returns (address adapter) {
+    function deployAdapter(address token, AdapterType adapterType) external onlyOwner returns (address adapter) {
         return _deployAdapterInternal(token, adapterType);
     }
 
     /// @notice Internal deploy function
-    function _deployAdapterInternal(
-        address token,
-        AdapterType adapterType
-    ) internal returns (address adapter) {
+    function _deployAdapterInternal(address token, AdapterType adapterType) internal returns (address adapter) {
         if (token == address(0)) revert ZeroAddress();
         if (tokenToAdapter[token] != address(0)) revert AdapterAlreadyExists(token);
         if (delegationManager == address(0)) revert DelegationManagerNotSet();

--- a/src/staking/adapters/RebasingAssetAdapter.sol
+++ b/src/staking/adapters/RebasingAssetAdapter.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IAssetAdapter} from "./IAssetAdapter.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import { IAssetAdapter } from "./IAssetAdapter.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /// @title RebasingAssetAdapter
 /// @notice Adapter for rebasing tokens like stETH where balance changes automatically

--- a/src/staking/adapters/StandardAssetAdapter.sol
+++ b/src/staking/adapters/StandardAssetAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IAssetAdapter} from "./IAssetAdapter.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import { IAssetAdapter } from "./IAssetAdapter.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title StandardAssetAdapter
 /// @notice Adapter for standard ERC-20 tokens (non-rebasing)

--- a/test/BLSAggregation.t.sol
+++ b/test/BLSAggregation.t.sol
@@ -14,34 +14,19 @@ contract MockAggregationBSM is BlueprintServiceManagerBase {
     mapping(uint8 => uint16) public thresholdBps;
     mapping(uint8 => uint8) public thresholdType;
 
-    constructor() {}
+    constructor() { }
 
-    function setAggregationConfig(
-        uint8 jobIndex,
-        bool required,
-        uint16 _thresholdBps,
-        uint8 _thresholdType
-    ) external {
+    function setAggregationConfig(uint8 jobIndex, bool required, uint16 _thresholdBps, uint8 _thresholdType) external {
         aggregationRequired[jobIndex] = required;
         thresholdBps[jobIndex] = _thresholdBps;
         thresholdType[jobIndex] = _thresholdType;
     }
 
-    function requiresAggregation(uint64, uint8 jobIndex)
-        external
-        view
-        override
-        returns (bool)
-    {
+    function requiresAggregation(uint64, uint8 jobIndex) external view override returns (bool) {
         return aggregationRequired[jobIndex];
     }
 
-    function getAggregationThreshold(uint64, uint8 jobIndex)
-        external
-        view
-        override
-        returns (uint16, uint8)
-    {
+    function getAggregationThreshold(uint64, uint8 jobIndex) external view override returns (uint16, uint8) {
         uint16 threshold = thresholdBps[jobIndex];
         if (threshold == 0) threshold = 6700; // Default 67%
         return (threshold, thresholdType[jobIndex]);
@@ -182,7 +167,7 @@ contract BLSAggregationTest is BaseTest {
         // Job 2: 100% threshold (3 of 3 operators)
         mockBsm.setAggregationConfig(0, true, 3400, 0);
         mockBsm.setAggregationConfig(1, true, 6700, 0);
-        mockBsm.setAggregationConfig(2, true, 10000, 0);
+        mockBsm.setAggregationConfig(2, true, 10_000, 0);
 
         // Submit jobs for each index
         vm.prank(user1);
@@ -202,18 +187,12 @@ contract BLSAggregationTest is BaseTest {
         tangle.submitAggregatedResult(serviceId, callId0, "result", oneSigner, sig, pubkey);
 
         // Job 1: 1 signer should fail threshold (67% of 3 = 2.01 -> 2)
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId, callId1, 1, 2
-        ));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId1, 1, 2));
         tangle.submitAggregatedResult(serviceId, callId1, "result", oneSigner, sig, pubkey);
 
         // Job 2: 2 signers should fail threshold (100% of 3 = 3)
         uint256 twoSigners = 0x3;
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId, callId2, 2, 3
-        ));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId2, 2, 3));
         tangle.submitAggregatedResult(serviceId, callId2, "result", twoSigners, sig, pubkey);
     }
 
@@ -279,13 +258,15 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail - threshold not met (1 < 2)
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            1, // achieved
-            2  // required
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                1, // achieved
+                2 // required
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", oneSigner, sig, pubkey);
     }
 
@@ -431,13 +412,15 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail threshold - only 1 valid signer counted, need 2
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            1, // achieved (only bit 0 counted)
-            2  // required
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                1, // achieved (only bit 0 counted)
+                2 // required
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", invalidBitmap, sig, pubkey);
     }
 
@@ -455,13 +438,15 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail - 0 valid signers, need 1
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            0, // achieved
-            1  // required
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                0, // achieved
+                1 // required
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", highBitsBitmap, sig, pubkey);
     }
 
@@ -477,13 +462,7 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail - 0 signers
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            0,
-            1
-        ));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId, 0, 1));
         tangle.submitAggregatedResult(serviceId, callId, "result", zeroBitmap, sig, pubkey);
     }
 
@@ -647,19 +626,21 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should require at least 1 signer
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            0,
-            1  // Minimum 1 required
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                0,
+                1 // Minimum 1 required
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", zeroBitmap, sig, pubkey);
     }
 
     /// @notice Test exactly 100% threshold
     function test_Threshold_ExactlyHundredPercent() public {
-        mockBsm.setAggregationConfig(0, true, 10000, 0); // 100% = all 3 required
+        mockBsm.setAggregationConfig(0, true, 10_000, 0); // 100% = all 3 required
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -669,13 +650,7 @@ contract BLSAggregationTest is BaseTest {
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            2,
-            3
-        ));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId, 2, 3));
         tangle.submitAggregatedResult(serviceId, callId, "result", twoSigners, sig, pubkey);
 
         // All 3 signers - should pass threshold, fail BLS
@@ -686,7 +661,7 @@ contract BLSAggregationTest is BaseTest {
 
     /// @notice Test threshold above 100% (edge case)
     function test_Threshold_AboveHundredPercent() public {
-        mockBsm.setAggregationConfig(0, true, 15000, 0); // 150% threshold
+        mockBsm.setAggregationConfig(0, true, 15_000, 0); // 150% threshold
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -697,13 +672,15 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail - can never meet 150% threshold with only 100% of operators
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.AggregationThresholdNotMet.selector,
-            serviceId,
-            callId,
-            3,  // achieved (all operators)
-            4   // required (150% of 3)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                3, // achieved (all operators)
+                4 // required (150% of 3)
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", allSigners, sig, pubkey);
     }
 
@@ -733,12 +710,9 @@ contract BLSAggregationTest is BaseTest {
     /// @notice Fuzz test for threshold calculation - count based
     /// @param thresholdBps The threshold in basis points (1-20000)
     /// @param signerBitmap Random signer bitmap
-    function testFuzz_ThresholdCalculation_CountBased(
-        uint16 thresholdBps,
-        uint256 signerBitmap
-    ) public {
+    function testFuzz_ThresholdCalculation_CountBased(uint16 thresholdBps, uint256 signerBitmap) public {
         // Bound threshold to reasonable range (avoid 0 because mock BSM defaults to 67%)
-        thresholdBps = uint16(bound(thresholdBps, 1, 20000));
+        thresholdBps = uint16(bound(thresholdBps, 1, 20_000));
 
         mockBsm.setAggregationConfig(0, true, thresholdBps, 0);
 
@@ -755,18 +729,16 @@ contract BLSAggregationTest is BaseTest {
         if ((signerBitmap >> 2) & 1 == 1) validSigners++;
 
         // Calculate required threshold (matching contract logic)
-        uint256 required = (uint256(3) * thresholdBps) / 10000;
+        uint256 required = (uint256(3) * thresholdBps) / 10_000;
         if (required == 0 && 3 > 0) required = 1;
 
         if (validSigners < required) {
             // Should fail with threshold not met
-            vm.expectRevert(abi.encodeWithSelector(
-                Errors.AggregationThresholdNotMet.selector,
-                serviceId,
-                callId,
-                validSigners,
-                required
-            ));
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    Errors.AggregationThresholdNotMet.selector, serviceId, callId, validSigners, required
+                )
+            );
         } else {
             // Should pass threshold but fail BLS verification
             vm.expectRevert(); // BLS fails
@@ -776,10 +748,7 @@ contract BLSAggregationTest is BaseTest {
     }
 
     /// @notice Fuzz test for invalid service/call IDs
-    function testFuzz_InvalidServiceOrCallId(
-        uint64 fuzzServiceId,
-        uint64 fuzzCallId
-    ) public {
+    function testFuzz_InvalidServiceOrCallId(uint64 fuzzServiceId, uint64 fuzzCallId) public {
         // Skip valid service ID (0)
         vm.assume(fuzzServiceId != serviceId || fuzzCallId > 100);
 
@@ -921,8 +890,8 @@ contract BLSAggregationTest is BaseTest {
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
 
         // 10KB of output data
-        bytes memory largeOutput = new bytes(10240);
-        for (uint i = 0; i < 10240; i++) {
+        bytes memory largeOutput = new bytes(10_240);
+        for (uint256 i = 0; i < 10_240; i++) {
             largeOutput[i] = bytes1(uint8(i % 256));
         }
 

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -74,19 +74,14 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         restakingProxy = new ERC1967Proxy(
             address(restakingImpl),
             abi.encodeCall(
-                MultiAssetDelegation.initialize,
-                (admin, MIN_OPERATOR_STAKE, MIN_DELEGATION, OPERATOR_COMMISSION_BPS)
+                MultiAssetDelegation.initialize, (admin, MIN_OPERATOR_STAKE, MIN_DELEGATION, OPERATOR_COMMISSION_BPS)
             )
         );
         staking = IMultiAssetDelegation(payable(address(restakingProxy)));
 
         // Deploy tangle proxy
         tangleProxy = new ERC1967Proxy(
-            address(tangleImpl),
-            abi.encodeCall(
-                Tangle.initialize,
-                (admin, address(staking), payable(treasury))
-            )
+            address(tangleImpl), abi.encodeCall(Tangle.initialize, (admin, address(staking), payable(treasury)))
         );
         tangle = ITangleFull(payable(address(tangleProxy)));
 
@@ -106,10 +101,8 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         // Deploy master blueprint service manager and registry
         masterManager = new MasterBlueprintServiceManager(admin, address(tangle));
         MBSMRegistry registryImpl = new MBSMRegistry();
-        ERC1967Proxy registryProxy = new ERC1967Proxy(
-            address(registryImpl),
-            abi.encodeCall(MBSMRegistry.initialize, (admin))
-        );
+        ERC1967Proxy registryProxy =
+            new ERC1967Proxy(address(registryImpl), abi.encodeCall(MBSMRegistry.initialize, (admin)));
         mbsmRegistry = MBSMRegistry(address(registryProxy));
 
         vm.startPrank(admin);
@@ -176,11 +169,7 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         return tangle.createBlueprint(_blueprintDefinition("ipfs://metadata", manager));
     }
 
-    function _createBlueprint(
-        address owner,
-        string memory metadataUri,
-        address manager
-    ) internal returns (uint64) {
+    function _createBlueprint(address owner, string memory metadataUri, address manager) internal returns (uint64) {
         vm.prank(owner);
         return tangle.createBlueprint(_blueprintDefinition(metadataUri, manager));
     }
@@ -217,7 +206,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address owner,
         address manager,
         Types.BlueprintConfig memory config
-    ) internal returns (uint64) {
+    )
+        internal
+        returns (uint64)
+    {
         vm.prank(owner);
         return tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://metadata", manager, config));
     }
@@ -227,16 +219,16 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         string memory metadataUri,
         address manager,
         Types.BlueprintConfig memory config
-    ) internal returns (uint64) {
+    )
+        internal
+        returns (uint64)
+    {
         vm.prank(owner);
         return tangle.createBlueprint(_blueprintDefinitionWithConfig(metadataUri, manager, config));
     }
 
     /// @notice Create a blueprint using the current msg.sender (expects caller to prank)
-    function _createBlueprintAsSender(
-        string memory metadataUri,
-        address manager
-    ) internal returns (uint64) {
+    function _createBlueprintAsSender(string memory metadataUri, address manager) internal returns (uint64) {
         return tangle.createBlueprint(_blueprintDefinition(metadataUri, manager));
     }
 
@@ -245,7 +237,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         string memory metadataUri,
         address manager,
         Types.BlueprintConfig memory config
-    ) internal returns (uint64) {
+    )
+        internal
+        returns (uint64)
+    {
         return tangle.createBlueprint(_blueprintDefinitionWithConfig(metadataUri, manager, config));
     }
 
@@ -254,7 +249,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         string memory metadataUri,
         address manager,
         uint256 jobCount
-    ) internal returns (uint64) {
+    )
+        internal
+        returns (uint64)
+    {
         return tangle.createBlueprint(_blueprintDefinitionWithJobCount(metadataUri, manager, jobCount));
     }
 
@@ -263,7 +261,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         bytes memory paramsSchema,
         bytes memory resultSchema,
         address manager
-    ) internal returns (uint64 blueprintId, uint64 serviceId) {
+    )
+        internal
+        returns (uint64 blueprintId, uint64 serviceId)
+    {
         Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://schema-service", manager);
         def.jobs[0].paramsSchema = paramsSchema;
         def.jobs[0].resultSchema = resultSchema;
@@ -294,7 +295,9 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
 
     function _registerForBlueprint(address operator, uint64 blueprintId, bytes memory registrationInputs) internal {
         vm.prank(operator);
-        tangle.registerOperator(blueprintId, _operatorGossipKey(operator, 0), "http://localhost:8545", registrationInputs);
+        tangle.registerOperator(
+            blueprintId, _operatorGossipKey(operator, 0), "http://localhost:8545", registrationInputs
+        );
     }
 
     function _directRegisterOperator(address operator, uint64 blueprintId, string memory rpc) internal {
@@ -307,7 +310,9 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         uint64 blueprintId,
         string memory rpc,
         bytes memory registrationInputs
-    ) internal {
+    )
+        internal
+    {
         vm.prank(operator);
         tangle.registerOperator(blueprintId, _operatorGossipKey(operator, 0), rpc, registrationInputs);
     }
@@ -323,11 +328,7 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
     }
 
     /// @notice Request a service with single operator
-    function _requestService(
-        address requester,
-        uint64 blueprintId,
-        address operator
-    ) internal returns (uint64) {
+    function _requestService(address requester, uint64 blueprintId, address operator) internal returns (uint64) {
         address[] memory operators = new address[](1);
         operators[0] = operator;
         address[] memory callers = new address[](0);
@@ -342,15 +343,16 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         uint64 blueprintId,
         address operator,
         uint256 payment
-    ) internal returns (uint64) {
+    )
+        internal
+        returns (uint64)
+    {
         address[] memory operators = new address[](1);
         operators[0] = operator;
         address[] memory callers = new address[](0);
 
         vm.prank(requester);
-        return tangle.requestService{ value: payment }(
-            blueprintId, operators, "", callers, 0, address(0), payment
-        );
+        return tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
     }
 
     /// @notice Approve a service request
@@ -364,7 +366,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address manager,
         address[] memory ops,
         uint16[] memory exposures
-    ) internal returns (uint64 blueprintId, uint64 serviceId) {
+    )
+        internal
+        returns (uint64 blueprintId, uint64 serviceId)
+    {
         Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://job-manager", manager);
         def.jobs[0].paramsSchema = _boolSchema();
         def.jobs[0].resultSchema = _boolSchema();
@@ -378,16 +383,7 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
 
         address[] memory callers = new address[](0);
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId,
-            ops,
-            exposures,
-            "",
-            callers,
-            0,
-            address(0),
-            0
-        );
+        uint64 requestId = tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", callers, 0, address(0), 0);
 
         for (uint256 i = 0; i < ops.length; i++) {
             vm.prank(ops[i]);
@@ -404,22 +400,17 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address operator,
         address token,
         uint256 payment
-    ) internal returns (uint64 requestId) {
+    )
+        internal
+        returns (uint64 requestId)
+    {
         address[] memory operators = new address[](1);
         operators[0] = operator;
         address[] memory callers = new address[](0);
 
         vm.startPrank(requester);
         IERC20(token).approve(address(tangle), payment);
-        requestId = tangle.requestService(
-            blueprintId,
-            operators,
-            "",
-            callers,
-            0,
-            token,
-            payment
-        );
+        requestId = tangle.requestService(blueprintId, operators, "", callers, 0, token, payment);
         vm.stopPrank();
     }
 }

--- a/test/EndToEndSlashingTest.t.sol
+++ b/test/EndToEndSlashingTest.t.sol
@@ -314,7 +314,8 @@ contract EndToEndSlashingTest is BaseTest {
         exposures[0] = 5000; // 50%
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 
@@ -498,17 +499,17 @@ contract MockMetricsRecorder {
     }
 
     // Stub remaining IMetricsRecorder functions
-    function recordStake(address, address, address, uint256) external {}
-    function recordUnstake(address, address, address, uint256) external {}
-    function recordOperatorRegistered(address, address, uint256) external {}
-    function recordHeartbeat(address, uint64, uint64) external {}
-    function recordJobCompletion(address, uint64, uint64, bool) external {}
-    function recordServiceCreated(uint64, uint64, address, uint256) external {}
-    function recordServiceTerminated(uint64, uint256) external {}
-    function recordJobCall(uint64, address, uint64) external {}
-    function recordPayment(address, uint64, address, uint256) external {}
-    function recordBlueprintCreated(uint64, address) external {}
-    function recordBlueprintRegistration(uint64, address) external {}
+    function recordStake(address, address, address, uint256) external { }
+    function recordUnstake(address, address, address, uint256) external { }
+    function recordOperatorRegistered(address, address, uint256) external { }
+    function recordHeartbeat(address, uint64, uint64) external { }
+    function recordJobCompletion(address, uint64, uint64, bool) external { }
+    function recordServiceCreated(uint64, uint64, address, uint256) external { }
+    function recordServiceTerminated(uint64, uint256) external { }
+    function recordJobCall(uint64, address, uint64) external { }
+    function recordPayment(address, uint64, address, uint256) external { }
+    function recordBlueprintCreated(uint64, address) external { }
+    function recordBlueprintRegistration(uint64, address) external { }
 }
 
 /// @title ChallengingSquareBSM
@@ -533,10 +534,22 @@ contract ChallengingSquareBSM is BlueprintServiceManagerBase {
         tangleCore = _tangleCore;
     }
 
-    function onRegister(address, bytes calldata) external payable override {}
-    function onRequest(uint64, address, address[] calldata, bytes calldata, uint64, address, uint256) external payable override {}
-    function onApprove(address, uint64, uint8) external payable override {}
-    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64) external override {}
+    function onRegister(address, bytes calldata) external payable override { }
+    function onRequest(
+        uint64,
+        address,
+        address[] calldata,
+        bytes calldata,
+        uint64,
+        address,
+        uint256
+    )
+        external
+        payable
+        override
+    { }
+    function onApprove(address, uint64, uint8) external payable override { }
+    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64) external override { }
 
     function onJobCall(uint64 serviceId, uint8, uint64 callId, bytes calldata inputs) external payable override {
         jobInputs[serviceId][callId] = abi.decode(inputs, (uint256));
@@ -549,7 +562,11 @@ contract ChallengingSquareBSM is BlueprintServiceManagerBase {
         address operator,
         bytes calldata,
         bytes calldata outputs
-    ) external payable override {
+    )
+        external
+        payable
+        override
+    {
         uint256 output = abi.decode(outputs, (uint256));
         uint256 input = jobInputs[serviceId][callId];
 
@@ -572,12 +589,15 @@ contract ChallengingSquareBSM is BlueprintServiceManagerBase {
         address operator = resultSubmitters[serviceId][callId];
 
         // Propose slash via Tangle (use ITangleFull which includes slashing)
-        return ITangleFull(tangleCore).proposeSlash(
-            serviceId,
-            operator,
-            CHALLENGE_SLASH_BPS,
-            keccak256(abi.encode("invalid_square", callId, jobInputs[serviceId][callId], jobOutputs[serviceId][callId]))
-        );
+        return ITangleFull(tangleCore)
+            .proposeSlash(
+                serviceId,
+                operator,
+                CHALLENGE_SLASH_BPS,
+                keccak256(
+                    abi.encode("invalid_square", callId, jobInputs[serviceId][callId], jobOutputs[serviceId][callId])
+                )
+            );
     }
 
     function querySlashingOrigin(uint64) external view override returns (address) {

--- a/test/EndToEndSubscriptionTest.t.sol
+++ b/test/EndToEndSubscriptionTest.t.sol
@@ -41,15 +41,8 @@ contract EndToEndSubscriptionTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: payment }(
-            blueprintId,
-            operators,
-            "",
-            callers,
-            0,
-            address(0),
-            payment
-        );
+        uint64 requestId =
+            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
 
         // Step 5: Operator approves - payment is distributed
         vm.prank(operator1);
@@ -63,7 +56,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
     /// @notice Test subscription billing fails when escrow is exhausted
     function test_E2E_Subscription_EscrowExhaustion() public {
-        uint256 startTime = 1000000;
+        uint256 startTime = 1_000_000;
         vm.warp(startTime);
 
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
@@ -77,8 +70,7 @@ contract EndToEndSubscriptionTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId =
-            _createBlueprintWithConfigAsSender("ipfs://exhaustion-test", address(0), config);
+        uint64 blueprintId = _createBlueprintWithConfigAsSender("ipfs://exhaustion-test", address(0), config);
 
         vm.prank(operator1);
         staking.registerOperator{ value: 5 ether }();
@@ -120,7 +112,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
     /// @notice Test subscription with dynamic membership (operators join/leave)
     function test_E2E_Subscription_DynamicMembership() public {
-        uint256 startTime = 1000000;
+        uint256 startTime = 1_000_000;
         vm.warp(startTime);
 
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
@@ -134,8 +126,7 @@ contract EndToEndSubscriptionTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId =
-            _createBlueprintWithConfigAsSender("ipfs://dynamic-subscription", address(0), config);
+        uint64 blueprintId = _createBlueprintWithConfigAsSender("ipfs://dynamic-subscription", address(0), config);
 
         // Register all operators
         vm.prank(operator1);
@@ -161,7 +152,7 @@ contract EndToEndSubscriptionTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 10000; // 100%
+        exposures[0] = 10_000; // 100%
         address[] memory callers = new address[](0);
 
         vm.deal(address(tangle), 100 ether);
@@ -219,7 +210,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
     /// @notice Test rewards distribution proportional to delegation stake
     function test_E2E_Subscription_RewardsProportionalToDelegation() public {
-        uint256 startTime = 1000000;
+        uint256 startTime = 1_000_000;
         vm.warp(startTime);
 
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
@@ -233,8 +224,7 @@ contract EndToEndSubscriptionTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId =
-            _createBlueprintWithConfigAsSender("ipfs://proportional-rewards", address(0), config);
+        uint64 blueprintId = _createBlueprintWithConfigAsSender("ipfs://proportional-rewards", address(0), config);
 
         vm.prank(operator1);
         staking.registerOperator{ value: 5 ether }();
@@ -280,7 +270,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
     /// @notice Test subscription termination and refund
     function test_E2E_Subscription_TerminationRefund() public {
-        uint256 startTime = 1000000;
+        uint256 startTime = 1_000_000;
         vm.warp(startTime);
 
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
@@ -294,8 +284,7 @@ contract EndToEndSubscriptionTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId =
-            _createBlueprintWithConfigAsSender("ipfs://termination", address(0), config);
+        uint64 blueprintId = _createBlueprintWithConfigAsSender("ipfs://termination", address(0), config);
 
         vm.prank(operator1);
         staking.registerOperator{ value: 5 ether }();

--- a/test/InflationPool.t.sol
+++ b/test/InflationPool.t.sol
@@ -54,8 +54,7 @@ contract InflationPoolTest is Test {
         // Deploy InflationPool
         InflationPool poolImpl = new InflationPool();
         bytes memory poolData = abi.encodeCall(
-            InflationPool.initialize,
-            (admin, address(tnt), address(metrics), address(vaults), EPOCH_LENGTH)
+            InflationPool.initialize, (admin, address(tnt), address(metrics), address(vaults), EPOCH_LENGTH)
         );
         ERC1967Proxy poolProxy = new ERC1967Proxy(address(poolImpl), poolData);
         pool = InflationPool(address(poolProxy));
@@ -100,10 +99,8 @@ contract InflationPoolTest is Test {
 
     function test_Initialize_RevertEpochTooShort() public {
         InflationPool poolImpl = new InflationPool();
-        bytes memory poolData = abi.encodeCall(
-            InflationPool.initialize,
-            (admin, address(tnt), address(metrics), address(vaults), 59)
-        );
+        bytes memory poolData =
+            abi.encodeCall(InflationPool.initialize, (admin, address(tnt), address(metrics), address(vaults), 59));
 
         vm.expectRevert(InflationPool.InvalidEpochLength.selector);
         new ERC1967Proxy(address(poolImpl), poolData);
@@ -112,8 +109,7 @@ contract InflationPoolTest is Test {
     function test_Initialize_RevertEpochTooLong() public {
         InflationPool poolImpl = new InflationPool();
         bytes memory poolData = abi.encodeCall(
-            InflationPool.initialize,
-            (admin, address(tnt), address(metrics), address(vaults), 365 days + 1)
+            InflationPool.initialize, (admin, address(tnt), address(metrics), address(vaults), 365 days + 1)
         );
 
         vm.expectRevert(InflationPool.InvalidEpochLength.selector);
@@ -259,8 +255,7 @@ contract InflationPoolTest is Test {
         vm.startPrank(admin);
         InflationPool poolImpl = new InflationPool();
         bytes memory poolData = abi.encodeCall(
-            InflationPool.initialize,
-            (admin, address(tnt), address(metrics), address(vaults), EPOCH_LENGTH)
+            InflationPool.initialize, (admin, address(tnt), address(metrics), address(vaults), EPOCH_LENGTH)
         );
         ERC1967Proxy poolProxy = new ERC1967Proxy(address(poolImpl), poolData);
         InflationPool emptyPool = InflationPool(address(poolProxy));
@@ -488,7 +483,11 @@ contract InflationPoolTest is Test {
 
         // After claims, pool balance should decrease by claimed amounts
         uint256 poolAfterClaims = pool.poolBalance();
-        assertEq(poolAfterClaims, poolBeforeClaims - claimedOp - claimedCust, "Pool balance should decrease by claimed amounts");
+        assertEq(
+            poolAfterClaims,
+            poolBeforeClaims - claimedOp - claimedCust,
+            "Pool balance should decrease by claimed amounts"
+        );
 
         // Verify no more pending rewards
         assertEq(pool.pendingOperatorRewards(operator1), 0, "No pending after claim");
@@ -526,8 +525,8 @@ contract InflationPoolTest is Test {
         InflationPool.EpochData memory epoch = _distributeCurrentEpoch();
         assertGt(pool.distributedThisPeriod(), 0);
         assertGt(
-            epoch.stakingDistributed + epoch.operatorsDistributed + epoch.customersDistributed +
-            epoch.developersDistributed + epoch.restakersDistributed,
+            epoch.stakingDistributed + epoch.operatorsDistributed + epoch.customersDistributed
+                + epoch.developersDistributed + epoch.restakersDistributed,
             0
         );
 
@@ -562,14 +561,12 @@ contract InflationPoolTest is Test {
 
     function test_DistributeEpoch_RedistributesToActiveStaking() public {
         vm.prank(admin);
-        vaults.recordStake(address(0), delegator1, operator1, 1_000 ether, RewardVaults.LockDuration.None);
+        vaults.recordStake(address(0), delegator1, operator1, 1000 ether, RewardVaults.LockDuration.None);
 
         InflationPool.EpochData memory epoch = _distributeCurrentEpoch();
 
-        uint256 totalDistributed = epoch.stakingDistributed +
-            epoch.operatorsDistributed +
-            epoch.customersDistributed +
-            epoch.developersDistributed;
+        uint256 totalDistributed = epoch.stakingDistributed + epoch.operatorsDistributed + epoch.customersDistributed
+            + epoch.developersDistributed;
 
         assertGt(totalDistributed, 0);
         assertEq(epoch.stakingDistributed, totalDistributed);
@@ -593,8 +590,10 @@ contract InflationPoolTest is Test {
         pool.setWeights(1000, 6000, 1000, 2000, 0); // 10/60/10/20/0
         InflationPool.EpochData memory epochTwo = _distributeCurrentEpoch();
 
-        uint256 totalOne = epochOne.stakingDistributed + epochOne.operatorsDistributed + epochOne.customersDistributed + epochOne.developersDistributed;
-        uint256 totalTwo = epochTwo.stakingDistributed + epochTwo.operatorsDistributed + epochTwo.customersDistributed + epochTwo.developersDistributed;
+        uint256 totalOne = epochOne.stakingDistributed + epochOne.operatorsDistributed + epochOne.customersDistributed
+            + epochOne.developersDistributed;
+        uint256 totalTwo = epochTwo.stakingDistributed + epochTwo.operatorsDistributed + epochTwo.customersDistributed
+            + epochTwo.developersDistributed;
 
         assertGt(epochOne.operatorsDistributed, 0);
         assertGt(epochTwo.operatorsDistributed, 0);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -62,15 +62,8 @@ contract IntegrationTest is BaseTest {
         uint256 developerBefore = developer.balance;
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: payment }(
-            blueprintId,
-            operators,
-            "",
-            callers,
-            0,
-            address(0),
-            payment
-        );
+        uint64 requestId =
+            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
 
         // Step 6: All operators approve (service activates after last approval)
         vm.prank(operator1);
@@ -83,8 +76,8 @@ contract IntegrationTest is BaseTest {
 
         // Step 7: Check payment was distributed (PayOnce model)
         // Default split: developer=2000, protocol=2000, operator=4000, restaker=2000
-        uint256 developerAmount = (payment * 2000) / 10000;
-        uint256 protocolAmount = (payment * 2000) / 10000;
+        uint256 developerAmount = (payment * 2000) / 10_000;
+        uint256 protocolAmount = (payment * 2000) / 10_000;
 
         assertEq(developer.balance, developerBefore + developerAmount, "Developer should receive 20%");
         assertEq(treasury.balance, treasuryBefore + protocolAmount, "Treasury should receive 20%");
@@ -138,14 +131,7 @@ contract IntegrationTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId,
-            operators,
-            exposures,
-            "",
-            callers,
-            0,
-            address(0),
-            payment
+            blueprintId, operators, exposures, "", callers, 0, address(0), payment
         );
 
         // Both approve
@@ -175,7 +161,8 @@ contract IntegrationTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         // Register all operators
         vm.prank(operator1);
@@ -199,13 +186,12 @@ contract IntegrationTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 10000;
+        exposures[0] = 10_000;
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -233,13 +219,13 @@ contract IntegrationTest is BaseTest {
         tangle.scheduleExit(serviceId);
 
         // Check exit status is Scheduled
-        assertEq(uint(tangle.getExitStatus(serviceId, operator2)), uint(Types.ExitStatus.Scheduled));
+        assertEq(uint256(tangle.getExitStatus(serviceId, operator2)), uint256(Types.ExitStatus.Scheduled));
 
         // Warp past exit queue duration (7 days default)
         vm.warp(block.timestamp + 7 days + 1);
 
         // Check exit status is now Executable
-        assertEq(uint(tangle.getExitStatus(serviceId, operator2)), uint(Types.ExitStatus.Executable));
+        assertEq(uint256(tangle.getExitStatus(serviceId, operator2)), uint256(Types.ExitStatus.Executable));
 
         // Execute exit
         vm.prank(operator2);
@@ -249,12 +235,12 @@ contract IntegrationTest is BaseTest {
         assertFalse(tangle.isServiceOperator(serviceId, operator2));
 
         // Check exit status is Completed
-        assertEq(uint(tangle.getExitStatus(serviceId, operator2)), uint(Types.ExitStatus.Completed));
+        assertEq(uint256(tangle.getExitStatus(serviceId, operator2)), uint256(Types.ExitStatus.Completed));
     }
 
     function test_FullWorkflow_SubscriptionBilling() public {
         // Use an explicit starting timestamp
-        uint256 startTime = 1000000;
+        uint256 startTime = 1_000_000;
         vm.warp(startTime);
 
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
@@ -268,7 +254,8 @@ contract IntegrationTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         // Setup operator
         vm.prank(operator1);
@@ -281,7 +268,7 @@ contract IntegrationTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 10000;
+        exposures[0] = 10_000;
         address[] memory callers = new address[](0);
 
         // Fund the Tangle contract and make request
@@ -628,11 +615,13 @@ contract CustomServiceManagerTest is BaseTest {
 
         // Should revert because manager rejects - wrapped in ManagerReverted
         vm.prank(operator1);
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.ManagerReverted.selector,
-            address(rejectingManager),
-            abi.encodeWithSelector(RejectingServiceManager.OperatorRejected.selector)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ManagerReverted.selector,
+                address(rejectingManager),
+                abi.encodeWithSelector(RejectingServiceManager.OperatorRejected.selector)
+            )
+        );
         tangle.registerOperator(blueprintId, _operatorGossipKey(operator1, 0), "");
     }
 
@@ -658,11 +647,7 @@ contract TestServiceManager is BlueprintServiceManagerBase {
     bool public serviceApproved;
     bool public serviceInitialized;
 
-    function onBlueprintCreated(
-        uint64 _blueprintId,
-        address _owner,
-        address _tangleCore
-    ) external override {
+    function onBlueprintCreated(uint64 _blueprintId, address _owner, address _tangleCore) external override {
         // Initialize base
         blueprintId = _blueprintId;
         blueprintOwner = _owner;
@@ -670,10 +655,7 @@ contract TestServiceManager is BlueprintServiceManagerBase {
         blueprintCreated = true;
     }
 
-    function onRegister(
-        address,
-        bytes calldata
-    ) external payable override {
+    function onRegister(address, bytes calldata) external payable override {
         operatorRegistered = true;
     }
 
@@ -685,26 +667,19 @@ contract TestServiceManager is BlueprintServiceManagerBase {
         uint64,
         address,
         uint256
-    ) external payable override {
+    )
+        external
+        payable
+        override
+    {
         serviceRequested = true;
     }
 
-    function onApprove(
-        address,
-        uint64,
-        uint8
-    ) external payable override {
+    function onApprove(address, uint64, uint8) external payable override {
         serviceApproved = true;
     }
 
-    function onServiceInitialized(
-        uint64,
-        uint64,
-        uint64,
-        address,
-        address[] calldata,
-        uint64
-    ) external override {
+    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64) external override {
         serviceInitialized = true;
     }
 }
@@ -714,10 +689,7 @@ contract TestServiceManager is BlueprintServiceManagerBase {
 contract RejectingServiceManager is BlueprintServiceManagerBase {
     error OperatorRejected();
 
-    function onRegister(
-        address,
-        bytes calldata
-    ) external payable override {
+    function onRegister(address, bytes calldata) external payable override {
         revert OperatorRejected();
     }
 }
@@ -761,8 +733,8 @@ contract MultiAssetSecurityTest is BaseTest {
         Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            minExposureBps: 5000,  // Min 50%
-            maxExposureBps: 10000  // Max 100%
+            minExposureBps: 5000, // Min 50%
+            maxExposureBps: 10_000 // Max 100%
         });
 
         address[] memory operators = new address[](1);
@@ -770,16 +742,8 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            operators,
-            requirements,
-            "",
-            callers,
-            0,
-            address(0),
-            0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Request should be created
         Types.ServiceRequest memory req = tangle.getServiceRequest(requestId);
@@ -815,16 +779,8 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            operators,
-            requirements,
-            "",
-            callers,
-            0,
-            address(0),
-            0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         assertEq(requestId, 0);
     }
@@ -864,7 +820,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 8000,
-            maxExposureBps: 5000  // Less than min!
+            maxExposureBps: 5000 // Less than min!
         });
 
         address[] memory operators = new address[](1);
@@ -891,7 +847,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 5000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory operators = new address[](1);
@@ -899,15 +855,13 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Operator approves with valid commitment (7500 bps = 75%)
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 7500
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 7500
         });
 
         vm.prank(operator1);
@@ -931,7 +885,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 5000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory operators = new address[](1);
@@ -939,15 +893,13 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Try to commit only 30% when min is 50%
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 3000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 3000
         });
 
         vm.prank(operator1);
@@ -969,7 +921,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 2000,
-            maxExposureBps: 5000  // Max 50%
+            maxExposureBps: 5000 // Max 50%
         });
 
         address[] memory operators = new address[](1);
@@ -977,15 +929,13 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Try to commit 80% when max is 50%
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 8000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 8000
         });
 
         vm.prank(operator1);
@@ -1021,15 +971,13 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Only commit for native asset, missing ERC20
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 5000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 5000
         });
 
         vm.prank(operator1);
@@ -1051,7 +999,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory operators = new address[](1);
@@ -1059,22 +1007,21 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](2);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 5000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 5000
         });
         commitments[1] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 6000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 6000
         });
 
         vm.prank(operator1);
-        vm.expectRevert(abi.encodeWithSelector(Errors.DuplicateAssetCommitment.selector, uint8(Types.AssetKind.Native), address(0)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.DuplicateAssetCommitment.selector, uint8(Types.AssetKind.Native), address(0))
+        );
         tangle.approveServiceWithCommitments(requestId, commitments);
     }
 
@@ -1098,7 +1045,7 @@ contract MultiAssetSecurityTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 3000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory operators = new address[](2);
@@ -1107,21 +1054,20 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         // Both operators commit with different amounts
         Types.AssetSecurityCommitment[] memory commitments1 = new Types.AssetSecurityCommitment[](1);
         commitments1[0] = Types.AssetSecurityCommitment({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 8000  // 80%
+            exposureBps: 8000 // 80%
         });
 
         Types.AssetSecurityCommitment[] memory commitments2 = new Types.AssetSecurityCommitment[](1);
         commitments2[0] = Types.AssetSecurityCommitment({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 5000  // 50%
+            exposureBps: 5000 // 50%
         });
 
         vm.prank(operator1);
@@ -1149,46 +1095,47 @@ contract RFQTest is BaseTest {
         vm.deal(operator2, 100 ether);
     }
 
-    function _signQuote(
-        Types.QuoteDetails memory details,
-        uint256 privateKey
-    ) internal view returns (bytes memory) {
+    function _signQuote(Types.QuoteDetails memory details, uint256 privateKey) internal view returns (bytes memory) {
         bytes32 QUOTE_TYPEHASH = keccak256(
-            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
         );
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
+        bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
 
-        bytes32 domainSeparator = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256("TangleQuote"),
-            keccak256("1"),
-            block.chainid,
-            address(tangle)
-        ));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("TangleQuote"),
+                keccak256("1"),
+                block.chainid,
+                address(tangle)
+            )
+        );
 
-        bytes32 structHash = keccak256(abi.encode(
-            QUOTE_TYPEHASH,
-            details.blueprintId,
-            details.ttlBlocks,
-            details.totalCost,
-            details.timestamp,
-            details.expiry,
-            commitmentsHash
-        ));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                QUOTE_TYPEHASH,
+                details.blueprintId,
+                details.ttlBlocks,
+                details.totalCost,
+                details.timestamp,
+                details.expiry,
+                commitmentsHash,
+                resourcesHash
+            )
+        );
 
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            domainSeparator,
-            structHash
-        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
     }
 
-    function _hashSecurityCommitments(
-        Types.AssetSecurityCommitment[] memory commitments
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitments(Types.AssetSecurityCommitment[] memory commitments)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32[] memory hashes = new bytes32[](commitments.length);
         for (uint256 i = 0; i < commitments.length; i++) {
             hashes[i] = _hashSecurityCommitment(commitments[i]);
@@ -1200,17 +1147,25 @@ contract RFQTest is BaseTest {
         return out;
     }
 
-    function _hashSecurityCommitment(
-        Types.AssetSecurityCommitment memory commitment
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitment(Types.AssetSecurityCommitment memory commitment) internal pure returns (bytes32) {
         bytes32 ASSET_TYPEHASH = keccak256("Asset(uint8 kind,address token)");
-        bytes32 COMMITMENT_TYPEHASH = keccak256(
-            "AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
-        );
-        bytes32 assetHash = keccak256(
-            abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token)
-        );
+        bytes32 COMMITMENT_TYPEHASH =
+            keccak256("AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)");
+        bytes32 assetHash = keccak256(abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token));
         return keccak256(abi.encode(COMMITMENT_TYPEHASH, assetHash, commitment.exposureBps));
+    }
+
+    function _hashResourceCommitments(Types.ResourceCommitment[] memory commitments) internal pure returns (bytes32) {
+        bytes32 RC_TYPEHASH = keccak256("ResourceCommitment(uint8 kind,uint64 count)");
+        bytes32[] memory hashes = new bytes32[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            hashes[i] = keccak256(abi.encode(RC_TYPEHASH, commitments[i].kind, commitments[i].count));
+        }
+        bytes32 out;
+        assembly ("memory-safe") {
+            out := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+        return out;
     }
 
     function test_CreateServiceFromQuotes_SingleOperator() public {
@@ -1236,29 +1191,20 @@ contract RFQTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuote(details, OPERATOR1_PK);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator1
-        });
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator1 });
 
         address[] memory callers = new address[](0);
 
         // Create service from quotes
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: cost }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: cost }(blueprintId, quotes, "", callers, ttl);
 
         // Service should be active
         assertTrue(tangle.isServiceActive(serviceId));
@@ -1292,7 +1238,8 @@ contract RFQTest is BaseTest {
             totalCost: 0.5 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.QuoteDetails memory details2 = Types.QuoteDetails({
@@ -1301,32 +1248,23 @@ contract RFQTest is BaseTest {
             totalCost: 0.7 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](2);
         quotes[0] = Types.SignedQuote({
-            details: details1,
-            signature: _signQuote(details1, OPERATOR1_PK),
-            operator: operator1
+            details: details1, signature: _signQuote(details1, OPERATOR1_PK), operator: operator1
         });
         quotes[1] = Types.SignedQuote({
-            details: details2,
-            signature: _signQuote(details2, OPERATOR2_PK),
-            operator: operator2
+            details: details2, signature: _signQuote(details2, OPERATOR2_PK), operator: operator2
         });
 
         address[] memory callers = new address[](0);
         uint256 totalCost = 1.2 ether;
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: totalCost }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: totalCost }(blueprintId, quotes, "", callers, ttl);
 
         assertTrue(tangle.isServiceActive(serviceId));
         assertTrue(tangle.isServiceOperator(serviceId, operator1));
@@ -1354,15 +1292,13 @@ contract RFQTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
 
         address[] memory callers = new address[](0);
         uint256 userBalanceBefore = user1.balance;
@@ -1394,15 +1330,13 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
 
         // Warp past expiry
         vm.warp(block.timestamp + 2 hours);
@@ -1433,14 +1367,15 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         // Sign with wrong key (operator2's key instead of operator1's)
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
         quotes[0] = Types.SignedQuote({
             details: details,
-            signature: _signQuote(details, OPERATOR2_PK),  // Wrong key!
+            signature: _signQuote(details, OPERATOR2_PK), // Wrong key!
             operator: operator1
         });
 
@@ -1466,20 +1401,18 @@ contract RFQTest is BaseTest {
 
         // Quote for wrong blueprint
         Types.QuoteDetails memory details = Types.QuoteDetails({
-            blueprintId: 999,  // Wrong blueprint!
+            blueprintId: 999, // Wrong blueprint!
             ttlBlocks: ttl,
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
 
         address[] memory callers = new address[](0);
 
@@ -1503,25 +1436,23 @@ contract RFQTest is BaseTest {
         // Quote for different TTL
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
-            ttlBlocks: 50,  // Quote says 50
+            ttlBlocks: 50, // Quote says 50
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.QuoteTTLMismatch.selector, operator1, 100, 50));
-        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, 100);  // Request wants 100
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, 100); // Request wants 100
     }
 
     function test_CreateServiceFromQuotes_RevertDuplicateOperator() public {
@@ -1543,20 +1474,18 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         // Same operator twice
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](2);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
         quotes[1] = Types.SignedQuote({
             details: details,
             signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1  // Duplicate!
+            operator: operator1 // Duplicate!
         });
 
         address[] memory callers = new address[](0);
@@ -1582,24 +1511,22 @@ contract RFQTest is BaseTest {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: ttl,
-            totalCost: 2 ether,  // Costs 2 ETH
+            totalCost: 2 ether, // Costs 2 ETH
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: _signQuote(details, OPERATOR1_PK),
-            operator: operator1
-        });
+        quotes[0] =
+            Types.SignedQuote({ details: details, signature: _signQuote(details, OPERATOR1_PK), operator: operator1 });
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.InsufficientPaymentForQuotes.selector, 2 ether, 1 ether));
-        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);  // Only sent 1 ETH
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl); // Only sent 1 ETH
     }
 
     function test_CreateServiceFromQuotes_RevertNoQuotes() public {

--- a/test/MultiAssetDelegation.t.sol
+++ b/test/MultiAssetDelegation.t.sol
@@ -50,8 +50,7 @@ contract MultiAssetDelegationTest is Test {
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(impl),
             abi.encodeCall(
-                MultiAssetDelegation.initialize,
-                (admin, MIN_OPERATOR_STAKE, MIN_DELEGATION, OPERATOR_COMMISSION_BPS)
+                MultiAssetDelegation.initialize, (admin, MIN_OPERATOR_STAKE, MIN_DELEGATION, OPERATOR_COMMISSION_BPS)
             )
         );
         delegation = IMultiAssetDelegation(payable(address(proxy)));
@@ -68,7 +67,7 @@ contract MultiAssetDelegationTest is Test {
 
         // Enable ERC20 token
         vm.prank(admin);
-        delegation.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10000);
+        delegation.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10_000);
     }
 
     function _registerFacets(address proxy) internal {
@@ -109,9 +108,7 @@ contract MultiAssetDelegationTest is Test {
         vm.prank(operator1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                DelegationErrors.InsufficientStake.selector,
-                MIN_OPERATOR_STAKE,
-                MIN_OPERATOR_STAKE - 1
+                DelegationErrors.InsufficientStake.selector, MIN_OPERATOR_STAKE, MIN_OPERATOR_STAKE - 1
             )
         );
         delegation.registerOperator{ value: MIN_OPERATOR_STAKE - 1 }();
@@ -122,9 +119,7 @@ contract MultiAssetDelegationTest is Test {
         delegation.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         vm.prank(operator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.OperatorAlreadyRegistered.selector, operator1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.OperatorAlreadyRegistered.selector, operator1));
         delegation.registerOperator{ value: MIN_OPERATOR_STAKE }();
     }
 
@@ -292,13 +287,7 @@ contract MultiAssetDelegationTest is Test {
         blueprints[1] = 2;
 
         vm.prank(delegator1);
-        delegation.delegateWithOptions(
-            operator1,
-            address(0),
-            0.5 ether,
-            Types.BlueprintSelectionMode.Fixed,
-            blueprints
-        );
+        delegation.delegateWithOptions(operator1, address(0), 0.5 ether, Types.BlueprintSelectionMode.Fixed, blueprints);
 
         uint64[] memory selectedBlueprints = delegation.getDelegationBlueprints(delegator1, 0);
         assertEq(selectedBlueprints.length, 2);
@@ -440,8 +429,7 @@ contract MultiAssetDelegationTest is Test {
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 10000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 10_000
         });
 
         vm.prank(delegator1);
@@ -457,13 +445,7 @@ contract MultiAssetDelegationTest is Test {
         vm.startPrank(delegator1);
         delegation.deposit{ value: 10 ether }();
         uint64[] memory empty = new uint64[](0);
-        delegation.delegateWithOptions(
-            operator1,
-            address(0),
-            10 ether,
-            Types.BlueprintSelectionMode.All,
-            empty
-        );
+        delegation.delegateWithOptions(operator1, address(0), 10 ether, Types.BlueprintSelectionMode.All, empty);
         vm.stopPrank();
 
         vm.prank(admin);
@@ -473,20 +455,13 @@ contract MultiAssetDelegationTest is Test {
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 10000 // 100% exposure
+            exposureBps: 10_000 // 100% exposure
         });
 
         // Total slashable: 10 operator + 10 delegator = 20 ether
         // Slash 10% of total
         vm.prank(admin);
-        uint256 slashed = delegation.slashForService(
-            operator1,
-            1,
-            1,
-            commitments,
-            1000,
-            bytes32("evidence")
-        );
+        uint256 slashed = delegation.slashForService(operator1, 1, 1, commitments, 1000, bytes32("evidence"));
 
         assertEq(slashed, 2 ether);
         // Operator should lose 1 ether (10% of 10 ether)
@@ -507,20 +482,8 @@ contract MultiAssetDelegationTest is Test {
 
         // Delegate both to operator (All mode)
         uint64[] memory empty = new uint64[](0);
-        delegation.delegateWithOptions(
-            operator1,
-            address(0),
-            5 ether,
-            Types.BlueprintSelectionMode.All,
-            empty
-        );
-        delegation.delegateWithOptions(
-            operator1,
-            address(token),
-            5 ether,
-            Types.BlueprintSelectionMode.All,
-            empty
-        );
+        delegation.delegateWithOptions(operator1, address(0), 5 ether, Types.BlueprintSelectionMode.All, empty);
+        delegation.delegateWithOptions(operator1, address(token), 5 ether, Types.BlueprintSelectionMode.All, empty);
         vm.stopPrank();
 
         vm.prank(admin);
@@ -530,7 +493,7 @@ contract MultiAssetDelegationTest is Test {
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](2);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 10000 // 100% exposure for native
+            exposureBps: 10_000 // 100% exposure for native
         });
         commitments[1] = Types.AssetSecurityCommitment({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(token) }),
@@ -538,14 +501,7 @@ contract MultiAssetDelegationTest is Test {
         });
 
         vm.prank(admin);
-        uint256 slashed = delegation.slashForService(
-            operator1,
-            1,
-            1,
-            commitments,
-            500,
-            bytes32("evidence")
-        );
+        uint256 slashed = delegation.slashForService(operator1, 1, 1, commitments, 500, bytes32("evidence"));
 
         // Should slash proportionally from committed assets
         uint256 nativeSlashed = (15 ether * 500) / 10_000;
@@ -563,20 +519,12 @@ contract MultiAssetDelegationTest is Test {
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 10000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 10_000
         });
 
         // Try to slash more than available
         vm.prank(admin);
-        uint256 slashed = delegation.slashForService(
-            operator1,
-            1,
-            1,
-            commitments,
-            10_000,
-            bytes32("evidence")
-        );
+        uint256 slashed = delegation.slashForService(operator1, 1, 1, commitments, 10_000, bytes32("evidence"));
 
         // Should only slash up to available amount
         assertEq(slashed, 5 ether);
@@ -595,13 +543,7 @@ contract MultiAssetDelegationTest is Test {
         delegation.depositERC20(address(token), 1 ether);
 
         uint64[] memory empty = new uint64[](0);
-        delegation.delegateWithOptions(
-            operator1,
-            address(token),
-            0.5 ether,
-            Types.BlueprintSelectionMode.All,
-            empty
-        );
+        delegation.delegateWithOptions(operator1, address(token), 0.5 ether, Types.BlueprintSelectionMode.All, empty);
         vm.stopPrank();
 
         Types.BondInfoDelegator[] memory delegations = delegation.getDelegations(delegator1);

--- a/test/Rewards.t.sol
+++ b/test/Rewards.t.sol
@@ -38,7 +38,8 @@ contract RewardsTest is Test {
 
         // Deploy RewardVaults
         RewardVaults vaultsImpl = new RewardVaults();
-        bytes memory vaultsData = abi.encodeCall(RewardVaults.initialize, (admin, address(tnt), 1500)); // 15% commission
+        bytes memory vaultsData = abi.encodeCall(RewardVaults.initialize, (admin, address(tnt), 1500)); // 15%
+        // commission
         ERC1967Proxy vaultsProxy = new ERC1967Proxy(address(vaultsImpl), vaultsData);
         vaults = RewardVaults(address(vaultsProxy));
 
@@ -164,7 +165,7 @@ contract RewardsTest is Test {
         vm.prank(admin);
         vaults.createVault(address(0), 1_000_000 ether);
 
-        vaults.recordDelegate(delegator1, operator1, address(0), 500 ether, 12000);
+        vaults.recordDelegate(delegator1, operator1, address(0), 500 ether, 12_000);
         (uint256 totalDeposits, uint256 totalScore,) = vaults.vaultStates(address(0));
         assertEq(totalDeposits, 500 ether);
         assertEq(totalScore, 600 ether); // 1.2x multiplier
@@ -264,10 +265,10 @@ contract RewardsTest is Test {
         vm.prank(admin);
         vaults.createVault(address(0), 100 ether);
 
-        vaults.recordDelegate(delegator1, operator1, address(0), 90 ether, 10000);
+        vaults.recordDelegate(delegator1, operator1, address(0), 90 ether, 10_000);
 
         vm.expectRevert(abi.encodeWithSelector(RewardVaults.DepositCapExceeded.selector, address(0)));
-        vaults.recordDelegate(delegator2, operator1, address(0), 20 ether, 15000);
+        vaults.recordDelegate(delegator2, operator1, address(0), 20 ether, 15_000);
     }
 
     function test_Vaults_RecordDelegate_RevertWhenVaultInactive() public {
@@ -277,7 +278,7 @@ contract RewardsTest is Test {
         vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSelector(RewardVaults.VaultNotActive.selector, address(0)));
-        vaults.recordDelegate(delegator1, operator1, address(0), 10 ether, 10000);
+        vaults.recordDelegate(delegator1, operator1, address(0), 10 ether, 10_000);
     }
 
     function test_Vaults_MultipleOperators() public {
@@ -300,8 +301,8 @@ contract RewardsTest is Test {
         vm.prank(delegator2);
         uint256 claimed2 = vaults.claimDelegatorRewards(address(0), operator2);
 
-        assertEq(claimed1, 8.5 ether);  // 85% of 10
-        assertEq(claimed2, 17 ether);   // 85% of 20
+        assertEq(claimed1, 8.5 ether); // 85% of 10
+        assertEq(claimed2, 17 ether); // 85% of 20
     }
 
     function test_Vaults_EpochRewardDistributesAcrossOperators() public {
@@ -396,7 +397,7 @@ contract RewardsTest is Test {
         vm.prank(admin);
         vaults.createVault(address(0), 1_000_000 ether);
 
-        vaults.recordDelegate(delegator1, operator1, address(0), 400 ether, 15000); // Score = 600
+        vaults.recordDelegate(delegator1, operator1, address(0), 400 ether, 15_000); // Score = 600
 
         (, uint256 totalScore,) = vaults.vaultStates(address(0));
         assertEq(totalScore, 600 ether);
@@ -442,8 +443,7 @@ contract RewardsTest is Test {
         assertEq(pending.length, 2);
         assertApproxEqAbs(total, 15.3 ether, 100); // rounding in per-score division
 
-        RewardVaults.DelegatorPosition[] memory positions =
-            vaults.getDelegatorPositions(address(0), delegator1);
+        RewardVaults.DelegatorPosition[] memory positions = vaults.getDelegatorPositions(address(0), delegator1);
         assertEq(positions.length, 2);
         assertEq(positions[0].pendingRewards, 8.5 ether);
         assertApproxEqAbs(positions[1].pendingRewards, 6.8 ether, 100);

--- a/test/SchemaValidationTest.t.sol
+++ b/test/SchemaValidationTest.t.sol
@@ -117,7 +117,11 @@ contract SchemaValidationTest is BaseTest {
     // HELPERS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function _blueprintWithSchemas(bytes memory registration, bytes memory request, bytes memory job)
+    function _blueprintWithSchemas(
+        bytes memory registration,
+        bytes memory request,
+        bytes memory job
+    )
         private
         returns (uint64)
     {

--- a/test/StakeRequirementTests.t.sol
+++ b/test/StakeRequirementTests.t.sol
@@ -30,20 +30,56 @@ contract MockBSM_StakeRequirement is BlueprintServiceManagerBase {
         tangleCore = _tangleCore;
     }
 
-    function onRegister(address, bytes calldata) external payable override onlyFromTangle {}
-    function onUnregister(address) external override onlyFromTangle {}
-    function onUpdatePreferences(address, bytes calldata) external payable override onlyFromTangle {}
-    function onRequest(uint64, address, address[] calldata, bytes calldata, uint64, address, uint256) external payable override onlyFromTangle {}
-    function onApprove(address, uint64, uint8) external payable override onlyFromTangle {}
-    function onReject(address, uint64) external override onlyFromTangle {}
-    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64) external override onlyFromTangle {}
-    function onServiceTermination(uint64, address) external override onlyFromTangle {}
-    function onJobCall(uint64, uint8, uint64, bytes calldata) external payable override onlyFromTangle {}
-    function onJobResult(uint64, uint8, uint64, address, bytes calldata, bytes calldata) external payable override onlyFromTangle {}
-    function onUnappliedSlash(uint64, bytes calldata, uint8) external override onlyFromTangle {}
-    function onSlash(uint64, bytes calldata, uint8) external override onlyFromTangle {}
-    function onOperatorJoined(uint64, address, uint16) external override onlyFromTangle {}
-    function onOperatorLeft(uint64, address) external override onlyFromTangle {}
+    function onRegister(address, bytes calldata) external payable override onlyFromTangle { }
+    function onUnregister(address) external override onlyFromTangle { }
+    function onUpdatePreferences(address, bytes calldata) external payable override onlyFromTangle { }
+    function onRequest(
+        uint64,
+        address,
+        address[] calldata,
+        bytes calldata,
+        uint64,
+        address,
+        uint256
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    { }
+    function onApprove(address, uint64, uint8) external payable override onlyFromTangle { }
+    function onReject(address, uint64) external override onlyFromTangle { }
+    function onServiceInitialized(
+        uint64,
+        uint64,
+        uint64,
+        address,
+        address[] calldata,
+        uint64
+    )
+        external
+        override
+        onlyFromTangle
+    { }
+    function onServiceTermination(uint64, address) external override onlyFromTangle { }
+    function onJobCall(uint64, uint8, uint64, bytes calldata) external payable override onlyFromTangle { }
+    function onJobResult(
+        uint64,
+        uint8,
+        uint64,
+        address,
+        bytes calldata,
+        bytes calldata
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    { }
+    function onUnappliedSlash(uint64, bytes calldata, uint8) external override onlyFromTangle { }
+    function onSlash(uint64, bytes calldata, uint8) external override onlyFromTangle { }
+    function onOperatorJoined(uint64, address, uint16) external override onlyFromTangle { }
+    function onOperatorLeft(uint64, address) external override onlyFromTangle { }
 }
 
 /// @title StakeRequirementTests
@@ -167,7 +203,8 @@ contract StakeRequirementTests is BaseTest {
             subscriptionInterval: 0,
             eventRate: 0
         });
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://test", address(mockBsm), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://test", address(mockBsm), config));
 
         _directRegisterOperator(operator1, blueprintId, "");
 
@@ -191,7 +228,7 @@ contract StakeRequirementTests is BaseTest {
         _directRegisterOperator(operator2, blueprintId, "");
 
         vm.prank(operator2);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
 
         assertTrue(tangle.isServiceOperator(serviceId, operator2));
     }
@@ -212,7 +249,8 @@ contract StakeRequirementTests is BaseTest {
             subscriptionInterval: 0,
             eventRate: 0
         });
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://test", address(mockBsm), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://test", address(mockBsm), config));
 
         _directRegisterOperator(operator1, blueprintId, "");
 
@@ -242,7 +280,7 @@ contract StakeRequirementTests is BaseTest {
         // Try to join service should fail
         vm.prank(operator2);
         vm.expectRevert(); // InsufficientStake
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -439,7 +477,8 @@ contract StakeRequirementTests is BaseTest {
             subscriptionInterval: 30 days,
             eventRate: 0
         });
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         _directRegisterOperator(operator1, blueprintId, "");
 
@@ -448,9 +487,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "", callers, 365 days, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -488,7 +526,8 @@ contract StakeRequirementTests is BaseTest {
             subscriptionInterval: 30 days,
             eventRate: 0
         });
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         _directRegisterOperator(operator1, blueprintId, "");
 
@@ -497,9 +536,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "", callers, 365 days, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -536,7 +574,8 @@ contract StakeRequirementTests is BaseTest {
             subscriptionInterval: 30 days,
             eventRate: 0
         });
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         _directRegisterOperator(operator1, blueprintId, "");
 
@@ -545,9 +584,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "", callers, 365 days, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/Tangle.t.sol
+++ b/test/Tangle.t.sol
@@ -19,12 +19,12 @@ contract ZeroDelayMockBSM is BlueprintServiceManagerBase {
         tangleCore = _tangleCore;
     }
 
-    function getExitConfig(uint64) external pure override returns (
-        bool useDefault,
-        uint64 minCommitmentDuration,
-        uint64 exitQueueDuration,
-        bool forceExitAllowed
-    ) {
+    function getExitConfig(uint64)
+        external
+        pure
+        override
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed)
+    {
         return (false, 0, 0, false);
     }
 }
@@ -519,12 +519,8 @@ contract TangleTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_SetPaymentSplit() public {
-        Types.PaymentSplit memory split = Types.PaymentSplit({
-            developerBps: 6000,
-            protocolBps: 500,
-            operatorBps: 1750,
-            stakerBps: 1750
-        });
+        Types.PaymentSplit memory split =
+            Types.PaymentSplit({ developerBps: 6000, protocolBps: 500, operatorBps: 1750, stakerBps: 1750 });
 
         vm.prank(admin);
         tangle.setPaymentSplit(split);
@@ -537,12 +533,8 @@ contract TangleTest is BaseTest {
     }
 
     function test_SetPaymentSplit_RevertInvalidTotal() public {
-        Types.PaymentSplit memory split = Types.PaymentSplit({
-            developerBps: 5000,
-            protocolBps: 5000,
-            operatorBps: 5000,
-            stakerBps: 5000
-        });
+        Types.PaymentSplit memory split =
+            Types.PaymentSplit({ developerBps: 5000, protocolBps: 5000, operatorBps: 5000, stakerBps: 5000 });
 
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidPaymentSplit.selector);
@@ -585,7 +577,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         assertEq(blueprintId, 0);
         Types.Blueprint memory bp = tangle.getBlueprint(blueprintId);
@@ -605,7 +598,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         // Register operators
         _registerOperator(operator1);
@@ -621,9 +615,8 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         // Approve to activate service
         vm.prank(operator1);
@@ -677,7 +670,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         _registerOperator(operator1);
         _registerOperator(operator2);
@@ -691,9 +685,8 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -716,7 +709,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         _registerOperator(operator1);
         _registerOperator(operator2);
@@ -732,9 +726,8 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -778,7 +771,8 @@ contract TangleTest is BaseTest {
         // Use mock BSM with zero exit delays to test min operators check directly
         ZeroDelayMockBSM zeroDelayBsm = new ZeroDelayMockBSM();
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(zeroDelayBsm), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(zeroDelayBsm), config));
 
         _registerOperator(operator1);
         _registerOperator(operator2);
@@ -794,9 +788,8 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -829,9 +822,8 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         assertEq(requestId, 0);
     }
@@ -844,14 +836,12 @@ contract TangleTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 15000; // > 100% - invalid
+        exposures[0] = 15_000; // > 100% - invalid
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidState.selector);
-        tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
     }
 
     function test_GetServiceOperators() public {
@@ -895,7 +885,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         Types.Blueprint memory bp = tangle.getBlueprint(blueprintId);
         assertEq(uint8(bp.pricing), uint8(Types.PricingModel.Subscription));
@@ -914,7 +905,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         _registerOperator(operator1);
         _registerForBlueprint(operator1, blueprintId);
@@ -922,12 +914,12 @@ contract TangleTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 10000;
+        exposures[0] = 10_000;
         address[] memory callers = new address[](0);
 
         // Request with payment for subscription
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure{value: 1 ether}(
+        uint64 requestId = tangle.requestServiceWithExposure{ value: 1 ether }(
             blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether
         );
 
@@ -969,7 +961,8 @@ contract TangleTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription", address(0), config));
 
         _registerOperator(operator1);
         _registerForBlueprint(operator1, blueprintId);
@@ -977,11 +970,11 @@ contract TangleTest is BaseTest {
         address[] memory operators = new address[](1);
         operators[0] = operator1;
         uint16[] memory exposures = new uint16[](1);
-        exposures[0] = 10000;
+        exposures[0] = 10_000;
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure{value: 1 ether}(
+        uint64 requestId = tangle.requestServiceWithExposure{ value: 1 ether }(
             blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether
         );
 

--- a/test/beacon/BeaconChainProofsTest.t.sol
+++ b/test/beacon/BeaconChainProofsTest.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BeaconTestBase} from "./BeaconTestBase.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {console2} from "forge-std/Test.sol";
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { console2 } from "forge-std/Test.sol";
 
 /// @title BeaconProofsHarness
 /// @notice Test harness with external functions for testing calldata library functions
@@ -12,7 +12,11 @@ contract BeaconProofsHarness {
     function verifyStateRoot(
         bytes32 beaconBlockRoot,
         ValidatorTypes.StateRootProof calldata stateRootProof
-    ) external pure returns (bool) {
+    )
+        external
+        pure
+        returns (bool)
+    {
         return BeaconChainProofs.verifyStateRoot(beaconBlockRoot, stateRootProof);
     }
 
@@ -20,14 +24,22 @@ contract BeaconProofsHarness {
         bytes32 beaconStateRoot,
         uint40 validatorIndex,
         ValidatorTypes.ValidatorFieldsProof memory proof
-    ) external pure returns (bool) {
+    )
+        external
+        pure
+        returns (bool)
+    {
         return BeaconChainProofs.verifyValidatorFields(beaconStateRoot, validatorIndex, proof);
     }
 
     function verifyBalanceContainer(
         bytes32 beaconBlockRoot,
         ValidatorTypes.BalanceContainerProof calldata proof
-    ) external pure returns (bool) {
+    )
+        external
+        pure
+        returns (bool)
+    {
         return BeaconChainProofs.verifyBalanceContainer(beaconBlockRoot, proof);
     }
 
@@ -35,7 +47,11 @@ contract BeaconProofsHarness {
         bytes32 balanceContainerRoot,
         uint40 validatorIndex,
         ValidatorTypes.BalanceProof calldata proof
-    ) external pure returns (uint64) {
+    )
+        external
+        pure
+        returns (uint64)
+    {
         return BeaconChainProofs.verifyValidatorBalance(balanceContainerRoot, validatorIndex, proof);
     }
 }
@@ -77,7 +93,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
         bytes memory proof = abi.encodePacked(siblings[0], siblings[1], siblings[2]);
 
         ValidatorTypes.StateRootProof memory stateRootProof =
-            ValidatorTypes.StateRootProof({beaconStateRoot: stateRoot, proof: proof});
+            ValidatorTypes.StateRootProof({ beaconStateRoot: stateRoot, proof: proof });
 
         bool result = harness.verifyStateRoot(beaconBlockRoot, stateRootProof);
         assertTrue(result, "Valid state root proof should verify");
@@ -101,7 +117,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
 
         // Try to verify with wrong state root
         ValidatorTypes.StateRootProof memory stateRootProof =
-            ValidatorTypes.StateRootProof({beaconStateRoot: wrongStateRoot, proof: proof});
+            ValidatorTypes.StateRootProof({ beaconStateRoot: wrongStateRoot, proof: proof });
 
         bool result = harness.verifyStateRoot(beaconBlockRoot, stateRootProof);
         assertFalse(result, "Invalid state root proof should not verify");
@@ -115,7 +131,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
         bytes memory wrongLengthProof = abi.encodePacked(keccak256("sibling0"), keccak256("sibling1"));
 
         ValidatorTypes.StateRootProof memory stateRootProof =
-            ValidatorTypes.StateRootProof({beaconStateRoot: stateRoot, proof: wrongLengthProof});
+            ValidatorTypes.StateRootProof({ beaconStateRoot: stateRoot, proof: wrongLengthProof });
 
         vm.expectRevert(BeaconChainProofs.InvalidProofLength.selector);
         harness.verifyStateRoot(beaconBlockRoot, stateRootProof);
@@ -132,7 +148,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
 
         // Empty proof with leaf == root would incorrectly pass without check
         ValidatorTypes.StateRootProof memory stateRootProof =
-            ValidatorTypes.StateRootProof({beaconStateRoot: stateRoot, proof: ""});
+            ValidatorTypes.StateRootProof({ beaconStateRoot: stateRoot, proof: "" });
 
         // Should revert with InvalidProofLength
         vm.expectRevert(BeaconChainProofs.InvalidProofLength.selector);
@@ -167,7 +183,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
         }
 
         ValidatorTypes.ValidatorFieldsProof memory proof =
-            ValidatorTypes.ValidatorFieldsProof({validatorFields: wrongFields, proof: ""});
+            ValidatorTypes.ValidatorFieldsProof({ validatorFields: wrongFields, proof: "" });
 
         vm.expectRevert(BeaconChainProofs.InvalidValidatorFieldsLength.selector);
         harness.verifyValidatorFields(beaconStateRoot, validatorIndex, proof);
@@ -205,10 +221,8 @@ contract BeaconChainProofsTest is BeaconTestBase {
         (bytes memory proofBytes, bytes32 stateRoot) =
             _buildProofFromGindex(balanceContainerRoot, BALANCE_CONTAINER_GINDEX);
 
-        ValidatorTypes.BalanceContainerProof memory proof = ValidatorTypes.BalanceContainerProof({
-            balanceContainerRoot: balanceContainerRoot,
-            proof: proofBytes
-        });
+        ValidatorTypes.BalanceContainerProof memory proof =
+            ValidatorTypes.BalanceContainerProof({ balanceContainerRoot: balanceContainerRoot, proof: proofBytes });
 
         bool result = harness.verifyBalanceContainer(stateRoot, proof);
         assertTrue(result, "Balance container proof should verify");
@@ -227,11 +241,8 @@ contract BeaconChainProofsTest is BeaconTestBase {
         (bytes memory proofBytes, bytes32 balanceContainerRoot) =
             _generateMerkleProof(balanceLeaf, siblings, validatorIndex / 4);
 
-        ValidatorTypes.BalanceProof memory proof = ValidatorTypes.BalanceProof({
-            pubkeyHash: bytes32(0),
-            balanceRoot: balanceLeaf,
-            proof: proofBytes
-        });
+        ValidatorTypes.BalanceProof memory proof =
+            ValidatorTypes.BalanceProof({ pubkeyHash: bytes32(0), balanceRoot: balanceLeaf, proof: proofBytes });
 
         uint64 balance = harness.verifyValidatorBalance(balanceContainerRoot, validatorIndex, proof);
         assertEq(balance, expectedBalance);
@@ -249,9 +260,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
         bytes memory wrongProof = abi.encodePacked(keccak256("sibling0"));
 
         ValidatorTypes.BalanceProof memory proof = ValidatorTypes.BalanceProof({
-            pubkeyHash: keccak256("pubkey"),
-            balanceRoot: keccak256("balance"),
-            proof: wrongProof
+            pubkeyHash: keccak256("pubkey"), balanceRoot: keccak256("balance"), proof: wrongProof
         });
 
         vm.expectRevert(BeaconChainProofs.InvalidProofLength.selector);
@@ -315,7 +324,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
     }
 
     function test_getActivationEpoch() public pure {
-        uint64 epoch = 12345;
+        uint64 epoch = 12_345;
         bytes32[] memory fields = new bytes32[](8);
         fields[5] = bytes32(uint256(epoch));
 
@@ -333,7 +342,7 @@ contract BeaconChainProofsTest is BeaconTestBase {
     }
 
     function test_getWithdrawableEpoch() public pure {
-        uint64 epoch = 99999;
+        uint64 epoch = 99_999;
         bytes32[] memory fields = new bytes32[](8);
         fields[7] = bytes32(uint256(epoch));
 
@@ -578,7 +587,10 @@ contract BeaconChainProofsTest is BeaconTestBase {
         assertFalse(ValidatorTypes.hasValidPrefix(invalidCreds), "0x03 prefix should be invalid");
     }
 
-    function _buildProofFromGindex(bytes32 leaf, uint256 gindex)
+    function _buildProofFromGindex(
+        bytes32 leaf,
+        uint256 gindex
+    )
         internal
         pure
         returns (bytes memory proof, bytes32 root)

--- a/test/beacon/BeaconFuzzTest.t.sol
+++ b/test/beacon/BeaconFuzzTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
 
 /// @title BeaconFuzzTest
 /// @notice Extensive fuzz testing for beacon chain proof verification
@@ -19,7 +19,10 @@ contract BeaconFuzzTest is Test {
         bytes32 leaf,
         bytes32[10] memory proofElements,
         uint256 index
-    ) public pure {
+    )
+        public
+        pure
+    {
         // Bound index to reasonable range
         index = bound(index, 0, 1023); // 2^10 - 1
 
@@ -54,7 +57,10 @@ contract BeaconFuzzTest is Test {
         bytes32 wrongLeaf,
         bytes32[5] memory proofElements,
         uint256 index
-    ) public pure {
+    )
+        public
+        pure
+    {
         vm.assume(correctLeaf != wrongLeaf);
         index = bound(index, 0, 31); // 2^5 - 1
 
@@ -88,7 +94,10 @@ contract BeaconFuzzTest is Test {
         bytes32[5] memory proofElements,
         uint256 correctIndex,
         uint256 wrongIndex
-    ) public pure {
+    )
+        public
+        pure
+    {
         correctIndex = bound(correctIndex, 0, 31);
         wrongIndex = bound(wrongIndex, 0, 31);
         vm.assume(correctIndex != wrongIndex);
@@ -174,13 +183,13 @@ contract BeaconFuzzTest is Test {
         uint64 balance1,
         uint64 balance2,
         uint64 balance3
-    ) public pure {
+    )
+        public
+        pure
+    {
         // Pack 4 balances into bytes32 (little-endian)
         bytes32 balanceRoot = bytes32(
-            uint256(balance0) |
-            (uint256(balance1) << 64) |
-            (uint256(balance2) << 128) |
-            (uint256(balance3) << 192)
+            uint256(balance0) | (uint256(balance1) << 64) | (uint256(balance2) << 128) | (uint256(balance3) << 192)
         );
 
         assertEq(_extractBalance(balanceRoot, 0), balance0);
@@ -284,9 +293,7 @@ contract BeaconFuzzTest is Test {
         vm.assume(oldFactor <= 1e18);
         vm.assume(currentBalance <= priorBalance);
 
-        uint64 newFactor = uint64(
-            (uint256(oldFactor) * uint256(currentBalance)) / uint256(priorBalance)
-        );
+        uint64 newFactor = uint64((uint256(oldFactor) * uint256(currentBalance)) / uint256(priorBalance));
 
         assertTrue(newFactor <= oldFactor, "New factor should be <= old factor");
         assertTrue(newFactor <= 1e18, "Factor should be <= 1e18");
@@ -298,7 +305,10 @@ contract BeaconFuzzTest is Test {
         uint64 balance1,
         uint64 balance2,
         uint64 balance3
-    ) public pure {
+    )
+        public
+        pure
+    {
         vm.assume(factor1 > 0 && factor1 <= 1e18);
         vm.assume(balance1 > 0);
         vm.assume(balance2 <= balance1 && balance2 > 0);
@@ -362,7 +372,10 @@ contract BeaconFuzzTest is Test {
         uint128 delegatorStake,
         uint128 totalDelegated,
         uint128 slashAmount
-    ) public pure {
+    )
+        public
+        pure
+    {
         vm.assume(totalDelegated > 0);
         vm.assume(delegatorStake <= totalDelegated);
         vm.assume(slashAmount <= totalDelegated);
@@ -383,7 +396,11 @@ contract BeaconFuzzTest is Test {
         bytes32 root,
         bytes32 leaf,
         uint256 index
-    ) internal pure returns (bool) {
+    )
+        internal
+        pure
+        returns (bool)
+    {
         bytes32 computedHash = leaf;
         uint256 proofLength = proof.length / 32;
 
@@ -408,7 +425,11 @@ contract BeaconFuzzTest is Test {
         bytes32 leaf,
         bytes32[5] memory proofElements,
         uint256 index
-    ) internal pure returns (bytes32 root) {
+    )
+        internal
+        pure
+        returns (bytes32 root)
+    {
         root = leaf;
         uint256 proofIndex = index;
         for (uint256 i = 0; i < proofElements.length; i++) {

--- a/test/beacon/BeaconIntegrationTest.t.sol
+++ b/test/beacon/BeaconIntegrationTest.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BeaconTestBase} from "./BeaconTestBase.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {console2} from "forge-std/Test.sol";
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { console2 } from "forge-std/Test.sol";
 
 /// @title BeaconIntegrationTest
 /// @notice Integration tests for the full beacon chain staking flow
@@ -14,6 +14,7 @@ import {console2} from "forge-std/Test.sol";
 contract BeaconIntegrationTest is BeaconTestBase {
     uint256 private constant POD_CREATION_GAS_BUDGET = 4_500_000;
     uint256 private constant BALANCE_UPDATE_GAS_BUDGET = 4_500_000;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // TEST FIXTURES (EigenLayer-style)
     // ═══════════════════════════════════════════════════════════════════════════
@@ -307,7 +308,7 @@ contract BeaconIntegrationTest is BeaconTestBase {
         if (_skipGasChecks()) return;
         vm.prank(operator1);
         uint256 gasBefore = gasleft();
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
         uint256 gasUsed = gasBefore - gasleft();
 
         console2.log("Gas used for registerOperator:", gasUsed);
@@ -326,6 +327,7 @@ contract BeaconIntegrationTest is BeaconTestBase {
         console2.log("Gas used for recordBeaconChainEthBalanceUpdate:", gasUsed);
         assertTrue(gasUsed < BALANCE_UPDATE_GAS_BUDGET, "Balance update should remain within gas budget");
     }
+
     function _skipGasChecks() internal view returns (bool) {
         return vm.envOr("FOUNDRY_COVERAGE", false);
     }

--- a/test/beacon/BeaconProofFixtureTest.t.sol
+++ b/test/beacon/BeaconProofFixtureTest.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BeaconTestBase} from "./BeaconTestBase.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {Test, console2} from "forge-std/Test.sol";
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { Test, console2 } from "forge-std/Test.sol";
 
 /// @title BeaconProofFixtureTest
 /// @notice Tests using real beacon chain proof fixtures
@@ -14,7 +14,6 @@ import {Test, console2} from "forge-std/Test.sol";
 /// @dev To generate real fixtures, use eigenpod-proofs-generation CLI tool:
 ///      https://github.com/Layr-Labs/eigenpod-proofs-generation
 contract BeaconProofFixtureTest is BeaconTestBase {
-
     // ═══════════════════════════════════════════════════════════════════════════
     // FIXTURE STRUCTURES
     // ═══════════════════════════════════════════════════════════════════════════
@@ -55,10 +54,11 @@ contract BeaconProofFixtureTest is BeaconTestBase {
         fixture.name = "Sample Mainnet Validator Proof - Slot 8000000";
         fixture.beaconBlockRoot = bytes32(uint256(0x1111));
         fixture.beaconStateRoot = bytes32(uint256(0x2222));
-        fixture.validatorIndex = 123456;
+        fixture.validatorIndex = 123_456;
         fixture.expectedPubkeyHash = bytes32(uint256(0xABCDEF));
         fixture.expectedEffectiveBalanceGwei = 32_000_000_000;
-        fixture.expectedWithdrawalCredentials = bytes32(uint256(0x010000000000000000000000000000000000000000000000000000000000BEEF));
+        fixture.expectedWithdrawalCredentials =
+            bytes32(uint256(0x010000000000000000000000000000000000000000000000000000000000BEEF));
         fixture.expectedSlashed = false;
 
         fixture.stateRootProof = new bytes32[](3);
@@ -89,8 +89,8 @@ contract BeaconProofFixtureTest is BeaconTestBase {
         ValidatorProofFixture memory fixture = _loadValidatorFixture("validator_proof_fixture_1.json");
 
         assertEq(fixture.name, "Sample Mainnet Validator Proof - Slot 8000000", "Name should match");
-        assertEq(fixture.validatorIndex, 123456, "Validator index should match");
-        assertEq(fixture.expectedEffectiveBalanceGwei, 32000000000, "Effective balance should be 32 ETH in gwei");
+        assertEq(fixture.validatorIndex, 123_456, "Validator index should match");
+        assertEq(fixture.expectedEffectiveBalanceGwei, 32_000_000_000, "Effective balance should be 32 ETH in gwei");
         assertFalse(fixture.expectedSlashed, "Should not be slashed");
     }
 
@@ -141,10 +141,8 @@ contract BeaconProofFixtureTest is BeaconTestBase {
             }
         }
 
-        ValidatorTypes.StateRootProof memory stateRootProof = ValidatorTypes.StateRootProof({
-            beaconStateRoot: fixture.beaconStateRoot,
-            proof: proofBytes
-        });
+        ValidatorTypes.StateRootProof memory stateRootProof =
+            ValidatorTypes.StateRootProof({ beaconStateRoot: fixture.beaconStateRoot, proof: proofBytes });
 
         // Note: This will fail with placeholder data
         // Replace fixture with real proof data from eigenpod-proofs-generation
@@ -176,15 +174,12 @@ contract BeaconProofFixtureTest is BeaconTestBase {
         bytes memory stateProofBytes = _bytes32ArrayToBytes(fixture.stateRootProof);
         bytes memory validatorProofBytes = _bytes32ArrayToBytes(fixture.validatorFieldsProof);
 
-        ValidatorTypes.StateRootProof memory stateRootProof = ValidatorTypes.StateRootProof({
-            beaconStateRoot: fixture.beaconStateRoot,
-            proof: stateProofBytes
-        });
+        ValidatorTypes.StateRootProof memory stateRootProof =
+            ValidatorTypes.StateRootProof({ beaconStateRoot: fixture.beaconStateRoot, proof: stateProofBytes });
 
         ValidatorTypes.ValidatorFieldsProof[] memory validatorProofs = new ValidatorTypes.ValidatorFieldsProof[](1);
         validatorProofs[0] = ValidatorTypes.ValidatorFieldsProof({
-            validatorFields: fixture.validatorFields,
-            proof: validatorProofBytes
+            validatorFields: fixture.validatorFields, proof: validatorProofBytes
         });
 
         uint40[] memory validatorIndices = new uint40[](1);

--- a/test/beacon/BeaconRootReceiverTest.t.sol
+++ b/test/beacon/BeaconRootReceiverTest.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {BeaconRootReceiver} from "../../src/beacon/BeaconRootReceiver.sol";
-import {IL2CrossDomainMessenger} from "../../src/beacon/IBeaconOracle.sol";
+import { BeaconRootReceiver } from "../../src/beacon/BeaconRootReceiver.sol";
+import { IL2CrossDomainMessenger } from "../../src/beacon/IBeaconOracle.sol";
 
 contract MockL2Messenger is IL2CrossDomainMessenger {
     address public currentSender;
@@ -13,12 +13,7 @@ contract MockL2Messenger is IL2CrossDomainMessenger {
         return currentSender;
     }
 
-    function deliver(
-        address receiver,
-        address l1Sender,
-        uint64 timestamp,
-        bytes32 root
-    ) external {
+    function deliver(address receiver, address l1Sender, uint64 timestamp, bytes32 root) external {
         currentSender = l1Sender;
         BeaconRootReceiver(receiver).receiveBeaconRoot(timestamp, root);
     }

--- a/test/beacon/BeaconRootRelayerTest.t.sol
+++ b/test/beacon/BeaconRootRelayerTest.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {BeaconRootRelayer} from "../../src/beacon/l1/BeaconRootRelayer.sol";
-import {IL1CrossDomainMessenger} from "../../src/beacon/IBeaconOracle.sol";
+import { BeaconRootRelayer } from "../../src/beacon/l1/BeaconRootRelayer.sol";
+import { IL1CrossDomainMessenger } from "../../src/beacon/IBeaconOracle.sol";
 
 contract MockL1CrossDomainMessenger is IL1CrossDomainMessenger {
     address public lastTarget;

--- a/test/beacon/BeaconTestBase.sol
+++ b/test/beacon/BeaconTestBase.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {MockBeaconOracle} from "../../src/beacon/BeaconRootReceiver.sol";
+import { Test } from "forge-std/Test.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { MockBeaconOracle } from "../../src/beacon/BeaconRootReceiver.sol";
 
 /// @title BeaconTestBase
 /// @notice Base test contract for beacon chain staking tests
@@ -14,7 +14,10 @@ abstract contract BeaconTestBase is Test {
         ValidatorTypes.ValidatorStatus left,
         ValidatorTypes.ValidatorStatus right,
         string memory err
-    ) internal pure {
+    )
+        internal
+        pure
+    {
         if (left != right) {
             revert(err);
         }
@@ -45,7 +48,7 @@ abstract contract BeaconTestBase is Test {
 
     uint256 public constant MIN_OPERATOR_STAKE = 1 ether;
     uint64 public constant VALIDATOR_BALANCE_GWEI = 32_000_000_000; // 32 ETH
-    uint64 public constant BEACON_TIMESTAMP = 1700000000;
+    uint64 public constant BEACON_TIMESTAMP = 1_700_000_000;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SETUP
@@ -84,7 +87,7 @@ abstract contract BeaconTestBase is Test {
     /// @notice Register an operator
     function _registerOperator(address operator, uint256 stake) internal {
         vm.prank(operator);
-        podManager.registerOperator{value: stake}();
+        podManager.registerOperator{ value: stake }();
     }
 
     /// @notice Create a pod and give it shares for delegation testing
@@ -104,7 +107,10 @@ abstract contract BeaconTestBase is Test {
 
     /// @notice Generate a simple valid Merkle proof for testing
     /// @dev Creates a minimal 2-level tree where leaf is at index 0
-    function _generateSimpleMerkleProof(bytes32 leaf, bytes32 sibling)
+    function _generateSimpleMerkleProof(
+        bytes32 leaf,
+        bytes32 sibling
+    )
         internal
         pure
         returns (bytes memory proof, bytes32 root)
@@ -122,7 +128,11 @@ abstract contract BeaconTestBase is Test {
         bytes32 leaf,
         bytes32[] memory siblings,
         uint256 leafIndex
-    ) internal pure returns (bytes memory proof, bytes32 root) {
+    )
+        internal
+        pure
+        returns (bytes memory proof, bytes32 root)
+    {
         bytes32 current = leaf;
         proof = "";
 
@@ -148,7 +158,11 @@ abstract contract BeaconTestBase is Test {
         bool slashed,
         uint64 activationEpoch,
         uint64 exitEpoch
-    ) internal pure returns (bytes32[] memory fields) {
+    )
+        internal
+        pure
+        returns (bytes32[] memory fields)
+    {
         fields = new bytes32[](8);
         fields[0] = pubkeyHash;
         fields[1] = withdrawalCredentials;
@@ -179,11 +193,14 @@ abstract contract BeaconTestBase is Test {
         uint64 balance1,
         uint64 balance2,
         uint64 balance3
-    ) internal pure returns (bytes32) {
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
         // Pack 4 64-bit balances into 32 bytes (little-endian)
         return bytes32(
-            uint256(balance0) | (uint256(balance1) << 64) | (uint256(balance2) << 128)
-                | (uint256(balance3) << 192)
+            uint256(balance0) | (uint256(balance1) << 64) | (uint256(balance2) << 128) | (uint256(balance3) << 192)
         );
     }
 

--- a/test/beacon/CrossChainSlashingTest.t.sol
+++ b/test/beacon/CrossChainSlashingTest.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test, console2} from "forge-std/Test.sol";
-import {L2SlashingConnector} from "../../src/beacon/L2SlashingConnector.sol";
-import {L2SlashingReceiver, IL2Slasher} from "../../src/beacon/L2SlashingReceiver.sol";
-import {TangleL2Slasher} from "../../src/beacon/TangleL2Slasher.sol";
-import {ICrossChainMessenger, ICrossChainReceiver} from "../../src/beacon/interfaces/ICrossChainMessenger.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {MockBeaconOracle} from "../../src/beacon/BeaconRootReceiver.sol";
+import { Test, console2 } from "forge-std/Test.sol";
+import { L2SlashingConnector } from "../../src/beacon/L2SlashingConnector.sol";
+import { L2SlashingReceiver, IL2Slasher } from "../../src/beacon/L2SlashingReceiver.sol";
+import { TangleL2Slasher } from "../../src/beacon/TangleL2Slasher.sol";
+import { ICrossChainMessenger, ICrossChainReceiver } from "../../src/beacon/interfaces/ICrossChainMessenger.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { MockBeaconOracle } from "../../src/beacon/BeaconRootReceiver.sol";
 import { IStaking } from "../../src/interfaces/IStaking.sol";
 import { Types } from "../../src/libraries/Types.sol";
 
@@ -30,10 +30,10 @@ contract MockCrossChainMessenger is ICrossChainMessenger {
 
     constructor() {
         // Support common test chains
-        supportedChains[1] = true;      // Ethereum
-        supportedChains[8453] = true;   // Base
-        supportedChains[42161] = true;  // Arbitrum
-        supportedChains[5000] = true;   // Test chain (Tangle)
+        supportedChains[1] = true; // Ethereum
+        supportedChains[8453] = true; // Base
+        supportedChains[42_161] = true; // Arbitrum
+        supportedChains[5000] = true; // Test chain (Tangle)
     }
 
     function sendMessage(
@@ -41,26 +41,28 @@ contract MockCrossChainMessenger is ICrossChainMessenger {
         address target,
         bytes calldata payload,
         uint256 gasLimit
-    ) external payable returns (bytes32 messageId) {
+    )
+        external
+        payable
+        returns (bytes32 messageId)
+    {
         require(supportedChains[destinationChainId], "Unsupported chain");
         require(msg.value >= mockFee, "Insufficient fee");
 
-        messages.push(Message({
-            destinationChainId: destinationChainId,
-            target: target,
-            payload: payload,
-            gasLimit: gasLimit,
-            fee: msg.value
-        }));
+        messages.push(
+            Message({
+                destinationChainId: destinationChainId,
+                target: target,
+                payload: payload,
+                gasLimit: gasLimit,
+                fee: msg.value
+            })
+        );
 
         messageId = keccak256(abi.encode(messageCount++, destinationChainId, target, payload));
     }
 
-    function estimateFee(
-        uint256,
-        bytes calldata,
-        uint256
-    ) external view returns (uint256 fee) {
+    function estimateFee(uint256, bytes calldata, uint256) external view returns (uint256 fee) {
         return mockFee;
     }
 
@@ -87,11 +89,7 @@ contract MockCrossChainMessenger is ICrossChainMessenger {
         Message memory msg_ = messages[messages.length - 1];
 
         // Call the receiver as if we're the bridge
-        ICrossChainReceiver(receiver).receiveMessage(
-            sourceChainId,
-            sender,
-            msg_.payload
-        );
+        ICrossChainReceiver(receiver).receiveMessage(sourceChainId, sender, msg_.payload);
     }
 }
 
@@ -128,7 +126,10 @@ contract MockStaking is IStaking {
         uint64,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed) {
+    )
+        external
+        returns (uint256 actualSlashed)
+    {
         require(slashers[msg.sender], "Not a slasher");
         require(operators[operator], "Not an operator");
 
@@ -150,7 +151,10 @@ contract MockStaking is IStaking {
         uint64,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed) {
+    )
+        external
+        returns (uint256 actualSlashed)
+    {
         return this.slash(operator, 0, slashBps, evidence);
     }
 
@@ -161,39 +165,72 @@ contract MockStaking is IStaking {
         Types.AssetSecurityCommitment[] calldata,
         uint16 slashBps,
         bytes32 evidence
-    ) external returns (uint256 actualSlashed) {
+    )
+        external
+        returns (uint256 actualSlashed)
+    {
         return this.slash(operator, 0, slashBps, evidence);
     }
 
     // Other interface methods (not used in tests)
-    function registerOperator(bytes calldata, bytes calldata) external {}
-    function updateOperatorMetadata(bytes calldata) external {}
-    function unregisterOperator() external {}
-    function delegate(address, uint256) external {}
-    function undelegate(address, uint256) external {}
-    function notifyReward(address, uint64, uint256) external {}
-    function notifyRewardForBlueprint(address, uint64, uint64, uint256) external {}
-    function getOperatorDelegatedStake(address) external view returns (uint256) { return 0; }
-    function getOperatorDelegatedStakeForAsset(address, Types.Asset calldata) external pure returns (uint256) { return 0; }
+    function registerOperator(bytes calldata, bytes calldata) external { }
+    function updateOperatorMetadata(bytes calldata) external { }
+    function unregisterOperator() external { }
+    function delegate(address, uint256) external { }
+    function undelegate(address, uint256) external { }
+    function notifyReward(address, uint64, uint256) external { }
+    function notifyRewardForBlueprint(address, uint64, uint64, uint256) external { }
+
+    function getOperatorDelegatedStake(address) external view returns (uint256) {
+        return 0;
+    }
+
+    function getOperatorDelegatedStakeForAsset(address, Types.Asset calldata) external pure returns (uint256) {
+        return 0;
+    }
+
     function getOperatorStakeForAsset(address operator, Types.Asset calldata) external view returns (uint256) {
         return operatorStakes[operator];
     }
 
     // Additional interface methods
-    function getDelegation(address, address) external pure returns (uint256) { return 0; }
-    function getOperatorSelfStake(address operator) external view returns (uint256) { return operatorStakes[operator]; }
-    function getTotalDelegation(address) external pure returns (uint256) { return 0; }
-    function isOperator(address operator) external view returns (bool) { return operators[operator]; }
-    function isOperatorActive(address operator) external view returns (bool) { return operators[operator]; }
-    function meetsStakeRequirement(address operator, uint256 required) external view returns (bool) { return operatorStakes[operator] >= required; }
-    function minOperatorStake() external pure returns (uint256) { return 1 ether; }
-    function addBlueprintForOperator(address, uint64) external override {}
-    function removeBlueprintForOperator(address, uint64) external override {}
+    function getDelegation(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getOperatorSelfStake(address operator) external view returns (uint256) {
+        return operatorStakes[operator];
+    }
+
+    function getTotalDelegation(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function isOperator(address operator) external view returns (bool) {
+        return operators[operator];
+    }
+
+    function isOperatorActive(address operator) external view returns (bool) {
+        return operators[operator];
+    }
+
+    function meetsStakeRequirement(address operator, uint256 required) external view returns (bool) {
+        return operatorStakes[operator] >= required;
+    }
+
+    function minOperatorStake() external pure returns (uint256) {
+        return 1 ether;
+    }
+    function addBlueprintForOperator(address, uint64) external override { }
+    function removeBlueprintForOperator(address, uint64) external override { }
 
     // M-9 FIX: Pending slash tracking (no-op for mock)
-    function incrementPendingSlash(address) external override {}
-    function decrementPendingSlash(address) external override {}
-    function getPendingSlashCount(address) external pure override returns (uint64) { return 0; }
+    function incrementPendingSlash(address) external override { }
+    function decrementPendingSlash(address) external override { }
+
+    function getPendingSlashCount(address) external pure override returns (uint64) {
+        return 0;
+    }
 }
 
 /// @title CrossChainSlashingTest
@@ -233,7 +270,7 @@ contract CrossChainSlashingTest is Test {
 
         // Register operator1 with pod manager so operatorDelegatedStake returns value
         vm.prank(operator1);
-        podManager.registerOperator{value: 10 ether}();
+        podManager.registerOperator{ value: 10 ether }();
 
         // Deploy mock messenger
         messenger = new MockCrossChainMessenger();
@@ -280,10 +317,10 @@ contract CrossChainSlashingTest is Test {
 
     function test_propagateBeaconSlashing_Success() public {
         // First slash: 100% (implicit) -> 90%
-        uint64 newFactor = 0.9e18;  // 90% (10% slashed from initial 100%)
+        uint64 newFactor = 0.9e18; // 90% (10% slashed from initial 100%)
 
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, newFactor);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, newFactor);
 
         // Check message was sent
         assertEq(messenger.messageCount(), 1);
@@ -296,7 +333,7 @@ contract CrossChainSlashingTest is Test {
         address unknownPod = makeAddr("unknownPod");
         vm.prank(oracle);
         vm.expectRevert(abi.encodeWithSelector(L2SlashingConnector.UnknownPod.selector, unknownPod));
-        connector.propagateBeaconSlashing{value: 0.01 ether}(unknownPod, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(unknownPod, 0.9e18);
     }
 
     function test_propagateBeaconSlashingToSpecificChain() public {
@@ -307,7 +344,7 @@ contract CrossChainSlashingTest is Test {
         connector.setChainConfig(altChainId, altReceiver, 150_000, true);
 
         vm.prank(oracle);
-        connector.propagateBeaconSlashingToChain{value: 0.01 ether}(pod1, 0.95e18, altChainId);
+        connector.propagateBeaconSlashingToChain{ value: 0.01 ether }(pod1, 0.95e18, altChainId);
 
         MockCrossChainMessenger.Message memory msgAlt = messenger.getLastMessage();
         assertEq(msgAlt.destinationChainId, altChainId);
@@ -359,7 +396,7 @@ contract CrossChainSlashingTest is Test {
         );
 
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
 
         uint64 futureFactor = 0.8e18;
         uint256 delta = uint256(0.9e18 - futureFactor);
@@ -389,18 +426,18 @@ contract CrossChainSlashingTest is Test {
         vm.deal(random, 1 ether);
         vm.prank(random);
         vm.expectRevert(L2SlashingConnector.OnlySlashingOracle.selector);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
     }
 
     function test_propagateBeaconSlashing_RevertInvalidFactor() public {
         // First set up initial factor: 100% -> 90%
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
 
         // Try to propagate a higher/equal factor (should revert)
         vm.prank(oracle);
         vm.expectRevert(L2SlashingConnector.InvalidSlashingFactor.selector);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.95e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.95e18);
     }
 
     function test_propagateBeaconSlashing_RevertUnsupportedChain() public {
@@ -410,7 +447,7 @@ contract CrossChainSlashingTest is Test {
 
         vm.expectRevert(L2SlashingConnector.UnsupportedDestinationChain.selector);
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
     }
 
     function test_propagateBeaconSlashing_RevertMessengerNotConfigured() public {
@@ -419,7 +456,7 @@ contract CrossChainSlashingTest is Test {
 
         vm.startPrank(oracle);
         vm.expectRevert(L2SlashingConnector.MessengerNotConfigured.selector);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
         vm.stopPrank();
     }
 
@@ -428,7 +465,7 @@ contract CrossChainSlashingTest is Test {
 
         vm.startPrank(oracle);
         vm.expectRevert(L2SlashingConnector.InsufficientFee.selector);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
         vm.stopPrank();
     }
 
@@ -475,7 +512,7 @@ contract CrossChainSlashingTest is Test {
     function test_estimatePropagationFee() public {
         // First propagate to set up state
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.95e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.95e18);
 
         // Now estimate fee for next slash
         uint256 fee = connector.estimatePropagationFee(pod1, 0.9e18, TANGLE_CHAIN_ID);
@@ -502,10 +539,8 @@ contract CrossChainSlashingTest is Test {
         uint64 slashingFactor = 0.9e18;
         uint256 nonce = 0;
 
-        bytes memory payload = abi.encodePacked(
-            messageType,
-            abi.encode(operator1, slashBps, slashingFactor, nonce, pod1)
-        );
+        bytes memory payload =
+            abi.encodePacked(messageType, abi.encode(operator1, slashBps, slashingFactor, nonce, pod1));
 
         // Deliver message as messenger
         vm.prank(address(messenger));
@@ -526,10 +561,7 @@ contract CrossChainSlashingTest is Test {
 
     function test_receiveMessage_RevertUnauthorizedSender() public {
         bytes4 messageType = bytes4(keccak256("BEACON_SLASH"));
-        bytes memory payload = abi.encodePacked(
-            messageType,
-            abi.encode(operator1, uint16(1000), 0.9e18, 0, pod1)
-        );
+        bytes memory payload = abi.encodePacked(messageType, abi.encode(operator1, uint16(1000), 0.9e18, 0, pod1));
 
         vm.expectRevert(L2SlashingReceiver.UnauthorizedSender.selector);
         vm.prank(address(messenger));
@@ -540,10 +572,7 @@ contract CrossChainSlashingTest is Test {
         bytes4 messageType = bytes4(keccak256("BEACON_SLASH"));
         uint256 nonce = 42;
         uint16 slashBps = 1000;
-        bytes memory payload = abi.encodePacked(
-            messageType,
-            abi.encode(operator1, slashBps, 0.9e18, nonce, pod1)
-        );
+        bytes memory payload = abi.encodePacked(messageType, abi.encode(operator1, slashBps, 0.9e18, nonce, pod1));
 
         // First delivery works
         vm.prank(address(messenger));
@@ -567,10 +596,7 @@ contract CrossChainSlashingTest is Test {
         slasher.setPaused(true);
 
         bytes4 messageType = bytes4(keccak256("BEACON_SLASH"));
-        bytes memory payload = abi.encodePacked(
-            messageType,
-            abi.encode(operator1, uint16(1000), 0.9e18, 0, pod1)
-        );
+        bytes memory payload = abi.encodePacked(messageType, abi.encode(operator1, uint16(1000), 0.9e18, 0, pod1));
 
         uint256 previousSlash = staking.lastSlashAmount();
         vm.prank(address(messenger));
@@ -660,11 +686,11 @@ contract CrossChainSlashingTest is Test {
         );
 
         // 1. Oracle detects beacon chain slashing and calls connector
-        uint64 slashedFactor = 0.8e18;  // 80% (20% slashed)
+        uint64 slashedFactor = 0.8e18; // 80% (20% slashed)
 
         // 2. Propagate slashing
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, slashedFactor);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, slashedFactor);
 
         // 3. Get cross-chain message
         MockCrossChainMessenger.Message memory msg1 = messenger.getLastMessage();
@@ -691,7 +717,7 @@ contract CrossChainSlashingTest is Test {
 
         // First slash: 100% (implicit) -> 90%
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
 
         MockCrossChainMessenger.Message memory msg1 = messenger.getLastMessage();
         vm.prank(address(messenger));
@@ -702,7 +728,7 @@ contract CrossChainSlashingTest is Test {
 
         // Second slash: 90% -> 80%
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{value: 0.01 ether}(pod1, 0.8e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.8e18);
 
         MockCrossChainMessenger.Message memory msg2 = messenger.getLastMessage();
         vm.prank(address(messenger));
@@ -717,7 +743,7 @@ contract CrossChainSlashingTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_connector_setChainConfig() public {
-        uint256 newChainId = 12345;
+        uint256 newChainId = 12_345;
 
         vm.prank(admin);
         connector.setChainConfig(newChainId, makeAddr("receiver"), 300_000, true);

--- a/test/beacon/LiveBeaconTest.t.sol
+++ b/test/beacon/LiveBeaconTest.t.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
 
 /// @title LiveBeaconTest
 /// @notice Integration tests using real Ethereum mainnet/testnet data
@@ -16,12 +16,12 @@ contract LiveBeaconTest is Test {
 
     // Test validator indices (mainnet examples)
     uint64 constant SAMPLE_VALIDATOR_INDEX = 0; // Genesis validator
-    uint64 constant LIDO_VALIDATOR_INDEX = 123456; // Example Lido validator
+    uint64 constant LIDO_VALIDATOR_INDEX = 123_456; // Example Lido validator
 
     /// @notice Test that EIP-4788 beacon root oracle is deployed on fork
     function test_beaconRootOracleExists() public view {
         // Skip if not on a fork
-        if (block.chainid != 1 && block.chainid != 17000) {
+        if (block.chainid != 1 && block.chainid != 17_000) {
             return;
         }
 
@@ -35,7 +35,7 @@ contract LiveBeaconTest is Test {
     /// @notice Test querying beacon root from EIP-4788 oracle
     function test_queryBeaconRoot() public {
         // Skip if not on a fork
-        if (block.chainid != 1 && block.chainid != 17000) {
+        if (block.chainid != 1 && block.chainid != 17_000) {
             return;
         }
 
@@ -120,10 +120,10 @@ contract LiveBeaconTest is Test {
         // Pack 4 balances into a leaf (little-endian)
         // Validator 0: 32 ETH, Validator 1: 31.5 ETH, Validator 2: 32.1 ETH, Validator 3: 0 ETH
         bytes32 balanceLeaf = bytes32(
-            uint256(32_000_000_000) |           // Index 0
-            (uint256(31_500_000_000) << 64) |   // Index 1
-            (uint256(32_100_000_000) << 128) |  // Index 2
-            (uint256(0) << 192)                  // Index 3
+            uint256(32_000_000_000) // Index 0
+                | (uint256(31_500_000_000) << 64) // Index 1
+                | (uint256(32_100_000_000) << 128) // Index 2
+                | (uint256(0) << 192) // Index 3
         );
 
         // Extract balances at each position
@@ -146,11 +146,11 @@ contract LiveBeaconTest is Test {
         // = 47278999994368
 
         uint256 gindex0 = (uint256(43) << 40) | 0;
-        assertEq(gindex0, 47278999994368, "Validator 0 gindex");
+        assertEq(gindex0, 47_278_999_994_368, "Validator 0 gindex");
 
         // Validator at index 100
         uint256 gindex100 = (uint256(43) << 40) | 100;
-        assertEq(gindex100, 47278999994468, "Validator 100 gindex");
+        assertEq(gindex100, 47_278_999_994_468, "Validator 100 gindex");
     }
 
     /// @notice Test generalized index calculation for balances
@@ -176,12 +176,10 @@ contract LiveBeaconTest is Test {
         uint64 priorBalance = 32_000_000_000;
         uint64 currentBalance = 31_000_000_000;
 
-        uint64 newFactor = uint64(
-            (uint256(initialFactor) * uint256(currentBalance)) / uint256(priorBalance)
-        );
+        uint64 newFactor = uint64((uint256(initialFactor) * uint256(currentBalance)) / uint256(priorBalance));
 
         // Expected: 31/32 * 1e18 = 968750000000000000
-        assertEq(newFactor, 968750000000000000, "Slashing factor after 1 ETH penalty");
+        assertEq(newFactor, 968_750_000_000_000_000, "Slashing factor after 1 ETH penalty");
 
         // Apply slashing factor to 100 ETH of shares
         uint256 shares = 100 ether;

--- a/test/beacon/ValidatorPodManagerTest.t.sol
+++ b/test/beacon/ValidatorPodManagerTest.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BeaconTestBase} from "./BeaconTestBase.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {console2} from "forge-std/Test.sol";
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { console2 } from "forge-std/Test.sol";
 
 /// @title ValidatorPodManagerTest
 /// @notice Tests for ValidatorPodManager contract
@@ -83,7 +83,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
 
     function test_registerOperator_Success() public {
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         assertTrue(podManager.isOperator(operator1), "Should be registered as operator");
         assertTrue(podManager.isOperatorActive(operator1), "Should be active operator");
@@ -93,33 +93,31 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_registerOperator_InsufficientStake() public {
         vm.prank(operator1);
         vm.expectRevert(ValidatorPodManager.InsufficientStake.selector);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE - 1}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE - 1 }();
     }
 
     function test_registerOperator_AlreadyOperator() public {
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         vm.prank(operator1);
         vm.expectRevert(ValidatorPodManager.AlreadyOperator.selector);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
     }
 
     function test_increaseOperatorStake_Success() public {
         _registerOperator(operator1, MIN_OPERATOR_STAKE);
 
         vm.prank(operator1);
-        podManager.increaseOperatorStake{value: 1 ether}();
+        podManager.increaseOperatorStake{ value: 1 ether }();
 
-        assertEq(
-            podManager.getOperatorSelfStake(operator1), MIN_OPERATOR_STAKE + 1 ether, "Stake should be increased"
-        );
+        assertEq(podManager.getOperatorSelfStake(operator1), MIN_OPERATOR_STAKE + 1 ether, "Stake should be increased");
     }
 
     function test_increaseOperatorStake_NotOperator() public {
         vm.prank(operator1);
         vm.expectRevert(ValidatorPodManager.NotOperator.selector);
-        podManager.increaseOperatorStake{value: 1 ether}();
+        podManager.increaseOperatorStake{ value: 1 ether }();
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -129,7 +127,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_Success() public {
         // Register operator with stake
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         uint256 balanceBefore = operator1.balance;
 
@@ -148,7 +146,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
 
     function test_deregisterOperator_EmitsEvent() public {
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         vm.prank(operator1);
         vm.expectEmit(true, false, false, false);
@@ -165,7 +163,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_HasPendingDelegations() public {
         // Setup: Register operator and create pod with shares
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         // Create pod and add shares for podOwner1
         vm.prank(podOwner1);
@@ -189,7 +187,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_AfterDelegatorsUndelegate() public {
         // Setup: Register operator
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         // Create pod and add shares
         vm.prank(podOwner1);
@@ -224,7 +222,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_ZeroStake() public {
         // Register with minimum stake
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         // Get slashed to zero (need to setup slasher)
         vm.prank(admin);
@@ -249,7 +247,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_CanReregister() public {
         // Register
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         // Deregister
         vm.prank(operator1);
@@ -257,7 +255,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
 
         // Re-register should work
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         assertTrue(podManager.isOperator(operator1), "Should be operator again");
         assertEq(podManager.getOperatorSelfStake(operator1), MIN_OPERATOR_STAKE, "Stake should be set");
@@ -266,11 +264,11 @@ contract ValidatorPodManagerTest is BeaconTestBase {
     function test_deregisterOperator_WithIncreasedStake() public {
         // Register with minimum
         vm.prank(operator1);
-        podManager.registerOperator{value: MIN_OPERATOR_STAKE}();
+        podManager.registerOperator{ value: MIN_OPERATOR_STAKE }();
 
         // Increase stake
         vm.prank(operator1);
-        podManager.increaseOperatorStake{value: 5 ether}();
+        podManager.increaseOperatorStake{ value: 5 ether }();
 
         uint256 totalStake = MIN_OPERATOR_STAKE + 5 ether;
         assertEq(podManager.getOperatorSelfStake(operator1), totalStake, "Total stake should be sum");
@@ -331,8 +329,14 @@ contract ValidatorPodManagerTest is BeaconTestBase {
         bytes32 undelegationRoot = podManager.queueUndelegation(operator1, 3 ether);
 
         // Check queued state
-        (address delegator, address operator, uint256 amount, uint32 startBlock, uint32 completableBlock, bool completed) =
-            podManager.getUndelegationInfo(undelegationRoot);
+        (
+            address delegator,
+            address operator,
+            uint256 amount,
+            uint32 startBlock,
+            uint32 completableBlock,
+            bool completed
+        ) = podManager.getUndelegationInfo(undelegationRoot);
 
         assertEq(delegator, podOwner1, "Delegator mismatch");
         assertEq(operator, operator1, "Operator mismatch");
@@ -449,11 +453,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
 
         uint256 expectedSlashed = (stakeBefore * slashBps) / 10_000;
         assertEq(slashed, expectedSlashed, "Should slash requested amount");
-        assertEq(
-            podManager.getOperatorSelfStake(operator1),
-            stakeBefore - expectedSlashed,
-            "Stake should be reduced"
-        );
+        assertEq(podManager.getOperatorSelfStake(operator1), stakeBefore - expectedSlashed, "Stake should be reduced");
     }
 
     function test_slash_ExceedsStake() public {
@@ -766,7 +766,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
         vm.roll(block.number + podManager.withdrawalDelayBlocks() + 1);
 
         // Check can complete
-        (, , , , bool canComplete) = podManager.getWithdrawalInfo(withdrawalRoot);
+        (,,,, bool canComplete) = podManager.getWithdrawalInfo(withdrawalRoot);
         assertTrue(canComplete, "Should be able to complete now");
 
         uint256 balanceBefore = podOwner1.balance;
@@ -776,7 +776,7 @@ contract ValidatorPodManagerTest is BeaconTestBase {
         podManager.completeWithdrawal(withdrawalRoot);
 
         // Verify completion
-        (, , , bool completed, ) = podManager.getWithdrawalInfo(withdrawalRoot);
+        (,,, bool completed,) = podManager.getWithdrawalInfo(withdrawalRoot);
         assertTrue(completed, "Should be completed");
 
         assertEq(podOwner1.balance, balanceBefore + 10 ether, "ETH should be transferred");

--- a/test/beacon/ValidatorPodTest.t.sol
+++ b/test/beacon/ValidatorPodTest.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BeaconTestBase} from "./BeaconTestBase.sol";
-import {ValidatorPod} from "../../src/beacon/ValidatorPod.sol";
-import {ValidatorPodManager} from "../../src/beacon/ValidatorPodManager.sol";
-import {ValidatorTypes} from "../../src/beacon/ValidatorTypes.sol";
-import {BeaconChainProofs} from "../../src/beacon/BeaconChainProofs.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {console2} from "forge-std/Test.sol";
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+import { ValidatorPodManager } from "../../src/beacon/ValidatorPodManager.sol";
+import { ValidatorTypes } from "../../src/beacon/ValidatorTypes.sol";
+import { BeaconChainProofs } from "../../src/beacon/BeaconChainProofs.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { console2 } from "forge-std/Test.sol";
 
 /// @title ValidatorPodTest
 /// @notice Tests for ValidatorPod contract
@@ -57,14 +57,13 @@ contract ValidatorPodTest is BeaconTestBase {
         bytes32 withdrawalCredentials,
         uint64 effectiveBalanceGwei,
         bytes32 salt
-    ) internal pure returns (RestakeProofData memory data) {
+    )
+        internal
+        pure
+        returns (RestakeProofData memory data)
+    {
         bytes32[] memory fields = _generateValidatorFields(
-            pubkeyHash,
-            withdrawalCredentials,
-            effectiveBalanceGwei,
-            false,
-            1234,
-            type(uint64).max - 1024
+            pubkeyHash, withdrawalCredentials, effectiveBalanceGwei, false, 1234, type(uint64).max - 1024
         );
 
         bytes32 validatorLeaf = _hashValidatorFields(fields);
@@ -76,18 +75,13 @@ contract ValidatorPodTest is BeaconTestBase {
         );
 
         (bytes memory stateProofBytes, bytes32 beaconBlockRoot) = _buildProofFromIndex(
-            beaconStateRoot,
-            STATE_ROOT_INDEX,
-            STATE_ROOT_TREE_HEIGHT,
-            keccak256(abi.encodePacked(salt, "state"))
+            beaconStateRoot, STATE_ROOT_INDEX, STATE_ROOT_TREE_HEIGHT, keccak256(abi.encodePacked(salt, "state"))
         );
 
         data.beaconTimestamp = beaconTimestamp;
         data.beaconBlockRoot = beaconBlockRoot;
-        data.stateRootProof = ValidatorTypes.StateRootProof({
-            beaconStateRoot: beaconStateRoot,
-            proof: stateProofBytes
-        });
+        data.stateRootProof =
+            ValidatorTypes.StateRootProof({ beaconStateRoot: beaconStateRoot, proof: stateProofBytes });
 
         data.validatorIndices = new uint40[](1);
         data.validatorIndices[0] = validatorIndex;
@@ -104,7 +98,11 @@ contract ValidatorPodTest is BeaconTestBase {
         bytes32 pubkeyHash,
         uint64 balanceGwei,
         bytes32 salt
-    ) internal pure returns (CheckpointProofData memory data) {
+    )
+        internal
+        pure
+        returns (CheckpointProofData memory data)
+    {
         bytes32 balanceLeaf = _buildBalanceLeaf(validatorIndex, balanceGwei);
 
         (bytes memory balanceProofBytes, bytes32 balanceContainerRoot) = _buildProofFromIndex(
@@ -129,21 +127,15 @@ contract ValidatorPodTest is BeaconTestBase {
         );
 
         data.beaconBlockRoot = beaconBlockRoot;
-        data.stateRootProof = ValidatorTypes.StateRootProof({
-            beaconStateRoot: beaconStateRoot,
-            proof: stateProofBytes
-        });
+        data.stateRootProof =
+            ValidatorTypes.StateRootProof({ beaconStateRoot: beaconStateRoot, proof: stateProofBytes });
         data.balanceContainerProof = ValidatorTypes.BalanceContainerProof({
-            balanceContainerRoot: balanceContainerRoot,
-            proof: balanceContainerProofBytes
+            balanceContainerRoot: balanceContainerRoot, proof: balanceContainerProofBytes
         });
 
         data.proofs = new ValidatorTypes.BalanceProof[](1);
-        data.proofs[0] = ValidatorTypes.BalanceProof({
-            pubkeyHash: pubkeyHash,
-            balanceRoot: balanceLeaf,
-            proof: balanceProofBytes
-        });
+        data.proofs[0] =
+            ValidatorTypes.BalanceProof({ pubkeyHash: pubkeyHash, balanceRoot: balanceLeaf, proof: balanceProofBytes });
     }
 
     function _buildProofFromIndex(
@@ -151,7 +143,11 @@ contract ValidatorPodTest is BeaconTestBase {
         uint256 index,
         uint256 depth,
         bytes32 salt
-    ) internal pure returns (bytes memory proof, bytes32 root) {
+    )
+        internal
+        pure
+        returns (bytes memory proof, bytes32 root)
+    {
         proof = new bytes(depth * 32);
         bytes32 computed = leaf;
         uint256 idx = index;
@@ -176,7 +172,11 @@ contract ValidatorPodTest is BeaconTestBase {
         uint256 gindex,
         uint256 depth,
         bytes32 salt
-    ) internal pure returns (bytes memory proof, bytes32 root) {
+    )
+        internal
+        pure
+        returns (bytes memory proof, bytes32 root)
+    {
         proof = new bytes(depth * 32);
         bytes32 computed = leaf;
         uint256 idx = gindex;
@@ -205,12 +205,7 @@ contract ValidatorPodTest is BeaconTestBase {
     function _buildBalanceLeaf(uint40 validatorIndex, uint64 balanceGwei) internal pure returns (bytes32) {
         uint64[4] memory packedBalances;
         packedBalances[validatorIndex % VALIDATORS_PER_BALANCE_LEAF] = balanceGwei;
-        return _generateBalanceRoot(
-            packedBalances[0],
-            packedBalances[1],
-            packedBalances[2],
-            packedBalances[3]
-        );
+        return _generateBalanceRoot(packedBalances[0], packedBalances[1], packedBalances[2], packedBalances[3]);
     }
 
     function _validatorGindex(uint40 validatorIndex) internal pure returns (uint256) {
@@ -352,12 +347,7 @@ contract ValidatorPodTest is BeaconTestBase {
         bytes32 wrongCredentials = ValidatorTypes.computeWithdrawalCredentials(makeAddr("otherWithdrawal"));
 
         RestakeProofData memory proof = _buildRestakeProof(
-            uint64(block.timestamp),
-            3,
-            pubkeyHash,
-            wrongCredentials,
-            32_000_000_000,
-            bytes32("invalidWithdrawals")
+            uint64(block.timestamp), 3, pubkeyHash, wrongCredentials, 32_000_000_000, bytes32("invalidWithdrawals")
         );
 
         _setBeaconRoot(proof.beaconTimestamp, proof.beaconBlockRoot);
@@ -376,20 +366,12 @@ contract ValidatorPodTest is BeaconTestBase {
     function test_verifyWithdrawalCredentials_revertsWhenProofIsStale() public {
         vm.warp(1_000_000);
         uint64 staleTimestamp = uint64(block.timestamp - (27 hours + 1));
-        ValidatorTypes.StateRootProof memory dummyProof = ValidatorTypes.StateRootProof({
-            beaconStateRoot: bytes32(0),
-            proof: ""
-        });
+        ValidatorTypes.StateRootProof memory dummyProof =
+            ValidatorTypes.StateRootProof({ beaconStateRoot: bytes32(0), proof: "" });
 
         vm.expectRevert(ValidatorPod.StaleProof.selector);
         vm.prank(podOwner1);
-        pod.verifyWithdrawalCredentials(
-            staleTimestamp,
-            dummyProof,
-            new uint40[](0),
-            new bytes[](0),
-            new bytes32[][](0)
-        );
+        pod.verifyWithdrawalCredentials(staleTimestamp, dummyProof, new uint40[](0), new bytes[](0), new bytes32[][](0));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -436,12 +418,8 @@ contract ValidatorPodTest is BeaconTestBase {
 
         uint64 checkpointTimestamp = restakeProof.beaconTimestamp + 12;
         uint64 newBalance = 31_000_000_000;
-        CheckpointProofData memory checkpointProof = _buildCheckpointProof(
-            validatorIndex,
-            pubkeyHash,
-            newBalance,
-            bytes32("checkpointProof")
-        );
+        CheckpointProofData memory checkpointProof =
+            _buildCheckpointProof(validatorIndex, pubkeyHash, newBalance, bytes32("checkpointProof"));
 
         _setBeaconRoot(checkpointTimestamp, checkpointProof.beaconBlockRoot);
         vm.warp(checkpointTimestamp);
@@ -450,9 +428,7 @@ contract ValidatorPodTest is BeaconTestBase {
         pod.startCheckpoint(false);
 
         pod.verifyCheckpointProofs(
-            checkpointProof.stateRootProof,
-            checkpointProof.balanceContainerProof,
-            checkpointProof.proofs
+            checkpointProof.stateRootProof, checkpointProof.balanceContainerProof, checkpointProof.proofs
         );
 
         assertEq(pod.activeValidatorCount(), 1, "validator still active");
@@ -462,17 +438,12 @@ contract ValidatorPodTest is BeaconTestBase {
         assertEq(pod.totalRestakedBalanceGwei(), newBalance, "restaked balance updated");
         assertEq(podManager.getShares(podOwner1), 31 ether, "shares reflect new balance");
 
-        uint64 expectedFactor =
-            uint64((uint256(1e18) * uint256(newBalance)) / uint256(initialBalance));
+        uint64 expectedFactor = uint64((uint256(1e18) * uint256(newBalance)) / uint256(initialBalance));
         assertEq(pod.beaconChainSlashingFactor(), expectedFactor, "slashing factor applied");
 
         ValidatorTypes.ValidatorInfo memory info = pod.getValidatorInfo(pubkeyHash);
         assertEq(info.restakedBalanceGwei, newBalance, "validator balance updated");
-        assertEq(
-            uint8(info.status),
-            uint8(ValidatorTypes.ValidatorStatus.ACTIVE),
-            "validator remains active"
-        );
+        assertEq(uint8(info.status), uint8(ValidatorTypes.ValidatorStatus.ACTIVE), "validator remains active");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -519,7 +490,7 @@ contract ValidatorPodTest is BeaconTestBase {
         uint256 balanceBefore = address(pod).balance;
 
         // Send ETH to pod
-        (bool success,) = address(pod).call{value: 1 ether}("");
+        (bool success,) = address(pod).call{ value: 1 ether }("");
         assertTrue(success, "Should accept ETH");
 
         assertEq(address(pod).balance, balanceBefore + 1 ether, "Pod should hold ETH");
@@ -531,11 +502,11 @@ contract ValidatorPodTest is BeaconTestBase {
         vm.deal(address(0x2), 2 ether);
 
         vm.prank(address(0x1));
-        (bool s1,) = address(pod).call{value: 1 ether}("");
+        (bool s1,) = address(pod).call{ value: 1 ether }("");
         assertTrue(s1);
 
         vm.prank(address(0x2));
-        (bool s2,) = address(pod).call{value: 2 ether}("");
+        (bool s2,) = address(pod).call{ value: 2 ether }("");
         assertTrue(s2);
 
         assertEq(address(pod).balance, 3 ether, "Pod should hold all ETH");
@@ -551,9 +522,7 @@ contract ValidatorPodTest is BeaconTestBase {
 
         assertEq(info.validatorIndex, 0, "Unknown validator should have zero index");
         assertEq(info.restakedBalanceGwei, 0, "Unknown validator should have zero balance");
-        assertTrue(
-            info.status == ValidatorTypes.ValidatorStatus.INACTIVE, "Unknown validator should be inactive"
-        );
+        assertTrue(info.status == ValidatorTypes.ValidatorStatus.INACTIVE, "Unknown validator should be inactive");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/beacon/bridges/CrossChainMessengersTest.t.sol
+++ b/test/beacon/bridges/CrossChainMessengersTest.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test, stdError} from "forge-std/Test.sol";
+import { Test, stdError } from "forge-std/Test.sol";
 
 import {
     ArbitrumCrossChainMessenger,
@@ -25,18 +25,14 @@ import {
     ILayerZeroEndpointV2,
     Origin
 } from "../../../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
-import {ICrossChainReceiver} from "../../../src/beacon/interfaces/ICrossChainMessenger.sol";
+import { ICrossChainReceiver } from "../../../src/beacon/interfaces/ICrossChainMessenger.sol";
 
 contract MockCrossChainReceiver is ICrossChainReceiver {
     uint256 public lastSourceChainId;
     address public lastSender;
     bytes public lastPayload;
 
-    function receiveMessage(
-        uint256 sourceChainId,
-        address sender,
-        bytes calldata payload
-    ) external override {
+    function receiveMessage(uint256 sourceChainId, address sender, bytes calldata payload) external override {
         lastSourceChainId = sourceChainId;
         lastSender = sender;
         lastPayload = payload;
@@ -77,7 +73,12 @@ contract MockArbitrumInbox is IArbitrumInbox {
         uint256 gasLimit,
         uint256 maxFeePerGas,
         bytes calldata data
-    ) external payable override returns (uint256) {
+    )
+        external
+        payable
+        override
+        returns (uint256)
+    {
         _lastTicket = TicketParams({
             to: to,
             l2CallValue: l2CallValue,
@@ -117,679 +118,672 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
     }
 }
 
-contract MockHyperlaneMailbox is IHyperlaneMailbox {
-    uint256 public quoteFee;
-    uint32 public lastDestinationDomain;
-    bytes32 public lastRecipient;
-    bytes public lastMessageBody;
-    uint256 public lastDispatchValue;
-    bytes32 public nextMessageId = bytes32(uint256(1));
-
-    function setQuoteFee(uint256 fee) external {
-        quoteFee = fee;
+    contract MockHyperlaneMailbox is IHyperlaneMailbox {
+        uint256 public quoteFee;
+        uint32 public lastDestinationDomain;
+        bytes32 public lastRecipient;
+        bytes public lastMessageBody;
+        uint256 public lastDispatchValue;
+        bytes32 public nextMessageId = bytes32(uint256(1));
+
+        function setQuoteFee(uint256 fee) external {
+            quoteFee = fee;
+        }
+
+        function setNextMessageId(bytes32 newId) external {
+            nextMessageId = newId;
+        }
+
+        function dispatch(
+            uint32 destinationDomain,
+            bytes32 recipientAddress,
+            bytes calldata messageBody
+        )
+            external
+            payable
+            override
+            returns (bytes32 messageId)
+        {
+            lastDestinationDomain = destinationDomain;
+            lastRecipient = recipientAddress;
+            lastMessageBody = messageBody;
+            lastDispatchValue = msg.value;
+            return nextMessageId;
+        }
+
+        function quoteDispatch(uint32, bytes32, bytes calldata) external view override returns (uint256 fee) {
+            return quoteFee;
+        }
+
+        function localDomain() external pure override returns (uint32) {
+            return 0;
+        }
+    }
+
+    contract MockInterchainGasPaymaster is IInterchainGasPaymaster {
+        uint256 public quoteFee;
+
+        struct Payment {
+            bytes32 messageId;
+            uint32 destinationDomain;
+            uint256 gasAmount;
+            address refundAddress;
+            uint256 value;
+        }
+
+        Payment public lastPayment;
+
+        function getLastPayment() external view returns (Payment memory) {
+            return lastPayment;
+        }
+
+        function setQuoteFee(uint256 fee) external {
+            quoteFee = fee;
+        }
+
+        function payForGas(
+            bytes32 messageId,
+            uint32 destinationDomain,
+            uint256 gasAmount,
+            address refundAddress
+        )
+            external
+            payable
+            override
+        {
+            lastPayment = Payment({
+                messageId: messageId,
+                destinationDomain: destinationDomain,
+                gasAmount: gasAmount,
+                refundAddress: refundAddress,
+                value: msg.value
+            });
+        }
+
+        function quoteGasPayment(uint32, uint256) external view override returns (uint256) {
+            return quoteFee;
+        }
+    }
+
+    contract MockLayerZeroEndpoint is ILayerZeroEndpointV2 {
+        MessagingParams internal _lastParams;
+        address public lastRefundAddress;
+        uint256 public lastValue;
+        MessagingFee internal _quoteFee;
+        bytes32 public nextGuid = bytes32(uint256(123));
+        uint64 public nonce;
+
+        function lastParams() external view returns (MessagingParams memory) {
+            return _lastParams;
+        }
+
+        function storedQuoteFee() external view returns (MessagingFee memory) {
+            return _quoteFee;
+        }
+
+        function setQuoteFee(uint256 nativeFee) external {
+            _quoteFee = MessagingFee({ nativeFee: nativeFee, lzTokenFee: 0 });
+        }
+
+        function setNextGuid(bytes32 guid) external {
+            nextGuid = guid;
+        }
+
+        function send(
+            MessagingParams calldata params,
+            address refundAddress
+        )
+            external
+            payable
+            override
+            returns (MessagingReceipt memory receipt)
+        {
+            _lastParams = params;
+            lastRefundAddress = refundAddress;
+            lastValue = msg.value;
+            nonce += 1;
+            receipt = MessagingReceipt({
+                guid: nextGuid, nonce: nonce, fee: MessagingFee({ nativeFee: msg.value, lzTokenFee: 0 })
+            });
+        }
+
+        function quote(MessagingParams calldata, address) external view override returns (MessagingFee memory fee) {
+            return _quoteFee;
+        }
+
+        function setDelegate(address) external override { }
+    }
+
+    contract ArbitrumCrossChainMessengerTest is Test {
+        MockArbitrumInbox internal inbox;
+        ArbitrumCrossChainMessenger internal messenger;
+        address internal target = makeAddr("target");
+        address internal sender = makeAddr("sender");
+        bytes internal payload = abi.encode("payload");
+
+        function setUp() public {
+            inbox = new MockArbitrumInbox();
+            messenger = new ArbitrumCrossChainMessenger(address(inbox));
+        }
+
+        function test_sendMessage_CreatesRetryableTicket() public {
+            inbox.setSubmissionFee(0.01 ether);
+            vm.deal(sender, 1 ether);
+
+            vm.prank(sender);
+            bytes32 messageId = messenger.sendMessage{ value: 0.2 ether }(42_161, target, payload, 500_000);
+
+            bytes memory expectedData =
+                abi.encodeCall(ICrossChainReceiver.receiveMessage, (block.chainid, sender, payload));
+            MockArbitrumInbox.TicketParams memory ticket = inbox.getLastTicket();
+            assertEq(ticket.to, target, "target");
+            assertEq(ticket.maxSubmissionCost, 0.01 ether, "submission");
+            assertEq(ticket.excessFeeRefundAddress, sender, "fee refund");
+            assertEq(ticket.callValueRefundAddress, sender, "call refund");
+            // M-12 FIX: Gas limit includes 10% buffer, so 500_000 * 1.1 = 550_000
+            assertEq(ticket.gasLimit, 550_000, "gasLimit");
+            assertEq(ticket.data, expectedData, "payload");
+            assertEq(inbox.lastValue(), 0.2 ether, "msg.value");
+            assertEq(messageId, bytes32(uint256(1)));
+        }
+
+        function test_sendMessage_RevertUnsupportedChain() public {
+            vm.expectRevert("Unsupported chain");
+            messenger.sendMessage(999, target, payload, 100);
+        }
+
+        function test_estimateFee_UsesSubmissionCostAndGasLimit() public {
+            inbox.setSubmissionFee(0.01 ether);
+            uint256 fee = messenger.estimateFee(42_161, payload, 100_000);
+            // M-12 FIX: Gas limit includes 10% buffer, so 100_000 * 1.1 = 110_000
+            assertEq(fee, 0.01 ether + 110_000 * messenger.l2MaxFeePerGas());
+        }
+
+        function test_onlyOwnerCanAdjustGasPrice() public {
+            vm.expectRevert("Only owner");
+            vm.prank(makeAddr("intruder"));
+            messenger.setL2MaxFeePerGas(1 gwei);
+
+            messenger.setL2MaxFeePerGas(2 gwei);
+            assertEq(messenger.l2MaxFeePerGas(), 2 gwei);
+        }
+
+        function test_transferOwnership_AllowsNewOwnerToUpdateGasPrice() public {
+            address newOwner = makeAddr("newOwner");
+            messenger.transferOwnership(newOwner);
+
+            vm.expectRevert("Only owner");
+            messenger.setL2MaxFeePerGas(3 gwei);
+
+            vm.prank(newOwner);
+            messenger.setL2MaxFeePerGas(3 gwei);
+            assertEq(messenger.l2MaxFeePerGas(), 3 gwei);
+        }
+
+        function test_arbitrumL2Receiver_RelaysFromAliasedSender() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            address l1Sender = makeAddr("l1Sender");
+            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
+
+            bytes memory data = abi.encode("hello");
+            address aliased = l2Receiver.applyL1ToL2Alias(l1Sender);
+
+            vm.prank(aliased);
+            l2Receiver.relayMessage(data);
+
+            assertEq(receiver.lastSourceChainId(), 1);
+            assertEq(receiver.lastSender(), l1Sender);
+            assertEq(receiver.lastPayload(), data);
+        }
+
+        function test_arbitrumL2Receiver_RevertWhenSenderIsNotAliased() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            address l1Sender = makeAddr("l1Sender");
+            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
+
+            vm.expectRevert("Invalid sender");
+            l2Receiver.relayMessage("bad");
+        }
+    }
+
+    contract BaseCrossChainMessengerTest is Test {
+        MockBaseMessenger internal baseMessenger;
+        BaseCrossChainMessenger internal messenger;
+        address internal target = makeAddr("target");
+        address internal sender = makeAddr("sender");
+        bytes internal payload = abi.encode("payload");
+
+        function setUp() public {
+            baseMessenger = new MockBaseMessenger();
+            messenger = new BaseCrossChainMessenger(address(baseMessenger));
+        }
+
+        function test_sendMessage_ForwardsToBaseMessenger() public {
+            vm.deal(sender, 1 ether);
+            vm.prank(sender);
+            bytes32 messageId = messenger.sendMessage{ value: 0.5 ether }(8453, target, payload, 120_000);
+
+            bytes memory expectedData =
+                abi.encodeCall(ICrossChainReceiver.receiveMessage, (block.chainid, sender, payload));
+            assertEq(baseMessenger.lastTarget(), target);
+            assertEq(baseMessenger.lastMessage(), expectedData);
+            // M-12 FIX: Gas limit includes 10% buffer, so 120_000 * 1.1 = 132_000
+            assertEq(baseMessenger.lastGasLimit(), 132_000);
+            assertEq(baseMessenger.lastValue(), 0.5 ether);
+            assertTrue(messageId != bytes32(0));
+        }
+
+        function test_sendMessage_RevertUnsupportedChain() public {
+            vm.expectRevert("Unsupported chain");
+            messenger.sendMessage(1, target, payload, 100);
+        }
+
+        function test_relayMessage_ValidatesMessengerAndSender() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            bytes memory message = abi.encode("data");
+
+            baseMessenger.setXDomainMessageSender(address(this));
+            vm.prank(address(baseMessenger));
+            l2Receiver.relayMessage(message);
+
+            assertEq(receiver.lastSourceChainId(), 1);
+            assertEq(receiver.lastSender(), address(this));
+            assertEq(receiver.lastPayload(), message);
+        }
+
+        function test_relayMessage_RevertWhenMessengerMismatch() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            bytes memory message = abi.encode("data");
+
+            vm.expectRevert("Only messenger");
+            l2Receiver.relayMessage(message);
+        }
+
+        function test_relayMessage_RevertWhenSenderMismatch() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            bytes memory message = abi.encode("data");
+
+            baseMessenger.setXDomainMessageSender(makeAddr("other"));
+            vm.prank(address(baseMessenger));
+            vm.expectRevert("Invalid sender");
+            l2Receiver.relayMessage(message);
+        }
+    }
+
+    contract HyperlaneCrossChainMessengerTest is Test {
+        MockHyperlaneMailbox internal mailbox;
+        MockInterchainGasPaymaster internal igp;
+        HyperlaneCrossChainMessenger internal messenger;
+        address internal sender = makeAddr("sender");
+        address internal target = makeAddr("target");
+
+        function setUp() public {
+            mailbox = new MockHyperlaneMailbox();
+            igp = new MockInterchainGasPaymaster();
+            messenger = new HyperlaneCrossChainMessenger(address(mailbox), address(igp));
+        }
+
+        function test_sendMessage_PaysDispatchAndGas() public {
+            mailbox.setQuoteFee(0.05 ether);
+            igp.setQuoteFee(0.01 ether);
+            bytes memory payload = abi.encode("hyperlane");
+
+            vm.deal(sender, 1 ether);
+            uint256 balanceBefore = sender.balance;
+            vm.prank(sender);
+            bytes32 messageId = messenger.sendMessage{ value: 0.2 ether }(42_161, target, payload, 150_000);
+
+            bytes memory expectedBody = abi.encode(block.chainid, sender, payload);
+            assertEq(mailbox.lastDestinationDomain(), 42_161);
+            assertEq(mailbox.lastRecipient(), bytes32(uint256(uint160(target))));
+            assertEq(mailbox.lastMessageBody(), expectedBody);
+            assertEq(mailbox.lastDispatchValue(), 0.05 ether);
+
+            MockInterchainGasPaymaster.Payment memory payment = igp.getLastPayment();
+            assertEq(payment.messageId, messageId);
+            assertEq(payment.destinationDomain, 42_161);
+            // M-12 FIX: Gas limit includes 10% buffer, so 150_000 * 1.1 = 165_000
+            assertEq(payment.gasAmount, 165_000);
+            assertEq(payment.refundAddress, sender);
+            assertEq(payment.value, 0.01 ether);
+            assertEq(sender.balance, balanceBefore - 0.06 ether);
+        }
+
+        function test_sendMessage_RevertWhenDispatchUnderfunded() public {
+            mailbox.setQuoteFee(0.05 ether);
+            bytes memory payload = abi.encode("hyperlane");
+
+            vm.deal(sender, 0.04 ether);
+            vm.prank(sender);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    HyperlaneCrossChainMessenger.InsufficientMsgValue.selector, 0.05 ether, 0.04 ether
+                )
+            );
+            messenger.sendMessage{ value: 0.04 ether }(42_161, target, payload, 0);
+        }
+
+        function test_sendMessage_RevertWhenGasPaymentUnderfunded() public {
+            mailbox.setQuoteFee(0.02 ether);
+            igp.setQuoteFee(0.01 ether);
+            bytes memory payload = abi.encode("hyperlane");
+
+            vm.deal(sender, 0.025 ether);
+            vm.prank(sender);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    HyperlaneCrossChainMessenger.InsufficientMsgValue.selector, 0.03 ether, 0.025 ether
+                )
+            );
+            messenger.sendMessage{ value: 0.025 ether }(42_161, target, payload, 100_000);
+        }
+
+        function test_sendMessage_RefundsExcessValue() public {
+            mailbox.setQuoteFee(0.01 ether);
+            igp.setQuoteFee(0.02 ether);
+            bytes memory payload = abi.encode("hyperlane");
+
+            vm.deal(sender, 0.05 ether);
+            uint256 balanceBefore = sender.balance;
+
+            vm.prank(sender);
+            messenger.sendMessage{ value: 0.05 ether }(42_161, target, payload, 120_000);
+
+            uint256 required = 0.03 ether;
+            assertEq(sender.balance, balanceBefore - required);
+            assertEq(mailbox.lastDispatchValue(), 0.01 ether);
+            assertEq(igp.getLastPayment().value, 0.02 ether);
+        }
+
+        function test_sendMessage_DoesNotPayGasWhenInsufficientValue() public {
+            mailbox.setQuoteFee(0.05 ether);
+            igp.setQuoteFee(0.01 ether);
+            bytes memory payload = abi.encode("hyperlane");
+
+            messenger.setIgp(address(igp));
+            vm.deal(sender, 0.05 ether);
+            vm.prank(sender);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    HyperlaneCrossChainMessenger.InsufficientMsgValue.selector, 0.06 ether, 0.05 ether
+                )
+            );
+            messenger.sendMessage{ value: 0.05 ether }(8453, target, payload, 200_000);
+        }
+
+        function test_sendMessage_RevertUnsupportedChain() public {
+            vm.expectRevert("Unsupported chain");
+            messenger.sendMessage(999, target, bytes(""), 0);
+        }
+
+        function test_estimateFee_UsesDispatchAndIgpQuotes() public {
+            mailbox.setQuoteFee(0.01 ether);
+            igp.setQuoteFee(0.005 ether);
+
+            uint256 fee = messenger.estimateFee(42_161, bytes(""), 100_000);
+            assertEq(fee, 0.015 ether);
+        }
+
+        function test_estimateFee_ReturnsZeroForUnknownChain() public {
+            uint256 fee = messenger.estimateFee(999, bytes(""), 1);
+            assertEq(fee, 0);
+        }
+
+        function test_setDomainMappingOnlyOwner() public {
+            messenger.setDomainMapping(100, 1000);
+            assertTrue(messenger.isChainSupported(100));
+
+            vm.expectRevert("Only owner");
+            vm.prank(makeAddr("intruder"));
+            messenger.setDomainMapping(200, 2000);
+        }
+
+        function test_setIgpOnlyOwner() public {
+            address newIgp = makeAddr("igp");
+            messenger.setIgp(newIgp);
+            assertEq(address(messenger.igp()), newIgp);
+
+            vm.expectRevert("Only owner");
+            vm.prank(makeAddr("intruder"));
+            messenger.setIgp(address(0));
+        }
+
+        function test_sendMessage_RevertsWhenDispatchFeeNotFunded() public {
+            mailbox.setQuoteFee(0.05 ether);
+
+            vm.prank(sender);
+            vm.expectRevert();
+            messenger.sendMessage(42_161, target, bytes("insufficient"), 50_000);
+        }
+
+        function test_sendMessage_SucceedsWhenIgpUnset() public {
+            mailbox.setQuoteFee(0.02 ether);
+            messenger.setIgp(address(0));
+
+            vm.deal(sender, 0.02 ether);
+            vm.prank(sender);
+            messenger.sendMessage{ value: 0.02 ether }(42_161, target, bytes("skip igp"), 60_000);
+
+            MockInterchainGasPaymaster.Payment memory payment = igp.getLastPayment();
+            assertEq(payment.value, 0, "IGP should not receive payment when unset");
+        }
+
+        function test_estimateFee_RevertsOnOverflowingGasQuote() public {
+            mailbox.setQuoteFee(1);
+            igp.setQuoteFee(type(uint256).max);
+
+            vm.expectRevert(stdError.arithmeticError);
+            messenger.estimateFee(42_161, bytes("overflow"), 1);
+        }
+    }
+
+    contract LayerZeroCrossChainMessengerTest is Test {
+        MockLayerZeroEndpoint internal endpoint;
+        LayerZeroCrossChainMessenger internal messenger;
+        address internal sender = makeAddr("sender");
+        address internal target = makeAddr("target");
+
+        function setUp() public {
+            endpoint = new MockLayerZeroEndpoint();
+            endpoint.setQuoteFee(0.02 ether);
+            messenger = new LayerZeroCrossChainMessenger(address(endpoint));
+        }
+
+        function test_sendMessage_UsesEndpoint() public {
+            bytes memory payload = abi.encode("lz");
+            vm.deal(sender, 1 ether);
+
+            vm.prank(sender);
+            bytes32 guid = messenger.sendMessage{ value: 0.05 ether }(42_161, target, payload, 250_000);
+
+            bytes memory expected = abi.encode(block.chainid, sender, payload);
+            ILayerZeroEndpointV2.MessagingParams memory params = endpoint.lastParams();
+            assertEq(params.dstEid, 30_110);
+            assertEq(params.receiver, bytes32(uint256(uint160(target))));
+            assertEq(params.message, expected);
+            assertEq(params.options.length, 37); // TYPE_3 header + executor option
+            assertEq(endpoint.lastRefundAddress(), sender);
+            assertEq(endpoint.lastValue(), 0.05 ether);
+            assertEq(guid, bytes32(uint256(123)));
+        }
+
+        function test_sendMessage_RevertUnsupportedChain() public {
+            vm.expectRevert("Unsupported chain");
+            messenger.sendMessage(555, target, bytes(""), 100);
+        }
+
+        function test_estimateFee_UsesEndpointQuote() public {
+            uint256 fee = messenger.estimateFee(42_161, bytes(""), 1);
+            assertEq(fee, endpoint.storedQuoteFee().nativeFee);
+        }
+
+        function test_onlyOwnerMayUpdateMappings() public {
+            messenger.setChainMapping(9000, 9001);
+            vm.expectRevert("Only owner");
+            vm.prank(makeAddr("intruder"));
+            messenger.setChainMapping(9001, 9002);
+        }
+
+        function test_onlyOwnerMaySetPeer() public {
+            messenger.setPeer(30_110, address(this));
+            assertEq(messenger.peers(30_110), bytes32(uint256(uint160(address(this)))));
+
+            vm.expectRevert("Only owner");
+            vm.prank(makeAddr("intruder"));
+            messenger.setPeer(1, address(0));
+        }
+    }
+
+    contract LayerZeroReceiverTest is Test {
+        MockCrossChainReceiver internal receiver;
+        LayerZeroReceiver internal lzReceiver;
+        address internal endpoint = makeAddr("endpoint");
+        address internal peer = makeAddr("peer");
+        address internal originalSender = makeAddr("origin");
+
+        function setUp() public {
+            receiver = new MockCrossChainReceiver();
+            lzReceiver = new LayerZeroReceiver(endpoint, address(receiver));
+        }
+
+        function test_lzReceive_ForwardsMessagesFromTrustedPeer() public {
+            uint32 eid = 30_110;
+            lzReceiver.setPeer(eid, bytes32(uint256(uint160(peer))));
+
+            Origin memory origin = Origin({ srcEid: eid, sender: bytes32(uint256(uint160(peer))), nonce: 1 });
+            bytes memory payload = abi.encode(uint256(42_161), originalSender, bytes("lz"));
+
+            vm.prank(endpoint);
+            lzReceiver.lzReceive(origin, bytes32(0), payload, address(0), bytes(""));
+
+            assertEq(receiver.lastSourceChainId(), 42_161);
+            assertEq(receiver.lastSender(), originalSender);
+            assertEq(receiver.lastPayload(), bytes("lz"));
+        }
+
+        function test_lzReceive_RevertWhenEndpointMismatch() public {
+            Origin memory origin = Origin({ srcEid: 30_110, sender: bytes32(uint256(1)), nonce: 0 });
+
+            vm.expectRevert("Only endpoint");
+            lzReceiver.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
+        }
+
+        function test_lzReceive_RevertWhenPeerUntrusted() public {
+            Origin memory origin = Origin({ srcEid: 30_110, sender: bytes32(uint256(1)), nonce: 0 });
+            vm.prank(endpoint);
+            vm.expectRevert("Untrusted peer");
+            lzReceiver.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
+        }
+
+        function test_setPeerRequiresOwner() public {
+            vm.prank(makeAddr("intruder"));
+            vm.expectRevert("Only owner");
+            lzReceiver.setPeer(1, bytes32(uint256(1)));
+        }
+
+        function test_transferOwnership() public {
+            address newOwner = makeAddr("newOwner");
+            lzReceiver.transferOwnership(newOwner);
+
+            vm.expectRevert("Only owner");
+            lzReceiver.setPeer(1, bytes32(uint256(1)));
+
+            vm.prank(newOwner);
+            lzReceiver.setPeer(1, bytes32(uint256(1)));
+        }
+    }
+
+    contract HyperlaneReceiverTest is Test {
+        MockCrossChainReceiver internal receiver;
+        HyperlaneReceiver internal hyperlaneReceiver;
+        address internal mailbox = makeAddr("mailbox");
+        address internal trustedSender = makeAddr("trustedSender");
+
+        function setUp() public {
+            receiver = new MockCrossChainReceiver();
+            hyperlaneReceiver = new HyperlaneReceiver(mailbox, address(receiver));
+        }
+
+        function test_handle_ForwardsTrustedMessage() public {
+            uint32 domain = 42_161;
+            hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
+            bytes memory payload = abi.encode(uint256(42_161), trustedSender, bytes("hl"));
+
+            vm.prank(mailbox);
+            hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
+
+            assertEq(receiver.lastSourceChainId(), 42_161);
+            assertEq(receiver.lastSender(), trustedSender);
+            assertEq(receiver.lastPayload(), bytes("hl"));
+        }
+
+        function test_handle_RevertsWhenCallerNotMailbox() public {
+            vm.expectRevert("Only mailbox");
+            hyperlaneReceiver.handle(42_161, bytes32(uint256(1)), bytes("bad"));
+        }
+
+        function test_handle_RevertsWhenSenderNotTrusted() public {
+            vm.prank(mailbox);
+            vm.expectRevert("Untrusted sender");
+            hyperlaneReceiver.handle(42_161, bytes32(uint256(1)), bytes("bad"));
+        }
+
+        function test_handle_RevertsWhenChainMismatch() public {
+            uint32 domain = 8453;
+            hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
+            bytes memory payload = abi.encode(uint256(999), trustedSender, bytes("bad"));
+
+            vm.prank(mailbox);
+            vm.expectRevert("Chain mismatch");
+            hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
+        }
+
+        function test_handle_RevertsAfterSenderRevoked() public {
+            uint32 domain = 42_161;
+            hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
+            hyperlaneReceiver.setTrustedSender(domain, trustedSender, false);
+            bytes memory payload = abi.encode(uint256(42_161), trustedSender, bytes("revoked"));
+
+            vm.prank(mailbox);
+            vm.expectRevert("Untrusted sender");
+            hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
+        }
+
+        function test_handle_UsesUpdatedDomainMapping() public {
+            uint32 domain = 9999;
+            hyperlaneReceiver.setDomainMapping(domain, 5555);
+            hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
+            bytes memory payload = abi.encode(uint256(5555), trustedSender, bytes("ok"));
+
+            vm.prank(mailbox);
+            hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
+
+            assertEq(receiver.lastSourceChainId(), 5555);
+        }
+
+        function test_setTrustedSender_OnlyOwner() public {
+            vm.prank(makeAddr("intruder"));
+            vm.expectRevert("Only owner");
+            hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
+        }
+
+        function test_setDomainMapping_OnlyOwner() public {
+            vm.prank(makeAddr("intruder"));
+            vm.expectRevert("Only owner");
+            hyperlaneReceiver.setDomainMapping(777, 888);
+        }
+
+        function test_transferOwnership_AllowsNewOwnerToManageSenders() public {
+            address newOwner = makeAddr("newOwner");
+            hyperlaneReceiver.transferOwnership(newOwner);
+
+            vm.expectRevert("Only owner");
+            hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
+
+            vm.prank(newOwner);
+            hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
+        }
     }
-
-    function setNextMessageId(bytes32 newId) external {
-        nextMessageId = newId;
-    }
-
-    function dispatch(
-        uint32 destinationDomain,
-        bytes32 recipientAddress,
-        bytes calldata messageBody
-    ) external payable override returns (bytes32 messageId) {
-        lastDestinationDomain = destinationDomain;
-        lastRecipient = recipientAddress;
-        lastMessageBody = messageBody;
-        lastDispatchValue = msg.value;
-        return nextMessageId;
-    }
-
-    function quoteDispatch(
-        uint32,
-        bytes32,
-        bytes calldata
-    ) external view override returns (uint256 fee) {
-        return quoteFee;
-    }
-
-    function localDomain() external pure override returns (uint32) {
-        return 0;
-    }
-}
-
-contract MockInterchainGasPaymaster is IInterchainGasPaymaster {
-    uint256 public quoteFee;
-    struct Payment {
-        bytes32 messageId;
-        uint32 destinationDomain;
-        uint256 gasAmount;
-        address refundAddress;
-        uint256 value;
-    }
-
-    Payment public lastPayment;
-
-    function getLastPayment() external view returns (Payment memory) {
-        return lastPayment;
-    }
-
-    function setQuoteFee(uint256 fee) external {
-        quoteFee = fee;
-    }
-
-    function payForGas(
-        bytes32 messageId,
-        uint32 destinationDomain,
-        uint256 gasAmount,
-        address refundAddress
-    ) external payable override {
-        lastPayment = Payment({
-            messageId: messageId,
-            destinationDomain: destinationDomain,
-            gasAmount: gasAmount,
-            refundAddress: refundAddress,
-            value: msg.value
-        });
-    }
-
-    function quoteGasPayment(
-        uint32,
-        uint256
-    ) external view override returns (uint256) {
-        return quoteFee;
-    }
-}
-
-contract MockLayerZeroEndpoint is ILayerZeroEndpointV2 {
-    MessagingParams internal _lastParams;
-    address public lastRefundAddress;
-    uint256 public lastValue;
-    MessagingFee internal _quoteFee;
-    bytes32 public nextGuid = bytes32(uint256(123));
-    uint64 public nonce;
-
-    function lastParams() external view returns (MessagingParams memory) {
-        return _lastParams;
-    }
-
-    function storedQuoteFee() external view returns (MessagingFee memory) {
-        return _quoteFee;
-    }
-
-    function setQuoteFee(uint256 nativeFee) external {
-        _quoteFee = MessagingFee({nativeFee: nativeFee, lzTokenFee: 0});
-    }
-
-    function setNextGuid(bytes32 guid) external {
-        nextGuid = guid;
-    }
-
-    function send(
-        MessagingParams calldata params,
-        address refundAddress
-    ) external payable override returns (MessagingReceipt memory receipt) {
-        _lastParams = params;
-        lastRefundAddress = refundAddress;
-        lastValue = msg.value;
-        nonce += 1;
-        receipt = MessagingReceipt({
-            guid: nextGuid,
-            nonce: nonce,
-            fee: MessagingFee({nativeFee: msg.value, lzTokenFee: 0})
-        });
-    }
-
-    function quote(
-        MessagingParams calldata,
-        address
-    ) external view override returns (MessagingFee memory fee) {
-        return _quoteFee;
-    }
-
-    function setDelegate(address) external override {}
-}
-
-contract ArbitrumCrossChainMessengerTest is Test {
-    MockArbitrumInbox internal inbox;
-    ArbitrumCrossChainMessenger internal messenger;
-    address internal target = makeAddr("target");
-    address internal sender = makeAddr("sender");
-    bytes internal payload = abi.encode("payload");
-
-    function setUp() public {
-        inbox = new MockArbitrumInbox();
-        messenger = new ArbitrumCrossChainMessenger(address(inbox));
-    }
-
-    function test_sendMessage_CreatesRetryableTicket() public {
-        inbox.setSubmissionFee(0.01 ether);
-        vm.deal(sender, 1 ether);
-
-        vm.prank(sender);
-        bytes32 messageId = messenger.sendMessage{value: 0.2 ether}(42161, target, payload, 500_000);
-
-        bytes memory expectedData = abi.encodeCall(
-            ICrossChainReceiver.receiveMessage,
-            (block.chainid, sender, payload)
-        );
-        MockArbitrumInbox.TicketParams memory ticket = inbox.getLastTicket();
-        assertEq(ticket.to, target, "target");
-        assertEq(ticket.maxSubmissionCost, 0.01 ether, "submission");
-        assertEq(ticket.excessFeeRefundAddress, sender, "fee refund");
-        assertEq(ticket.callValueRefundAddress, sender, "call refund");
-        // M-12 FIX: Gas limit includes 10% buffer, so 500_000 * 1.1 = 550_000
-        assertEq(ticket.gasLimit, 550_000, "gasLimit");
-        assertEq(ticket.data, expectedData, "payload");
-        assertEq(inbox.lastValue(), 0.2 ether, "msg.value");
-        assertEq(messageId, bytes32(uint256(1)));
-    }
-
-    function test_sendMessage_RevertUnsupportedChain() public {
-        vm.expectRevert("Unsupported chain");
-        messenger.sendMessage(999, target, payload, 100);
-    }
-
-    function test_estimateFee_UsesSubmissionCostAndGasLimit() public {
-        inbox.setSubmissionFee(0.01 ether);
-        uint256 fee = messenger.estimateFee(42161, payload, 100_000);
-        // M-12 FIX: Gas limit includes 10% buffer, so 100_000 * 1.1 = 110_000
-        assertEq(fee, 0.01 ether + 110_000 * messenger.l2MaxFeePerGas());
-    }
-
-    function test_onlyOwnerCanAdjustGasPrice() public {
-        vm.expectRevert("Only owner");
-        vm.prank(makeAddr("intruder"));
-        messenger.setL2MaxFeePerGas(1 gwei);
-
-        messenger.setL2MaxFeePerGas(2 gwei);
-        assertEq(messenger.l2MaxFeePerGas(), 2 gwei);
-    }
-
-    function test_transferOwnership_AllowsNewOwnerToUpdateGasPrice() public {
-        address newOwner = makeAddr("newOwner");
-        messenger.transferOwnership(newOwner);
-
-        vm.expectRevert("Only owner");
-        messenger.setL2MaxFeePerGas(3 gwei);
-
-        vm.prank(newOwner);
-        messenger.setL2MaxFeePerGas(3 gwei);
-        assertEq(messenger.l2MaxFeePerGas(), 3 gwei);
-    }
-
-    function test_arbitrumL2Receiver_RelaysFromAliasedSender() public {
-        MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-        address l1Sender = makeAddr("l1Sender");
-        ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
-
-        bytes memory data = abi.encode("hello");
-        address aliased = l2Receiver.applyL1ToL2Alias(l1Sender);
-
-        vm.prank(aliased);
-        l2Receiver.relayMessage(data);
-
-        assertEq(receiver.lastSourceChainId(), 1);
-        assertEq(receiver.lastSender(), l1Sender);
-        assertEq(receiver.lastPayload(), data);
-    }
-
-    function test_arbitrumL2Receiver_RevertWhenSenderIsNotAliased() public {
-        MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-        address l1Sender = makeAddr("l1Sender");
-        ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
-
-        vm.expectRevert("Invalid sender");
-        l2Receiver.relayMessage("bad");
-    }
-}
-
-contract BaseCrossChainMessengerTest is Test {
-    MockBaseMessenger internal baseMessenger;
-    BaseCrossChainMessenger internal messenger;
-    address internal target = makeAddr("target");
-    address internal sender = makeAddr("sender");
-    bytes internal payload = abi.encode("payload");
-
-    function setUp() public {
-        baseMessenger = new MockBaseMessenger();
-        messenger = new BaseCrossChainMessenger(address(baseMessenger));
-    }
-
-    function test_sendMessage_ForwardsToBaseMessenger() public {
-        vm.deal(sender, 1 ether);
-        vm.prank(sender);
-        bytes32 messageId = messenger.sendMessage{value: 0.5 ether}(8453, target, payload, 120_000);
-
-        bytes memory expectedData = abi.encodeCall(
-            ICrossChainReceiver.receiveMessage,
-            (block.chainid, sender, payload)
-        );
-        assertEq(baseMessenger.lastTarget(), target);
-        assertEq(baseMessenger.lastMessage(), expectedData);
-        // M-12 FIX: Gas limit includes 10% buffer, so 120_000 * 1.1 = 132_000
-        assertEq(baseMessenger.lastGasLimit(), 132_000);
-        assertEq(baseMessenger.lastValue(), 0.5 ether);
-        assertTrue(messageId != bytes32(0));
-    }
-
-    function test_sendMessage_RevertUnsupportedChain() public {
-        vm.expectRevert("Unsupported chain");
-        messenger.sendMessage(1, target, payload, 100);
-    }
-
-    function test_relayMessage_ValidatesMessengerAndSender() public {
-        MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-        BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
-        bytes memory message = abi.encode("data");
-
-        baseMessenger.setXDomainMessageSender(address(this));
-        vm.prank(address(baseMessenger));
-        l2Receiver.relayMessage(message);
-
-        assertEq(receiver.lastSourceChainId(), 1);
-        assertEq(receiver.lastSender(), address(this));
-        assertEq(receiver.lastPayload(), message);
-    }
-
-    function test_relayMessage_RevertWhenMessengerMismatch() public {
-        MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-        BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
-        bytes memory message = abi.encode("data");
-
-        vm.expectRevert("Only messenger");
-        l2Receiver.relayMessage(message);
-    }
-
-    function test_relayMessage_RevertWhenSenderMismatch() public {
-        MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-        BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
-        bytes memory message = abi.encode("data");
-
-        baseMessenger.setXDomainMessageSender(makeAddr("other"));
-        vm.prank(address(baseMessenger));
-        vm.expectRevert("Invalid sender");
-        l2Receiver.relayMessage(message);
-    }
-}
-
-contract HyperlaneCrossChainMessengerTest is Test {
-    MockHyperlaneMailbox internal mailbox;
-    MockInterchainGasPaymaster internal igp;
-    HyperlaneCrossChainMessenger internal messenger;
-    address internal sender = makeAddr("sender");
-    address internal target = makeAddr("target");
-
-    function setUp() public {
-        mailbox = new MockHyperlaneMailbox();
-        igp = new MockInterchainGasPaymaster();
-        messenger = new HyperlaneCrossChainMessenger(address(mailbox), address(igp));
-    }
-
-    function test_sendMessage_PaysDispatchAndGas() public {
-        mailbox.setQuoteFee(0.05 ether);
-        igp.setQuoteFee(0.01 ether);
-        bytes memory payload = abi.encode("hyperlane");
-
-        vm.deal(sender, 1 ether);
-        uint256 balanceBefore = sender.balance;
-        vm.prank(sender);
-        bytes32 messageId = messenger.sendMessage{value: 0.2 ether}(42161, target, payload, 150_000);
-
-        bytes memory expectedBody = abi.encode(block.chainid, sender, payload);
-        assertEq(mailbox.lastDestinationDomain(), 42161);
-        assertEq(mailbox.lastRecipient(), bytes32(uint256(uint160(target))));
-        assertEq(mailbox.lastMessageBody(), expectedBody);
-        assertEq(mailbox.lastDispatchValue(), 0.05 ether);
-
-        MockInterchainGasPaymaster.Payment memory payment = igp.getLastPayment();
-        assertEq(payment.messageId, messageId);
-        assertEq(payment.destinationDomain, 42161);
-        // M-12 FIX: Gas limit includes 10% buffer, so 150_000 * 1.1 = 165_000
-        assertEq(payment.gasAmount, 165_000);
-        assertEq(payment.refundAddress, sender);
-        assertEq(payment.value, 0.01 ether);
-        assertEq(sender.balance, balanceBefore - 0.06 ether);
-    }
-
-    function test_sendMessage_RevertWhenDispatchUnderfunded() public {
-        mailbox.setQuoteFee(0.05 ether);
-        bytes memory payload = abi.encode("hyperlane");
-
-        vm.deal(sender, 0.04 ether);
-        vm.prank(sender);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                HyperlaneCrossChainMessenger.InsufficientMsgValue.selector,
-                0.05 ether,
-                0.04 ether
-            )
-        );
-        messenger.sendMessage{value: 0.04 ether}(42161, target, payload, 0);
-    }
-
-    function test_sendMessage_RevertWhenGasPaymentUnderfunded() public {
-        mailbox.setQuoteFee(0.02 ether);
-        igp.setQuoteFee(0.01 ether);
-        bytes memory payload = abi.encode("hyperlane");
-
-        vm.deal(sender, 0.025 ether);
-        vm.prank(sender);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                HyperlaneCrossChainMessenger.InsufficientMsgValue.selector,
-                0.03 ether,
-                0.025 ether
-            )
-        );
-        messenger.sendMessage{value: 0.025 ether}(42161, target, payload, 100_000);
-    }
-
-    function test_sendMessage_RefundsExcessValue() public {
-        mailbox.setQuoteFee(0.01 ether);
-        igp.setQuoteFee(0.02 ether);
-        bytes memory payload = abi.encode("hyperlane");
-
-        vm.deal(sender, 0.05 ether);
-        uint256 balanceBefore = sender.balance;
-
-        vm.prank(sender);
-        messenger.sendMessage{value: 0.05 ether}(42161, target, payload, 120_000);
-
-        uint256 required = 0.03 ether;
-        assertEq(sender.balance, balanceBefore - required);
-        assertEq(mailbox.lastDispatchValue(), 0.01 ether);
-        assertEq(igp.getLastPayment().value, 0.02 ether);
-    }
-
-    function test_sendMessage_DoesNotPayGasWhenInsufficientValue() public {
-        mailbox.setQuoteFee(0.05 ether);
-        igp.setQuoteFee(0.01 ether);
-        bytes memory payload = abi.encode("hyperlane");
-
-        messenger.setIgp(address(igp));
-        vm.deal(sender, 0.05 ether);
-        vm.prank(sender);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                HyperlaneCrossChainMessenger.InsufficientMsgValue.selector,
-                0.06 ether,
-                0.05 ether
-            )
-        );
-        messenger.sendMessage{value: 0.05 ether}(8453, target, payload, 200_000);
-    }
-
-    function test_sendMessage_RevertUnsupportedChain() public {
-        vm.expectRevert("Unsupported chain");
-        messenger.sendMessage(999, target, bytes(""), 0);
-    }
-
-    function test_estimateFee_UsesDispatchAndIgpQuotes() public {
-        mailbox.setQuoteFee(0.01 ether);
-        igp.setQuoteFee(0.005 ether);
-
-        uint256 fee = messenger.estimateFee(42161, bytes(""), 100_000);
-        assertEq(fee, 0.015 ether);
-    }
-
-    function test_estimateFee_ReturnsZeroForUnknownChain() public {
-        uint256 fee = messenger.estimateFee(999, bytes(""), 1);
-        assertEq(fee, 0);
-    }
-
-    function test_setDomainMappingOnlyOwner() public {
-        messenger.setDomainMapping(100, 1000);
-        assertTrue(messenger.isChainSupported(100));
-
-        vm.expectRevert("Only owner");
-        vm.prank(makeAddr("intruder"));
-        messenger.setDomainMapping(200, 2000);
-    }
-
-    function test_setIgpOnlyOwner() public {
-        address newIgp = makeAddr("igp");
-        messenger.setIgp(newIgp);
-        assertEq(address(messenger.igp()), newIgp);
-
-        vm.expectRevert("Only owner");
-        vm.prank(makeAddr("intruder"));
-        messenger.setIgp(address(0));
-    }
-
-    function test_sendMessage_RevertsWhenDispatchFeeNotFunded() public {
-        mailbox.setQuoteFee(0.05 ether);
-
-        vm.prank(sender);
-        vm.expectRevert();
-        messenger.sendMessage(42161, target, bytes("insufficient"), 50_000);
-    }
-
-    function test_sendMessage_SucceedsWhenIgpUnset() public {
-        mailbox.setQuoteFee(0.02 ether);
-        messenger.setIgp(address(0));
-
-        vm.deal(sender, 0.02 ether);
-        vm.prank(sender);
-        messenger.sendMessage{value: 0.02 ether}(42161, target, bytes("skip igp"), 60_000);
-
-        MockInterchainGasPaymaster.Payment memory payment = igp.getLastPayment();
-        assertEq(payment.value, 0, "IGP should not receive payment when unset");
-    }
-
-    function test_estimateFee_RevertsOnOverflowingGasQuote() public {
-        mailbox.setQuoteFee(1);
-        igp.setQuoteFee(type(uint256).max);
-
-        vm.expectRevert(stdError.arithmeticError);
-        messenger.estimateFee(42161, bytes("overflow"), 1);
-    }
-}
-
-contract LayerZeroCrossChainMessengerTest is Test {
-    MockLayerZeroEndpoint internal endpoint;
-    LayerZeroCrossChainMessenger internal messenger;
-    address internal sender = makeAddr("sender");
-    address internal target = makeAddr("target");
-
-    function setUp() public {
-        endpoint = new MockLayerZeroEndpoint();
-        endpoint.setQuoteFee(0.02 ether);
-        messenger = new LayerZeroCrossChainMessenger(address(endpoint));
-    }
-
-    function test_sendMessage_UsesEndpoint() public {
-        bytes memory payload = abi.encode("lz");
-        vm.deal(sender, 1 ether);
-
-        vm.prank(sender);
-        bytes32 guid = messenger.sendMessage{value: 0.05 ether}(42161, target, payload, 250_000);
-
-        bytes memory expected = abi.encode(block.chainid, sender, payload);
-        ILayerZeroEndpointV2.MessagingParams memory params = endpoint.lastParams();
-        assertEq(params.dstEid, 30110);
-        assertEq(params.receiver, bytes32(uint256(uint160(target))));
-        assertEq(params.message, expected);
-        assertEq(params.options.length, 37); // TYPE_3 header + executor option
-        assertEq(endpoint.lastRefundAddress(), sender);
-        assertEq(endpoint.lastValue(), 0.05 ether);
-        assertEq(guid, bytes32(uint256(123)));
-    }
-
-    function test_sendMessage_RevertUnsupportedChain() public {
-        vm.expectRevert("Unsupported chain");
-        messenger.sendMessage(555, target, bytes(""), 100);
-    }
-
-    function test_estimateFee_UsesEndpointQuote() public {
-        uint256 fee = messenger.estimateFee(42161, bytes(""), 1);
-        assertEq(fee, endpoint.storedQuoteFee().nativeFee);
-    }
-
-    function test_onlyOwnerMayUpdateMappings() public {
-        messenger.setChainMapping(9000, 9001);
-        vm.expectRevert("Only owner");
-        vm.prank(makeAddr("intruder"));
-        messenger.setChainMapping(9001, 9002);
-    }
-
-    function test_onlyOwnerMaySetPeer() public {
-        messenger.setPeer(30110, address(this));
-        assertEq(messenger.peers(30110), bytes32(uint256(uint160(address(this)))));
-
-        vm.expectRevert("Only owner");
-        vm.prank(makeAddr("intruder"));
-        messenger.setPeer(1, address(0));
-    }
-}
-
-contract LayerZeroReceiverTest is Test {
-    MockCrossChainReceiver internal receiver;
-    LayerZeroReceiver internal lzReceiver;
-    address internal endpoint = makeAddr("endpoint");
-    address internal peer = makeAddr("peer");
-    address internal originalSender = makeAddr("origin");
-
-    function setUp() public {
-        receiver = new MockCrossChainReceiver();
-        lzReceiver = new LayerZeroReceiver(endpoint, address(receiver));
-    }
-
-    function test_lzReceive_ForwardsMessagesFromTrustedPeer() public {
-        uint32 eid = 30110;
-        lzReceiver.setPeer(eid, bytes32(uint256(uint160(peer))));
-
-        Origin memory origin = Origin({srcEid: eid, sender: bytes32(uint256(uint160(peer))), nonce: 1});
-        bytes memory payload = abi.encode(uint256(42161), originalSender, bytes("lz"));
-
-        vm.prank(endpoint);
-        lzReceiver.lzReceive(origin, bytes32(0), payload, address(0), bytes(""));
-
-        assertEq(receiver.lastSourceChainId(), 42161);
-        assertEq(receiver.lastSender(), originalSender);
-        assertEq(receiver.lastPayload(), bytes("lz"));
-    }
-
-    function test_lzReceive_RevertWhenEndpointMismatch() public {
-        Origin memory origin = Origin({srcEid: 30110, sender: bytes32(uint256(1)), nonce: 0});
-
-        vm.expectRevert("Only endpoint");
-        lzReceiver.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
-    }
-
-    function test_lzReceive_RevertWhenPeerUntrusted() public {
-        Origin memory origin = Origin({srcEid: 30110, sender: bytes32(uint256(1)), nonce: 0});
-        vm.prank(endpoint);
-        vm.expectRevert("Untrusted peer");
-        lzReceiver.lzReceive(origin, bytes32(0), bytes(""), address(0), bytes(""));
-    }
-
-    function test_setPeerRequiresOwner() public {
-        vm.prank(makeAddr("intruder"));
-        vm.expectRevert("Only owner");
-        lzReceiver.setPeer(1, bytes32(uint256(1)));
-    }
-
-    function test_transferOwnership() public {
-        address newOwner = makeAddr("newOwner");
-        lzReceiver.transferOwnership(newOwner);
-
-        vm.expectRevert("Only owner");
-        lzReceiver.setPeer(1, bytes32(uint256(1)));
-
-        vm.prank(newOwner);
-        lzReceiver.setPeer(1, bytes32(uint256(1)));
-    }
-}
-
-contract HyperlaneReceiverTest is Test {
-    MockCrossChainReceiver internal receiver;
-    HyperlaneReceiver internal hyperlaneReceiver;
-    address internal mailbox = makeAddr("mailbox");
-    address internal trustedSender = makeAddr("trustedSender");
-
-    function setUp() public {
-        receiver = new MockCrossChainReceiver();
-        hyperlaneReceiver = new HyperlaneReceiver(mailbox, address(receiver));
-    }
-
-    function test_handle_ForwardsTrustedMessage() public {
-        uint32 domain = 42161;
-        hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
-        bytes memory payload = abi.encode(uint256(42161), trustedSender, bytes("hl"));
-
-        vm.prank(mailbox);
-        hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
-
-        assertEq(receiver.lastSourceChainId(), 42161);
-        assertEq(receiver.lastSender(), trustedSender);
-        assertEq(receiver.lastPayload(), bytes("hl"));
-    }
-
-    function test_handle_RevertsWhenCallerNotMailbox() public {
-        vm.expectRevert("Only mailbox");
-        hyperlaneReceiver.handle(42161, bytes32(uint256(1)), bytes("bad"));
-    }
-
-    function test_handle_RevertsWhenSenderNotTrusted() public {
-        vm.prank(mailbox);
-        vm.expectRevert("Untrusted sender");
-        hyperlaneReceiver.handle(42161, bytes32(uint256(1)), bytes("bad"));
-    }
-
-    function test_handle_RevertsWhenChainMismatch() public {
-        uint32 domain = 8453;
-        hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
-        bytes memory payload = abi.encode(uint256(999), trustedSender, bytes("bad"));
-
-        vm.prank(mailbox);
-        vm.expectRevert("Chain mismatch");
-        hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
-    }
-
-    function test_handle_RevertsAfterSenderRevoked() public {
-        uint32 domain = 42161;
-        hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
-        hyperlaneReceiver.setTrustedSender(domain, trustedSender, false);
-        bytes memory payload = abi.encode(uint256(42161), trustedSender, bytes("revoked"));
-
-        vm.prank(mailbox);
-        vm.expectRevert("Untrusted sender");
-        hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
-    }
-
-    function test_handle_UsesUpdatedDomainMapping() public {
-        uint32 domain = 9999;
-        hyperlaneReceiver.setDomainMapping(domain, 5555);
-        hyperlaneReceiver.setTrustedSender(domain, trustedSender, true);
-        bytes memory payload = abi.encode(uint256(5555), trustedSender, bytes("ok"));
-
-        vm.prank(mailbox);
-        hyperlaneReceiver.handle(domain, bytes32(uint256(uint160(trustedSender))), payload);
-
-        assertEq(receiver.lastSourceChainId(), 5555);
-    }
-
-    function test_setTrustedSender_OnlyOwner() public {
-        vm.prank(makeAddr("intruder"));
-        vm.expectRevert("Only owner");
-        hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
-    }
-
-    function test_setDomainMapping_OnlyOwner() public {
-        vm.prank(makeAddr("intruder"));
-        vm.expectRevert("Only owner");
-        hyperlaneReceiver.setDomainMapping(777, 888);
-    }
-
-    function test_transferOwnership_AllowsNewOwnerToManageSenders() public {
-        address newOwner = makeAddr("newOwner");
-        hyperlaneReceiver.transferOwnership(newOwner);
-
-        vm.expectRevert("Only owner");
-        hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
-
-        vm.prank(newOwner);
-        hyperlaneReceiver.setTrustedSender(1, trustedSender, true);
-    }
-}

--- a/test/blueprints/BSMHooksLifecycle.t.sol
+++ b/test/blueprints/BSMHooksLifecycle.t.sol
@@ -79,9 +79,8 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         tangle.registerOperator(blueprintId, customKey, "");
 
         // The contract wraps inputs in OperatorPreferences struct before calling onRegister
-        bytes memory expectedInputs = abi.encode(
-            Types.OperatorPreferences({ ecdsaPublicKey: customKey, rpcAddress: "" })
-        );
+        bytes memory expectedInputs =
+            abi.encode(Types.OperatorPreferences({ ecdsaPublicKey: customKey, rpcAddress: "" }));
         assertEq(bsm.operatorRegistrationInputs(operator1), expectedInputs);
     }
 
@@ -100,11 +99,13 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
 
         // Non-allowed operator fails - error is wrapped in ManagerReverted
         vm.prank(operator2);
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.ManagerReverted.selector,
-            manager,
-            abi.encodeWithSelector(MockBSM_V2.OperatorNotAllowed.selector, operator2)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ManagerReverted.selector,
+                manager,
+                abi.encodeWithSelector(MockBSM_V2.OperatorNotAllowed.selector, operator2)
+            )
+        );
         tangle.registerOperator(blueprintId, _operatorGossipKey(operator2, 0), "");
     }
 
@@ -134,7 +135,9 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[0] = operator1;
 
         vm.prank(serviceOwner);
-        tangle.requestService{ value: 1 ether }(blueprintId, ops, "test-inputs", new address[](0), 0, address(0), 1 ether);
+        tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "test-inputs", new address[](0), 0, address(0), 1 ether
+        );
 
         assertEq(bsm.getHookCalls().onRequest, 1);
     }
@@ -153,11 +156,13 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
 
         // Below minimum fails - error is wrapped in ManagerReverted
         vm.prank(serviceOwner);
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.ManagerReverted.selector,
-            manager,
-            abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 1 ether, 0.5 ether)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ManagerReverted.selector,
+                manager,
+                abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 1 ether, 0.5 ether)
+            )
+        );
         tangle.requestService{ value: 0.5 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 0.5 ether);
 
         // At minimum succeeds
@@ -182,9 +187,8 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[1] = operator2;
 
         vm.prank(serviceOwner);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "", new address[](0), 0, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -217,9 +221,8 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[0] = operator1;
 
         vm.prank(serviceOwner);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "", new address[](0), 0, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.rejectService(requestId);
@@ -280,11 +283,11 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
 
         // Job index 6 should fail (wrapped in ManagerReverted)
         vm.prank(serviceOwner);
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.ManagerReverted.selector,
-            manager,
-            abi.encodeWithSelector(MockBSM_V2.InvalidJobIndex.selector, 6)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ManagerReverted.selector, manager, abi.encodeWithSelector(MockBSM_V2.InvalidJobIndex.selector, 6)
+            )
+        );
         tangle.submitJob(serviceId, 6, "inputs");
     }
 

--- a/test/blueprints/BlueprintDefinitionStorage.t.sol
+++ b/test/blueprints/BlueprintDefinitionStorage.t.sol
@@ -7,122 +7,121 @@ import { Errors } from "../../src/libraries/Errors.sol";
 import { MasterBlueprintServiceManager } from "../../src/MasterBlueprintServiceManager.sol";
 
 contract BlueprintDefinitionStorageTest is BaseTest {
-	function test_MetadataSourcesAndMembershipsPersisted() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://custom-metadata", address(0));
-		def.metadata.name = "Custom Blueprint";
-		def.metadata.description = "Verifies metadata persistence";
-		def.metadata.author = "Integration Team";
-		def.metadata.category = "Test Suite";
-		def.metadata.license = "Apache-2.0";
+    function test_MetadataSourcesAndMembershipsPersisted() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://custom-metadata", address(0));
+        def.metadata.name = "Custom Blueprint";
+        def.metadata.description = "Verifies metadata persistence";
+        def.metadata.author = "Integration Team";
+        def.metadata.category = "Test Suite";
+        def.metadata.license = "Apache-2.0";
 
-		def.sources = new Types.BlueprintSource[](2);
-		def.sources[0] = _defaultBlueprintSource();
-		def.sources[1].kind = Types.BlueprintSourceKind.Wasm;
-		def.sources[1].wasm.runtime = Types.WasmRuntime.Wasmer;
-		def.sources[1].wasm.fetcher = Types.BlueprintFetcherKind.Ipfs;
-		def.sources[1].wasm.artifactUri = "ipfs://artifact";
-		def.sources[1].wasm.entrypoint = "main";
-		def.sources[1].binaries = new Types.BlueprintBinary[](1);
-		def.sources[1].binaries[0] = Types.BlueprintBinary({
-			arch: Types.BlueprintArchitecture.Wasm32,
-			os: Types.BlueprintOperatingSystem.Unknown,
-			name: "wasm",
-			sha256: bytes32(uint256(0x5678))
-		});
+        def.sources = new Types.BlueprintSource[](2);
+        def.sources[0] = _defaultBlueprintSource();
+        def.sources[1].kind = Types.BlueprintSourceKind.Wasm;
+        def.sources[1].wasm.runtime = Types.WasmRuntime.Wasmer;
+        def.sources[1].wasm.fetcher = Types.BlueprintFetcherKind.Ipfs;
+        def.sources[1].wasm.artifactUri = "ipfs://artifact";
+        def.sources[1].wasm.entrypoint = "main";
+        def.sources[1].binaries = new Types.BlueprintBinary[](1);
+        def.sources[1].binaries[0] = Types.BlueprintBinary({
+            arch: Types.BlueprintArchitecture.Wasm32,
+            os: Types.BlueprintOperatingSystem.Unknown,
+            name: "wasm",
+            sha256: bytes32(uint256(0x5678))
+        });
 
-		def.supportedMemberships = new Types.MembershipModel[](1);
-		def.supportedMemberships[0] = Types.MembershipModel.Dynamic;
+        def.supportedMemberships = new Types.MembershipModel[](1);
+        def.supportedMemberships[0] = Types.MembershipModel.Dynamic;
 
-		bytes memory encodedDefinition = abi.encode(def);
-		vm.prank(developer);
-		uint64 blueprintId = tangle.createBlueprint(def);
+        bytes memory encodedDefinition = abi.encode(def);
+        vm.prank(developer);
+        uint64 blueprintId = tangle.createBlueprint(def);
 
-		(Types.BlueprintMetadata memory storedMetadata, string memory metadataUri) =
-			tangle.blueprintMetadata(blueprintId);
-		assertEq(metadataUri, def.metadataUri, "metadata URI mismatch");
-		assertEq(storedMetadata.name, def.metadata.name);
-		assertEq(storedMetadata.description, def.metadata.description);
-		assertEq(storedMetadata.author, def.metadata.author);
-		assertEq(storedMetadata.license, def.metadata.license);
+        (Types.BlueprintMetadata memory storedMetadata, string memory metadataUri) =
+            tangle.blueprintMetadata(blueprintId);
+        assertEq(metadataUri, def.metadataUri, "metadata URI mismatch");
+        assertEq(storedMetadata.name, def.metadata.name);
+        assertEq(storedMetadata.description, def.metadata.description);
+        assertEq(storedMetadata.author, def.metadata.author);
+        assertEq(storedMetadata.license, def.metadata.license);
 
-		Types.BlueprintSource[] memory storedSources = tangle.blueprintSources(blueprintId);
-		assertEq(storedSources.length, def.sources.length, "source length mismatch");
-		assertEq(uint256(storedSources[1].kind), uint256(def.sources[1].kind));
-		assertEq(storedSources[1].wasm.artifactUri, def.sources[1].wasm.artifactUri);
-		assertEq(storedSources[1].wasm.entrypoint, def.sources[1].wasm.entrypoint);
+        Types.BlueprintSource[] memory storedSources = tangle.blueprintSources(blueprintId);
+        assertEq(storedSources.length, def.sources.length, "source length mismatch");
+        assertEq(uint256(storedSources[1].kind), uint256(def.sources[1].kind));
+        assertEq(storedSources[1].wasm.artifactUri, def.sources[1].wasm.artifactUri);
+        assertEq(storedSources[1].wasm.entrypoint, def.sources[1].wasm.entrypoint);
 
-		Types.MembershipModel[] memory memberships = tangle.blueprintSupportedMemberships(blueprintId);
-		assertEq(memberships.length, def.supportedMemberships.length, "membership length mismatch");
-		assertEq(uint256(memberships[0]), uint256(def.supportedMemberships[0]));
+        Types.MembershipModel[] memory memberships = tangle.blueprintSupportedMemberships(blueprintId);
+        assertEq(memberships.length, def.supportedMemberships.length, "membership length mismatch");
+        assertEq(uint256(memberships[0]), uint256(def.supportedMemberships[0]));
 
-		assertEq(
-			tangle.blueprintMasterRevision(blueprintId),
-			mbsmRegistry.getPinnedRevision(blueprintId),
-			"master revision mismatch"
-		);
-	}
+        assertEq(
+            tangle.blueprintMasterRevision(blueprintId),
+            mbsmRegistry.getPinnedRevision(blueprintId),
+            "master revision mismatch"
+        );
+    }
 
-	function test_MasterManagerRecordsDefinition() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://mbsm-record", address(0));
-		bytes memory encodedDefinition = abi.encode(def);
+    function test_MasterManagerRecordsDefinition() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://mbsm-record", address(0));
+        bytes memory encodedDefinition = abi.encode(def);
 
-		vm.prank(developer);
-		uint64 blueprintId = tangle.createBlueprint(def);
+        vm.prank(developer);
+        uint64 blueprintId = tangle.createBlueprint(def);
 
-		MasterBlueprintServiceManager.BlueprintRecord memory record =
-			masterManager.getBlueprintRecord(blueprintId);
-		assertEq(record.owner, developer, "record owner mismatch");
-		assertGt(record.recordedAt, 0, "record timestamp missing");
-		assertEq(record.encodedDefinition, encodedDefinition, "definition payload mismatch");
-	}
+        MasterBlueprintServiceManager.BlueprintRecord memory record = masterManager.getBlueprintRecord(blueprintId);
+        assertEq(record.owner, developer, "record owner mismatch");
+        assertGt(record.recordedAt, 0, "record timestamp missing");
+        assertEq(record.encodedDefinition, encodedDefinition, "definition payload mismatch");
+    }
 
-	function test_SetMBSMRegistryAccessAndZeroChecks() public {
-		vm.expectRevert();
-		vm.prank(developer);
-		tangle.setMBSMRegistry(address(1));
+    function test_SetMBSMRegistryAccessAndZeroChecks() public {
+        vm.expectRevert();
+        vm.prank(developer);
+        tangle.setMBSMRegistry(address(1));
 
-		vm.prank(admin);
-		vm.expectRevert(abi.encodeWithSelector(Errors.ZeroAddress.selector));
-		tangle.setMBSMRegistry(address(0));
-	}
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(Errors.ZeroAddress.selector));
+        tangle.setMBSMRegistry(address(0));
+    }
 
-	function test_CreateBlueprintFailsWithoutMetadata() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("", address(0));
-		bytes memory encoded = abi.encode(def);
-		vm.prank(developer);
-		vm.expectRevert(Errors.BlueprintMetadataRequired.selector);
-		tangle.createBlueprint(def);
-	}
+    function test_CreateBlueprintFailsWithoutMetadata() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("", address(0));
+        bytes memory encoded = abi.encode(def);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintMetadataRequired.selector);
+        tangle.createBlueprint(def);
+    }
 
-	function test_CreateBlueprintFailsWithoutSources() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://no-sources", address(0));
-		def.sources = new Types.BlueprintSource[](0);
-		vm.prank(developer);
-		vm.expectRevert(Errors.BlueprintSourcesRequired.selector);
-		tangle.createBlueprint(def);
-	}
+    function test_CreateBlueprintFailsWithoutSources() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://no-sources", address(0));
+        def.sources = new Types.BlueprintSource[](0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintSourcesRequired.selector);
+        tangle.createBlueprint(def);
+    }
 
-	function test_CreateBlueprintFailsWithoutSupportedMemberships() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://no-memberships", address(0));
-		def.supportedMemberships = new Types.MembershipModel[](0);
-		vm.prank(developer);
-		vm.expectRevert(Errors.BlueprintMembershipRequired.selector);
-		tangle.createBlueprint(def);
-	}
+    function test_CreateBlueprintFailsWithoutSupportedMemberships() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://no-memberships", address(0));
+        def.supportedMemberships = new Types.MembershipModel[](0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintMembershipRequired.selector);
+        tangle.createBlueprint(def);
+    }
 
-	function test_CreateBlueprintFailsWithoutBinaryDescriptors() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://missing-binaries", address(0));
-		def.sources[0].binaries = new Types.BlueprintBinary[](0);
-		vm.prank(developer);
-		vm.expectRevert(Errors.BlueprintBinaryRequired.selector);
-		tangle.createBlueprint(def);
-	}
+    function test_CreateBlueprintFailsWithoutBinaryDescriptors() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://missing-binaries", address(0));
+        def.sources[0].binaries = new Types.BlueprintBinary[](0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintBinaryRequired.selector);
+        tangle.createBlueprint(def);
+    }
 
-	function test_CreateBlueprintFailsWithZeroHash() public {
-		Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://zero-hash", address(0));
-		def.sources[0].binaries[0].sha256 = bytes32(0);
-		vm.prank(developer);
-		vm.expectRevert(Errors.BlueprintBinaryHashRequired.selector);
-		tangle.createBlueprint(def);
-	}
+    function test_CreateBlueprintFailsWithZeroHash() public {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://zero-hash", address(0));
+        def.sources[0].binaries[0].sha256 = bytes32(0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintBinaryHashRequired.selector);
+        tangle.createBlueprint(def);
+    }
 }

--- a/test/blueprints/BlueprintServiceManagerBase.t.sol
+++ b/test/blueprints/BlueprintServiceManagerBase.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {BlueprintServiceManagerBase} from "../../src/BlueprintServiceManagerBase.sol";
+import { BlueprintServiceManagerBase } from "../../src/BlueprintServiceManagerBase.sol";
 
 /// @notice Concrete test double that exposes internal helpers
 contract BlueprintServiceManagerBaseHarness is BlueprintServiceManagerBase {
@@ -58,11 +58,7 @@ contract BlueprintServiceManagerBaseTest is Test {
 
     function test_OnlyFromTangle_EnforcedForHooks() public {
         vm.expectRevert(
-            abi.encodeWithSelector(
-                BlueprintServiceManagerBase.OnlyTangleAllowed.selector,
-                address(this),
-                tangle
-            )
+            abi.encodeWithSelector(BlueprintServiceManagerBase.OnlyTangleAllowed.selector, address(this), tangle)
         );
         bsm.onRegister(address(0xBEEF), "");
 
@@ -129,7 +125,7 @@ contract BlueprintServiceManagerBaseTest is Test {
 
     function test_ReceiveHook_TracksPayments() public {
         vm.deal(address(this), 1 ether);
-        (bool ok,) = address(bsm).call{value: 0.75 ether}("");
+        (bool ok,) = address(bsm).call{ value: 0.75 ether }("");
         require(ok, "send failed");
 
         assertEq(bsm.totalReceived(), 0.75 ether);

--- a/test/blueprints/CrossVersionCompatibility.t.sol
+++ b/test/blueprints/CrossVersionCompatibility.t.sol
@@ -335,11 +335,13 @@ contract CrossVersionCompatibilityTest is BlueprintTestHarness {
         ops[0] = operator1;
 
         vm.prank(serviceOwner);
-        vm.expectRevert(abi.encodeWithSelector(
-            Errors.ManagerReverted.selector,
-            address(bsmV2),
-            abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 5 ether, 1 ether)
-        ));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.ManagerReverted.selector,
+                address(bsmV2),
+                abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 5 ether, 1 ether)
+            )
+        );
         tangle.requestService{ value: 1 ether }(blueprintV2, ops, "", new address[](0), 0, address(0), 1 ether);
     }
 

--- a/test/blueprints/MBSMRegistry.t.sol
+++ b/test/blueprints/MBSMRegistry.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import {MBSMRegistry} from "../../src/MBSMRegistry.sol";
-import {Errors} from "../../src/libraries/Errors.sol";
+import { MBSMRegistry } from "../../src/MBSMRegistry.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
 
 contract MBSMRegistryTest is Test {
     MBSMRegistry internal registry;
@@ -14,10 +14,7 @@ contract MBSMRegistryTest is Test {
 
     function setUp() public {
         MBSMRegistry implementation = new MBSMRegistry();
-        ERC1967Proxy proxy = new ERC1967Proxy(
-            address(implementation),
-            abi.encodeCall(MBSMRegistry.initialize, (admin))
-        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), abi.encodeCall(MBSMRegistry.initialize, (admin)));
         registry = MBSMRegistry(address(proxy));
     }
 

--- a/test/blueprints/MasterBlueprintServiceManager.t.sol
+++ b/test/blueprints/MasterBlueprintServiceManager.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {MasterBlueprintServiceManager} from "../../src/MasterBlueprintServiceManager.sol";
+import { MasterBlueprintServiceManager } from "../../src/MasterBlueprintServiceManager.sol";
 
 contract MasterBlueprintServiceManagerTest is Test {
     MasterBlueprintServiceManager internal mbsm;
@@ -34,14 +34,13 @@ contract MasterBlueprintServiceManagerTest is Test {
 
     function test_OnBlueprintCreated_RecordsDefinition() public {
         bytes memory encodedDefinition = abi.encode("ipfs://definition");
-        uint64 nowTs = 1234567;
+        uint64 nowTs = 1_234_567;
         vm.warp(nowTs);
 
         vm.prank(tangle);
         mbsm.onBlueprintCreated(BLUEPRINT_ID, address(0xBEEF), encodedDefinition);
 
-        MasterBlueprintServiceManager.BlueprintRecord memory record =
-            mbsm.getBlueprintRecord(BLUEPRINT_ID);
+        MasterBlueprintServiceManager.BlueprintRecord memory record = mbsm.getBlueprintRecord(BLUEPRINT_ID);
 
         assertEq(record.owner, address(0xBEEF));
         assertEq(record.recordedAt, nowTs);
@@ -51,9 +50,7 @@ contract MasterBlueprintServiceManagerTest is Test {
     function test_OnBlueprintCreated_RevertsWithoutRole() public {
         vm.expectRevert(
             abi.encodeWithSignature(
-                "AccessControlUnauthorizedAccount(address,bytes32)",
-                address(this),
-                mbsm.TANGLE_ROLE()
+                "AccessControlUnauthorizedAccount(address,bytes32)", address(this), mbsm.TANGLE_ROLE()
             )
         );
         mbsm.onBlueprintCreated(BLUEPRINT_ID, address(1), "data");

--- a/test/blueprints/mocks/MockBSM.sol
+++ b/test/blueprints/mocks/MockBSM.sol
@@ -89,7 +89,13 @@ contract MockBSM_V1 is BlueprintServiceManagerBase {
         uint64,
         address,
         uint256
-    ) external payable virtual override onlyFromTangle {
+    )
+        external
+        payable
+        virtual
+        override
+        onlyFromTangle
+    {
         hookCalls.onRequest++;
         serviceRequestInputs[requestId] = requestInputs;
     }
@@ -109,7 +115,12 @@ contract MockBSM_V1 is BlueprintServiceManagerBase {
         address,
         address[] calldata,
         uint64
-    ) external virtual override onlyFromTangle {
+    )
+        external
+        virtual
+        override
+        onlyFromTangle
+    {
         hookCalls.onServiceInitialized++;
         initializedServices.push(serviceId);
     }
@@ -134,7 +145,12 @@ contract MockBSM_V1 is BlueprintServiceManagerBase {
     // JOB LIFECYCLE
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function onJobCall(uint64 serviceId, uint8, uint64 jobCallId, bytes calldata inputs)
+    function onJobCall(
+        uint64 serviceId,
+        uint8,
+        uint64 jobCallId,
+        bytes calldata inputs
+    )
         external
         payable
         virtual
@@ -153,7 +169,13 @@ contract MockBSM_V1 is BlueprintServiceManagerBase {
         address,
         bytes calldata,
         bytes calldata outputs
-    ) external payable virtual override onlyFromTangle {
+    )
+        external
+        payable
+        virtual
+        override
+        onlyFromTangle
+    {
         hookCalls.onJobResult++;
         jobOutputs[serviceId][jobCallId] = outputs;
     }
@@ -187,12 +209,13 @@ contract MockBSM_V1 is BlueprintServiceManagerBase {
     }
 
     /// @notice Allow immediate exits for testing (no commitment/queue durations)
-    function getExitConfig(uint64) external pure virtual override returns (
-        bool useDefault,
-        uint64 minCommitmentDuration,
-        uint64 exitQueueDuration,
-        bool forceExitAllowed
-    ) {
+    function getExitConfig(uint64)
+        external
+        pure
+        virtual
+        override
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed)
+    {
         return (false, 0, 0, false);
     }
 }
@@ -271,7 +294,12 @@ contract MockBSM_V2 is MockBSM_V1 {
         uint64,
         address,
         uint256 paymentAmount
-    ) external payable override onlyFromTangle {
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    {
         if (minimumPayment > 0 && paymentAmount < minimumPayment) {
             revert InsufficientPayment(minimumPayment, paymentAmount);
         }
@@ -279,7 +307,12 @@ contract MockBSM_V2 is MockBSM_V1 {
         serviceRequestInputs[requestId] = requestInputs;
     }
 
-    function onJobCall(uint64 serviceId, uint8 job, uint64 jobCallId, bytes calldata inputs)
+    function onJobCall(
+        uint64 serviceId,
+        uint8 job,
+        uint64 jobCallId,
+        bytes calldata inputs
+    )
         external
         payable
         virtual
@@ -298,12 +331,7 @@ contract MockBSM_V2 is MockBSM_V1 {
     // V2 CUSTOM CONFIGS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function getHeartbeatInterval(uint64 serviceId)
-        external
-        view
-        override
-        returns (bool useDefault, uint64 interval)
-    {
+    function getHeartbeatInterval(uint64 serviceId) external view override returns (bool useDefault, uint64 interval) {
         if (customHeartbeatIntervals[serviceId] > 0) {
             return (false, customHeartbeatIntervals[serviceId]);
         }
@@ -387,7 +415,11 @@ contract MockBSM_V3 is MockBSM_V2 {
         address,
         address[] calldata,
         uint64
-    ) external override onlyFromTangle {
+    )
+        external
+        override
+        onlyFromTangle
+    {
         hookCalls.onServiceInitialized++;
         initializedServices.push(serviceId);
         serviceActive[serviceId] = true;
@@ -398,7 +430,12 @@ contract MockBSM_V3 is MockBSM_V2 {
         serviceActive[serviceId] = false;
     }
 
-    function onJobCall(uint64 serviceId, uint8 job, uint64 jobCallId, bytes calldata inputs)
+    function onJobCall(
+        uint64 serviceId,
+        uint8 job,
+        uint64 jobCallId,
+        bytes calldata inputs
+    )
         external
         payable
         override

--- a/test/exposure/ExposureEdgeCases.t.sol
+++ b/test/exposure/ExposureEdgeCases.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
-import {ExposureManager} from "../../src/exposure/ExposureManager.sol";
-import {ExposureTypes} from "../../src/exposure/ExposureTypes.sol";
-import {ExposureCalculator} from "../../src/exposure/ExposureCalculator.sol";
-import {Types} from "../../src/libraries/Types.sol";
-import {SlashingLib} from "../../src/libraries/SlashingLib.sol";
-import {IStaking} from "../../src/interfaces/IStaking.sol";
+import { ExposureManager } from "../../src/exposure/ExposureManager.sol";
+import { ExposureTypes } from "../../src/exposure/ExposureTypes.sol";
+import { ExposureCalculator } from "../../src/exposure/ExposureCalculator.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { SlashingLib } from "../../src/libraries/SlashingLib.sol";
+import { IStaking } from "../../src/interfaces/IStaking.sol";
 
 /// @notice Mock staking for testing
 contract MockStakingEdge is IStaking {
@@ -15,48 +15,100 @@ contract MockStakingEdge is IStaking {
     mapping(address => uint256) public stakes;
     mapping(address => uint256) public delegatedStakes;
 
-    function setOperator(address operator, bool isOp) external { operators[operator] = isOp; }
-    function setStake(address operator, uint256 amount) external { stakes[operator] = amount; }
-    function setDelegatedStake(address operator, uint256 amount) external { delegatedStakes[operator] = amount; }
+    function setOperator(address operator, bool isOp) external {
+        operators[operator] = isOp;
+    }
 
-    function isOperator(address account) external view returns (bool) { return operators[account]; }
-    function isOperatorActive(address) external pure returns (bool) { return true; }
-    function getOperatorStake(address operator) external view returns (uint256) { return stakes[operator]; }
-    function getOperatorSelfStake(address operator) external view returns (uint256) { return stakes[operator]; }
-    function getOperatorDelegatedStake(address operator) external view returns (uint256) { return delegatedStakes[operator]; }
+    function setStake(address operator, uint256 amount) external {
+        stakes[operator] = amount;
+    }
+
+    function setDelegatedStake(address operator, uint256 amount) external {
+        delegatedStakes[operator] = amount;
+    }
+
+    function isOperator(address account) external view returns (bool) {
+        return operators[account];
+    }
+
+    function isOperatorActive(address) external pure returns (bool) {
+        return true;
+    }
+
+    function getOperatorStake(address operator) external view returns (uint256) {
+        return stakes[operator];
+    }
+
+    function getOperatorSelfStake(address operator) external view returns (uint256) {
+        return stakes[operator];
+    }
+
+    function getOperatorDelegatedStake(address operator) external view returns (uint256) {
+        return delegatedStakes[operator];
+    }
+
     function getOperatorDelegatedStakeForAsset(address operator, Types.Asset calldata) external view returns (uint256) {
         return delegatedStakes[operator];
     }
+
     function getOperatorStakeForAsset(address operator, Types.Asset calldata) external view returns (uint256) {
         return stakes[operator];
     }
-    function getDelegation(address, address) external pure returns (uint256) { return 0; }
-    function getTotalDelegation(address) external pure returns (uint256) { return 0; }
-    function minOperatorStake() external pure returns (uint256) { return 0; }
-    function meetsStakeRequirement(address, uint256) external pure returns (bool) { return true; }
+
+    function getDelegation(address, address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getTotalDelegation(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function minOperatorStake() external pure returns (uint256) {
+        return 0;
+    }
+
+    function meetsStakeRequirement(address, uint256) external pure returns (bool) {
+        return true;
+    }
+
     function slashForBlueprint(address, uint64, uint64, uint16 slashBps, bytes32) external pure returns (uint256) {
         return slashBps;
     }
-    function slashForService(address, uint64, uint64, Types.AssetSecurityCommitment[] calldata, uint16 slashBps, bytes32)
+
+    function slashForService(
+        address,
+        uint64,
+        uint64,
+        Types.AssetSecurityCommitment[] calldata,
+        uint16 slashBps,
+        bytes32
+    )
         external
         pure
         returns (uint256)
     {
         return slashBps;
     }
+
     function slash(address, uint64, uint16 slashBps, bytes32) external pure returns (uint256) {
         return slashBps;
     }
-    function isSlasher(address) external pure returns (bool) { return false; }
-    function notifyRewardForBlueprint(address, uint64, uint64, uint256) external {}
-    function notifyReward(address, uint64, uint256) external {}
-    function addBlueprintForOperator(address, uint64) external override {}
-    function removeBlueprintForOperator(address, uint64) external override {}
+
+    function isSlasher(address) external pure returns (bool) {
+        return false;
+    }
+    function notifyRewardForBlueprint(address, uint64, uint64, uint256) external { }
+    function notifyReward(address, uint64, uint256) external { }
+    function addBlueprintForOperator(address, uint64) external override { }
+    function removeBlueprintForOperator(address, uint64) external override { }
 
     // M-9 FIX: Pending slash tracking (no-op for mock)
-    function incrementPendingSlash(address) external override {}
-    function decrementPendingSlash(address) external override {}
-    function getPendingSlashCount(address) external pure override returns (uint64) { return 0; }
+    function incrementPendingSlash(address) external override { }
+    function decrementPendingSlash(address) external override { }
+
+    function getPendingSlashCount(address) external pure override returns (uint64) {
+        return 0;
+    }
 }
 
 /// @title ExposureEdgeCasesTest
@@ -101,7 +153,7 @@ contract ExposureEdgeCasesTest is Test {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: nativeAsset,
             minExposureBps: 1, // Minimum is 0.01%
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
@@ -119,11 +171,8 @@ contract ExposureEdgeCasesTest is Test {
 
     function test_Exposure_BoundaryOne_MinimumValid() public {
         Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1,
-            maxExposureBps: 10000
-        });
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1, maxExposureBps: 10_000 });
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
@@ -137,25 +186,22 @@ contract ExposureEdgeCasesTest is Test {
 
     function test_Exposure_Boundary9999_JustUnderMax() public {
         vm.prank(operator1);
-        manager.setAssetExposureLimit(nativeAsset, 10000, 5000, true);
+        manager.setAssetExposureLimit(nativeAsset, 10_000, 5000, true);
 
         (bool canAccept, uint16 limit) = manager.canAcceptExposure(operator1, nativeAsset, 9999);
         assertTrue(canAccept);
-        assertEq(limit, 10000);
+        assertEq(limit, 10_000);
     }
 
     function test_Exposure_Boundary10000_FullExposure() public {
         Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1,
-            maxExposureBps: 10000
-        });
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1, maxExposureBps: 10_000 });
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: nativeAsset,
-            exposureBps: 10000 // 100%
+            exposureBps: 10_000 // 100%
         });
 
         (bool valid,) = manager.validateCommitments(operator1, requirements, commitments);
@@ -165,7 +211,7 @@ contract ExposureEdgeCasesTest is Test {
     function test_Exposure_Boundary10001_ExceedsMax() public {
         vm.prank(operator1);
         vm.expectRevert();
-        manager.setAssetExposureLimit(nativeAsset, 10001, 5000, true);
+        manager.setAssetExposureLimit(nativeAsset, 10_001, 5000, true);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -178,8 +224,7 @@ contract ExposureEdgeCasesTest is Test {
         staking.setOperator(bigOperator, true);
         staking.setStake(bigOperator, type(uint128).max);
 
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(bigOperator, nativeAsset, 10000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(bigOperator, nativeAsset, 10_000);
 
         assertEq(delegated, type(uint128).max);
         assertEq(exposed, type(uint128).max); // 100% exposure
@@ -190,8 +235,7 @@ contract ExposureEdgeCasesTest is Test {
         staking.setOperator(bigOperator, true);
         staking.setStake(bigOperator, type(uint128).max);
 
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(bigOperator, nativeAsset, 5000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(bigOperator, nativeAsset, 5000);
 
         assertEq(delegated, type(uint128).max);
         assertEq(exposed, type(uint128).max / 2); // 50% exposure
@@ -201,14 +245,14 @@ contract ExposureEdgeCasesTest is Test {
         uint256 largeAmount = type(uint128).max;
 
         // Should not overflow
-        uint256 exposed = ExposureCalculator.calculateExposedAmount(largeAmount, 10000);
+        uint256 exposed = ExposureCalculator.calculateExposedAmount(largeAmount, 10_000);
         assertEq(exposed, largeAmount);
 
         exposed = ExposureCalculator.calculateExposedAmount(largeAmount, 5000);
         assertEq(exposed, largeAmount / 2);
 
         exposed = ExposureCalculator.calculateExposedAmount(largeAmount, 1);
-        assertEq(exposed, largeAmount / 10000);
+        assertEq(exposed, largeAmount / 10_000);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -217,16 +261,14 @@ contract ExposureEdgeCasesTest is Test {
 
     function test_ExposedAmount_TinyStake_RoundsDown() public {
         // operator3 has 1 wei stake
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(operator3, nativeAsset, 5000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(operator3, nativeAsset, 5000);
 
         assertEq(delegated, 1);
         assertEq(exposed, 0); // 1 * 5000 / 10000 = 0 (rounds down)
     }
 
     function test_ExposedAmount_TinyStake_FullExposure() public {
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(operator3, nativeAsset, 10000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(operator3, nativeAsset, 10_000);
 
         assertEq(delegated, 1);
         assertEq(exposed, 1); // 100% of 1 wei = 1 wei
@@ -237,7 +279,7 @@ contract ExposureEdgeCasesTest is Test {
         assertEq(ExposureCalculator.calculateExposedAmount(1, 1), 0);
 
         // 10000 wei with 1 bps = 1 wei
-        assertEq(ExposureCalculator.calculateExposedAmount(10000, 1), 1);
+        assertEq(ExposureCalculator.calculateExposedAmount(10_000, 1), 1);
 
         // 99 with 100 bps (1%) = 0 (rounds down)
         assertEq(ExposureCalculator.calculateExposedAmount(99, 100), 0);
@@ -259,7 +301,7 @@ contract ExposureEdgeCasesTest is Test {
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true); // Max 50%
 
         vm.prank(operator3);
-        manager.setAssetExposureLimit(nativeAsset, 10000, 5000, true); // Max 100%
+        manager.setAssetExposureLimit(nativeAsset, 10_000, 5000, true); // Max 100%
 
         // Verify each operator's limit is independent
         (bool canAccept1,) = manager.canAcceptExposure(operator1, nativeAsset, 3000);
@@ -267,8 +309,8 @@ contract ExposureEdgeCasesTest is Test {
         (bool canAccept3,) = manager.canAcceptExposure(operator3, nativeAsset, 3000);
 
         assertFalse(canAccept1); // 30% exceeds 25% limit
-        assertTrue(canAccept2);  // 30% within 50% limit
-        assertTrue(canAccept3);  // 30% within 100% limit
+        assertTrue(canAccept2); // 30% within 50% limit
+        assertTrue(canAccept3); // 30% within 100% limit
     }
 
     function test_MultiOperator_SameAsset_DifferentExposures() public {
@@ -276,14 +318,14 @@ contract ExposureEdgeCasesTest is Test {
         // Simulate weighted exposure calculation
 
         uint256[] memory delegations = new uint256[](3);
-        delegations[0] = 100 ether;  // operator1
+        delegations[0] = 100 ether; // operator1
         delegations[1] = 1000 ether; // operator2
-        delegations[2] = 50 ether;   // operator3
+        delegations[2] = 50 ether; // operator3
 
         uint16[] memory exposures = new uint16[](3);
-        exposures[0] = 5000;  // 50%
-        exposures[1] = 2500;  // 25%
-        exposures[2] = 10000; // 100%
+        exposures[0] = 5000; // 50%
+        exposures[1] = 2500; // 25%
+        exposures[2] = 10_000; // 100%
 
         uint16 weighted = ExposureCalculator.calculateWeightedExposure(delegations, exposures);
 
@@ -301,8 +343,8 @@ contract ExposureEdgeCasesTest is Test {
 
         vm.startPrank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true); // Native: 50%
-        manager.setAssetExposureLimit(erc20Asset, 3000, 1500, true);  // Token1: 30%
-        manager.setAssetExposureLimit(asset2, 10000, 5000, true);     // Token2: 100%
+        manager.setAssetExposureLimit(erc20Asset, 3000, 1500, true); // Token1: 30%
+        manager.setAssetExposureLimit(asset2, 10_000, 5000, true); // Token2: 100%
         // asset3 has no limit set
         vm.stopPrank();
 
@@ -311,33 +353,26 @@ contract ExposureEdgeCasesTest is Test {
         (bool canAccept3,) = manager.canAcceptExposure(operator1, asset2, 4000);
         (bool canAccept4,) = manager.canAcceptExposure(operator1, asset3, 4000);
 
-        assertTrue(canAccept1);  // 40% < 50%
+        assertTrue(canAccept1); // 40% < 50%
         assertFalse(canAccept2); // 40% > 30%
-        assertTrue(canAccept3);  // 40% < 100%
-        assertTrue(canAccept4);  // No limit, defaults to 100%
+        assertTrue(canAccept3); // 40% < 100%
+        assertTrue(canAccept4); // No limit, defaults to 100%
     }
 
     function test_MultiAsset_BatchSet_AllApplied() public {
-        ExposureTypes.OperatorAssetExposureLimit[] memory limits =
-            new ExposureTypes.OperatorAssetExposureLimit[](3);
+        ExposureTypes.OperatorAssetExposureLimit[] memory limits = new ExposureTypes.OperatorAssetExposureLimit[](3);
 
         limits[0] = ExposureTypes.OperatorAssetExposureLimit({
-            asset: nativeAsset,
-            maxExposureBps: 5000,
-            defaultExposureBps: 2500,
-            enabled: true
+            asset: nativeAsset, maxExposureBps: 5000, defaultExposureBps: 2500, enabled: true
         });
 
         limits[1] = ExposureTypes.OperatorAssetExposureLimit({
-            asset: erc20Asset,
-            maxExposureBps: 3000,
-            defaultExposureBps: 1500,
-            enabled: true
+            asset: erc20Asset, maxExposureBps: 3000, defaultExposureBps: 1500, enabled: true
         });
 
         limits[2] = ExposureTypes.OperatorAssetExposureLimit({
             asset: Types.Asset(Types.AssetKind.ERC20, makeAddr("token2")),
-            maxExposureBps: 10000,
+            maxExposureBps: 10_000,
             defaultExposureBps: 5000,
             enabled: true
         });
@@ -346,10 +381,8 @@ contract ExposureEdgeCasesTest is Test {
         manager.batchSetAssetExposureLimits(limits);
 
         // Verify all were set
-        ExposureTypes.OperatorAssetExposureLimit memory l1 =
-            manager.getAssetExposureLimit(operator1, nativeAsset);
-        ExposureTypes.OperatorAssetExposureLimit memory l2 =
-            manager.getAssetExposureLimit(operator1, erc20Asset);
+        ExposureTypes.OperatorAssetExposureLimit memory l1 = manager.getAssetExposureLimit(operator1, nativeAsset);
+        ExposureTypes.OperatorAssetExposureLimit memory l2 = manager.getAssetExposureLimit(operator1, erc20Asset);
 
         assertEq(l1.maxExposureBps, 5000);
         assertEq(l2.maxExposureBps, 3000);
@@ -393,7 +426,7 @@ contract ExposureEdgeCasesTest is Test {
 
         // Without per-asset limit, defaults to max (100%)
         assertTrue(canAccept);
-        assertEq(limit, 10000);
+        assertEq(limit, 10_000);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -412,8 +445,8 @@ contract ExposureEdgeCasesTest is Test {
         assertEq(effective, 2500);
 
         // 100% exposure
-        effective = SlashingLib.calculateEffectiveSlashBps(slashBps, 10000);
-        assertEq(effective, 10000);
+        effective = SlashingLib.calculateEffectiveSlashBps(slashBps, 10_000);
+        assertEq(effective, 10_000);
 
         // 1% exposure
         effective = SlashingLib.calculateEffectiveSlashBps(slashBps, 100);
@@ -427,12 +460,12 @@ contract ExposureEdgeCasesTest is Test {
 
     function test_SlashingLib_CapSlashBps() public pure {
         // Slash 50% with 100% max = 50%
-        uint16 capped = SlashingLib.capSlashBps(5000, 10000);
+        uint16 capped = SlashingLib.capSlashBps(5000, 10_000);
         assertEq(capped, 5000);
 
         // Slash 120% with 100% max = 100% (capped)
-        capped = SlashingLib.capSlashBps(12000, 10000);
-        assertEq(capped, 10000);
+        capped = SlashingLib.capSlashBps(12_000, 10_000);
+        assertEq(capped, 10_000);
 
         // Slash 50% with 25% max = 25% (capped)
         capped = SlashingLib.capSlashBps(5000, 2500);
@@ -493,8 +526,7 @@ contract ExposureEdgeCasesTest is Test {
         vm.prank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, false); // Disabled
 
-        ExposureTypes.OperatorAssetExposureLimit memory limit =
-            manager.getAssetExposureLimit(operator1, nativeAsset);
+        ExposureTypes.OperatorAssetExposureLimit memory limit = manager.getAssetExposureLimit(operator1, nativeAsset);
 
         assertFalse(limit.enabled);
         assertEq(limit.maxExposureBps, 5000); // Limit still stored
@@ -519,10 +551,7 @@ contract ExposureEdgeCasesTest is Test {
         assertEq(staking.getTotalDelegation(tempOperator), 0);
         assertEq(staking.minOperatorStake(), 0);
         assertTrue(staking.meetsStakeRequirement(tempOperator, 1 ether));
-        assertEq(
-            staking.slashForBlueprint(tempOperator, 1, 2, 5000, keccak256("bp-slash")),
-            5000
-        );
+        assertEq(staking.slashForBlueprint(tempOperator, 1, 2, 5000, keccak256("bp-slash")), 5000);
         assertEq(staking.slash(tempOperator, 3, 4000, keccak256("plain-slash")), 4000);
         assertFalse(staking.isSlasher(tempOperator));
 
@@ -573,13 +602,13 @@ contract ExposureFuzzTest is Test {
     function testFuzz_CalculateExposedAmount(uint256 delegation, uint16 exposureBps) public pure {
         // Bound inputs to reasonable ranges
         delegation = bound(delegation, 0, type(uint128).max);
-        exposureBps = uint16(bound(uint256(exposureBps), 0, 10000));
+        exposureBps = uint16(bound(uint256(exposureBps), 0, 10_000));
 
         uint256 exposed = ExposureCalculator.calculateExposedAmount(delegation, exposureBps);
 
         // Verify invariants
         assertLe(exposed, delegation); // Exposed <= Delegated
-        if (exposureBps == 10000) {
+        if (exposureBps == 10_000) {
             assertEq(exposed, delegation); // 100% exposure = full amount
         }
         if (exposureBps == 0) {
@@ -587,14 +616,10 @@ contract ExposureFuzzTest is Test {
         }
     }
 
-    function testFuzz_CalculateSlashAmount(
-        uint256 delegation,
-        uint16 exposureBps,
-        uint16 slashBps
-    ) public pure {
+    function testFuzz_CalculateSlashAmount(uint256 delegation, uint16 exposureBps, uint16 slashBps) public pure {
         delegation = bound(delegation, 0, type(uint128).max);
-        exposureBps = uint16(bound(uint256(exposureBps), 0, 10000));
-        slashBps = uint16(bound(uint256(slashBps), 0, 10000));
+        exposureBps = uint16(bound(uint256(exposureBps), 0, 10_000));
+        slashBps = uint16(bound(uint256(slashBps), 0, 10_000));
 
         uint256 slashAmount = ExposureCalculator.calculateSlashAmount(delegation, exposureBps, slashBps);
         uint256 maxSlashable = ExposureCalculator.calculateMaxSlashable(delegation, exposureBps);
@@ -606,7 +631,7 @@ contract ExposureFuzzTest is Test {
 
     function testFuzz_WeightedExposure_SingleElement(uint256 delegation, uint16 exposureBps) public pure {
         delegation = bound(delegation, 1, type(uint128).max);
-        exposureBps = uint16(bound(uint256(exposureBps), 0, 10000));
+        exposureBps = uint16(bound(uint256(exposureBps), 0, 10_000));
 
         uint256[] memory delegations = new uint256[](1);
         delegations[0] = delegation;
@@ -626,12 +651,15 @@ contract ExposureFuzzTest is Test {
         uint256 delegation2,
         uint16 exposure1,
         uint16 exposure2
-    ) public pure {
+    )
+        public
+        pure
+    {
         totalReward = bound(totalReward, 0, type(uint128).max);
         delegation1 = bound(delegation1, 1, type(uint64).max);
         delegation2 = bound(delegation2, 1, type(uint64).max);
-        exposure1 = uint16(bound(uint256(exposure1), 1, 10000));
-        exposure2 = uint16(bound(uint256(exposure2), 1, 10000));
+        exposure1 = uint16(bound(uint256(exposure1), 1, 10_000));
+        exposure2 = uint16(bound(uint256(exposure2), 1, 10_000));
 
         uint256 exposed1 = ExposureCalculator.calculateExposedAmount(delegation1, exposure1);
         uint256 exposed2 = ExposureCalculator.calculateExposedAmount(delegation2, exposure2);
@@ -649,13 +677,13 @@ contract ExposureFuzzTest is Test {
     }
 
     function testFuzz_SlashingLib_EffectiveSlashBps(uint16 slashBps, uint16 exposureBps) public pure {
-        slashBps = uint16(bound(uint256(slashBps), 0, 10000));
-        exposureBps = uint16(bound(uint256(exposureBps), 0, 10000));
+        slashBps = uint16(bound(uint256(slashBps), 0, 10_000));
+        exposureBps = uint16(bound(uint256(exposureBps), 0, 10_000));
 
         uint16 effective = SlashingLib.calculateEffectiveSlashBps(slashBps, exposureBps);
 
         assertLe(effective, slashBps);
-        if (exposureBps == 10000) {
+        if (exposureBps == 10_000) {
             assertEq(effective, slashBps);
         }
     }
@@ -663,7 +691,7 @@ contract ExposureFuzzTest is Test {
     function testFuzz_IsValidExposure(uint16 exposureBps) public pure {
         bool valid = ExposureCalculator.isValidExposure(exposureBps);
 
-        if (exposureBps >= 1 && exposureBps <= 10000) {
+        if (exposureBps >= 1 && exposureBps <= 10_000) {
             assertTrue(valid);
         } else {
             assertFalse(valid);
@@ -674,9 +702,9 @@ contract ExposureFuzzTest is Test {
         uint16 clamped = ExposureCalculator.clampExposure(exposureBps);
 
         assertGe(clamped, 1); // Min
-        assertLe(clamped, 10000); // Max
+        assertLe(clamped, 10_000); // Max
 
-        if (exposureBps >= 1 && exposureBps <= 10000) {
+        if (exposureBps >= 1 && exposureBps <= 10_000) {
             assertEq(clamped, exposureBps); // Unchanged if valid
         }
     }

--- a/test/exposure/ExposureManager.t.sol
+++ b/test/exposure/ExposureManager.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
-import {ExposureManager} from "../../src/exposure/ExposureManager.sol";
-import {ExposureTypes} from "../../src/exposure/ExposureTypes.sol";
-import {ExposureCalculator} from "../../src/exposure/ExposureCalculator.sol";
-import {MockPriceOracle} from "./MockPriceOracle.sol";
-import {Types} from "../../src/libraries/Types.sol";
-import {IStaking} from "../../src/interfaces/IStaking.sol";
+import { ExposureManager } from "../../src/exposure/ExposureManager.sol";
+import { ExposureTypes } from "../../src/exposure/ExposureTypes.sol";
+import { ExposureCalculator } from "../../src/exposure/ExposureCalculator.sol";
+import { MockPriceOracle } from "./MockPriceOracle.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { IStaking } from "../../src/interfaces/IStaking.sol";
 
 /// @notice Mock staking contract for testing
 contract MockStaking is IStaking {
@@ -46,9 +46,11 @@ contract MockStaking is IStaking {
     function getOperatorDelegatedStake(address operator) external view returns (uint256) {
         return delegatedStakes[operator];
     }
+
     function getOperatorDelegatedStakeForAsset(address operator, Types.Asset calldata) external view returns (uint256) {
         return delegatedStakes[operator];
     }
+
     function getOperatorStakeForAsset(address operator, Types.Asset calldata) external view returns (uint256) {
         return stakes[operator];
     }
@@ -69,13 +71,7 @@ contract MockStaking is IStaking {
         return true;
     }
 
-    function slashForBlueprint(
-        address,
-        uint64,
-        uint64,
-        uint16 slashBps,
-        bytes32
-    ) external pure returns (uint256) {
+    function slashForBlueprint(address, uint64, uint64, uint16 slashBps, bytes32) external pure returns (uint256) {
         return slashBps;
     }
 
@@ -86,16 +82,15 @@ contract MockStaking is IStaking {
         Types.AssetSecurityCommitment[] calldata,
         uint16 slashBps,
         bytes32
-    ) external pure returns (uint256) {
+    )
+        external
+        pure
+        returns (uint256)
+    {
         return slashBps;
     }
 
-    function slash(
-        address,
-        uint64,
-        uint16 slashBps,
-        bytes32
-    ) external pure returns (uint256) {
+    function slash(address, uint64, uint16 slashBps, bytes32) external pure returns (uint256) {
         return slashBps;
     }
 
@@ -103,26 +98,20 @@ contract MockStaking is IStaking {
         return false;
     }
 
-    function notifyRewardForBlueprint(
-        address,
-        uint64,
-        uint64,
-        uint256
-    ) external {}
+    function notifyRewardForBlueprint(address, uint64, uint64, uint256) external { }
 
-    function notifyReward(
-        address,
-        uint64,
-        uint256
-    ) external {}
+    function notifyReward(address, uint64, uint256) external { }
 
-    function addBlueprintForOperator(address, uint64) external override {}
-    function removeBlueprintForOperator(address, uint64) external override {}
+    function addBlueprintForOperator(address, uint64) external override { }
+    function removeBlueprintForOperator(address, uint64) external override { }
 
     // M-9 FIX: Pending slash tracking (no-op for mock)
-    function incrementPendingSlash(address) external override {}
-    function decrementPendingSlash(address) external override {}
-    function getPendingSlashCount(address) external pure override returns (uint64) { return 0; }
+    function incrementPendingSlash(address) external override { }
+    function decrementPendingSlash(address) external override { }
+
+    function getPendingSlashCount(address) external pure override returns (uint64) {
+        return 0;
+    }
 }
 
 /// @title ExposureManagerTest
@@ -184,8 +173,7 @@ contract ExposureManagerTest is Test {
         vm.prank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true);
 
-        ExposureTypes.OperatorAssetExposureLimit memory limit =
-            manager.getAssetExposureLimit(operator1, nativeAsset);
+        ExposureTypes.OperatorAssetExposureLimit memory limit = manager.getAssetExposureLimit(operator1, nativeAsset);
 
         assertEq(limit.maxExposureBps, 5000);
         assertEq(limit.defaultExposureBps, 2500);
@@ -196,7 +184,7 @@ contract ExposureManagerTest is Test {
         vm.startPrank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true);
         manager.setAssetExposureLimit(erc20Asset1, 3000, 1000, true);
-        manager.setAssetExposureLimit(erc20Asset2, 10000, 5000, true);
+        manager.setAssetExposureLimit(erc20Asset2, 10_000, 5000, true);
         vm.stopPrank();
 
         ExposureTypes.OperatorAssetExposureLimit memory nativeLimit =
@@ -208,13 +196,13 @@ contract ExposureManagerTest is Test {
 
         assertEq(nativeLimit.maxExposureBps, 5000);
         assertEq(erc20Limit1.maxExposureBps, 3000);
-        assertEq(erc20Limit2.maxExposureBps, 10000);
+        assertEq(erc20Limit2.maxExposureBps, 10_000);
     }
 
     function test_SetAssetExposureLimit_InvalidMaxExceeds100Percent() public {
         vm.prank(operator1);
         vm.expectRevert();
-        manager.setAssetExposureLimit(nativeAsset, 10001, 5000, true);
+        manager.setAssetExposureLimit(nativeAsset, 10_001, 5000, true);
     }
 
     function test_SetAssetExposureLimit_InvalidDefaultExceedsMax() public {
@@ -224,21 +212,14 @@ contract ExposureManagerTest is Test {
     }
 
     function test_BatchSetAssetExposureLimits() public {
-        ExposureTypes.OperatorAssetExposureLimit[] memory limits =
-            new ExposureTypes.OperatorAssetExposureLimit[](2);
+        ExposureTypes.OperatorAssetExposureLimit[] memory limits = new ExposureTypes.OperatorAssetExposureLimit[](2);
 
         limits[0] = ExposureTypes.OperatorAssetExposureLimit({
-            asset: nativeAsset,
-            maxExposureBps: 5000,
-            defaultExposureBps: 2500,
-            enabled: true
+            asset: nativeAsset, maxExposureBps: 5000, defaultExposureBps: 2500, enabled: true
         });
 
         limits[1] = ExposureTypes.OperatorAssetExposureLimit({
-            asset: erc20Asset1,
-            maxExposureBps: 3000,
-            defaultExposureBps: 1000,
-            enabled: true
+            asset: erc20Asset1, maxExposureBps: 3000, defaultExposureBps: 1000, enabled: true
         });
 
         vm.prank(operator1);
@@ -257,8 +238,7 @@ contract ExposureManagerTest is Test {
         vm.prank(operator1);
         manager.setOperatorExposureConfig(7500, true);
 
-        ExposureTypes.OperatorExposureConfig memory config =
-            manager.getOperatorExposureConfig(operator1);
+        ExposureTypes.OperatorExposureConfig memory config = manager.getOperatorExposureConfig(operator1);
 
         assertEq(config.globalMaxExposureBps, 7500);
         assertTrue(config.requireExplicitApproval);
@@ -269,20 +249,12 @@ contract ExposureManagerTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_ValidateCommitments_Success() public {
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 5000 });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
-        commitments[0] = Types.AssetSecurityCommitment({
-            asset: nativeAsset,
-            exposureBps: 2500
-        });
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
+        commitments[0] = Types.AssetSecurityCommitment({ asset: nativeAsset, exposureBps: 2500 });
 
         (bool valid, ExposureTypes.CommitmentValidationResult memory result) =
             manager.validateCommitments(operator1, requirements, commitments);
@@ -292,16 +264,11 @@ contract ExposureManagerTest is Test {
     }
 
     function test_ValidateCommitments_BelowMinimum() public {
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 3000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 3000, maxExposureBps: 5000 });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: nativeAsset,
             exposureBps: 2000 // Below minimum
@@ -315,16 +282,11 @@ contract ExposureManagerTest is Test {
     }
 
     function test_ValidateCommitments_AboveMaximum() public {
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 3000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 3000 });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: nativeAsset,
             exposureBps: 4000 // Above maximum
@@ -342,16 +304,14 @@ contract ExposureManagerTest is Test {
         vm.prank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 2000, 1000, true);
 
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
         requirements[0] = Types.AssetSecurityRequirement({
             asset: nativeAsset,
             minExposureBps: 1000,
             maxExposureBps: 5000 // Service allows up to 50%
         });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
         commitments[0] = Types.AssetSecurityCommitment({
             asset: nativeAsset,
             exposureBps: 3000 // Within service bounds but exceeds operator limit
@@ -365,26 +325,15 @@ contract ExposureManagerTest is Test {
     }
 
     function test_ValidateCommitments_MissingCommitment() public {
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](2);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
-        requirements[1] = Types.AssetSecurityRequirement({
-            asset: erc20Asset1,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](2);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 5000 });
+        requirements[1] =
+            Types.AssetSecurityRequirement({ asset: erc20Asset1, minExposureBps: 1000, maxExposureBps: 5000 });
 
         // Only provide commitment for native asset
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
-        commitments[0] = Types.AssetSecurityCommitment({
-            asset: nativeAsset,
-            exposureBps: 2500
-        });
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
+        commitments[0] = Types.AssetSecurityCommitment({ asset: nativeAsset, exposureBps: 2500 });
 
         (bool valid, ExposureTypes.CommitmentValidationResult memory result) =
             manager.validateCommitments(operator1, requirements, commitments);
@@ -394,25 +343,14 @@ contract ExposureManagerTest is Test {
     }
 
     function test_ValidateCommitments_UnexpectedCommitment() public {
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 5000 });
 
         // Provide commitments for both native and erc20 (unexpected)
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](2);
-        commitments[0] = Types.AssetSecurityCommitment({
-            asset: nativeAsset,
-            exposureBps: 2500
-        });
-        commitments[1] = Types.AssetSecurityCommitment({
-            asset: erc20Asset1,
-            exposureBps: 2500
-        });
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](2);
+        commitments[0] = Types.AssetSecurityCommitment({ asset: nativeAsset, exposureBps: 2500 });
+        commitments[1] = Types.AssetSecurityCommitment({ asset: erc20Asset1, exposureBps: 2500 });
 
         (bool valid, ExposureTypes.CommitmentValidationResult memory result) =
             manager.validateCommitments(operator1, requirements, commitments);
@@ -424,20 +362,12 @@ contract ExposureManagerTest is Test {
     function test_ValidateCommitments_NotOperator() public {
         address notOperator = makeAddr("notOperator");
 
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 5000 });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
-        commitments[0] = Types.AssetSecurityCommitment({
-            asset: nativeAsset,
-            exposureBps: 2500
-        });
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
+        commitments[0] = Types.AssetSecurityCommitment({ asset: nativeAsset, exposureBps: 2500 });
 
         (bool valid, ExposureTypes.CommitmentValidationResult memory result) =
             manager.validateCommitments(notOperator, requirements, commitments);
@@ -452,20 +382,12 @@ contract ExposureManagerTest is Test {
         staking.setOperator(noStakeOperator, true);
         staking.setStake(noStakeOperator, 0);
 
-        Types.AssetSecurityRequirement[] memory requirements =
-            new Types.AssetSecurityRequirement[](1);
-        requirements[0] = Types.AssetSecurityRequirement({
-            asset: nativeAsset,
-            minExposureBps: 1000,
-            maxExposureBps: 5000
-        });
+        Types.AssetSecurityRequirement[] memory requirements = new Types.AssetSecurityRequirement[](1);
+        requirements[0] =
+            Types.AssetSecurityRequirement({ asset: nativeAsset, minExposureBps: 1000, maxExposureBps: 5000 });
 
-        Types.AssetSecurityCommitment[] memory commitments =
-            new Types.AssetSecurityCommitment[](1);
-        commitments[0] = Types.AssetSecurityCommitment({
-            asset: nativeAsset,
-            exposureBps: 2500
-        });
+        Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
+        commitments[0] = Types.AssetSecurityCommitment({ asset: nativeAsset, exposureBps: 2500 });
 
         (bool valid, ExposureTypes.CommitmentValidationResult memory result) =
             manager.validateCommitments(noStakeOperator, requirements, commitments);
@@ -479,19 +401,17 @@ contract ExposureManagerTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_CanAcceptExposure_NoLimitSet() public view {
-        (bool canAccept, uint16 effectiveLimit) =
-            manager.canAcceptExposure(operator1, nativeAsset, 5000);
+        (bool canAccept, uint16 effectiveLimit) = manager.canAcceptExposure(operator1, nativeAsset, 5000);
 
         assertTrue(canAccept);
-        assertEq(effectiveLimit, 10000); // Default 100%
+        assertEq(effectiveLimit, 10_000); // Default 100%
     }
 
     function test_CanAcceptExposure_WithinLimit() public {
         vm.prank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true);
 
-        (bool canAccept, uint16 effectiveLimit) =
-            manager.canAcceptExposure(operator1, nativeAsset, 4000);
+        (bool canAccept, uint16 effectiveLimit) = manager.canAcceptExposure(operator1, nativeAsset, 4000);
 
         assertTrue(canAccept);
         assertEq(effectiveLimit, 5000);
@@ -501,8 +421,7 @@ contract ExposureManagerTest is Test {
         vm.prank(operator1);
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true);
 
-        (bool canAccept, uint16 effectiveLimit) =
-            manager.canAcceptExposure(operator1, nativeAsset, 6000);
+        (bool canAccept, uint16 effectiveLimit) = manager.canAcceptExposure(operator1, nativeAsset, 6000);
 
         assertFalse(canAccept);
         assertEq(effectiveLimit, 5000);
@@ -512,8 +431,7 @@ contract ExposureManagerTest is Test {
         vm.prank(operator1);
         manager.setOperatorExposureConfig(3000, false);
 
-        (bool canAccept, uint16 effectiveLimit) =
-            manager.canAcceptExposure(operator1, nativeAsset, 2500);
+        (bool canAccept, uint16 effectiveLimit) = manager.canAcceptExposure(operator1, nativeAsset, 2500);
 
         assertTrue(canAccept);
         assertEq(effectiveLimit, 3000);
@@ -525,8 +443,7 @@ contract ExposureManagerTest is Test {
         manager.setAssetExposureLimit(nativeAsset, 5000, 2500, true);
         vm.stopPrank();
 
-        (bool canAccept, uint16 effectiveLimit) =
-            manager.canAcceptExposure(operator1, nativeAsset, 4000);
+        (bool canAccept, uint16 effectiveLimit) = manager.canAcceptExposure(operator1, nativeAsset, 4000);
 
         assertTrue(canAccept);
         assertEq(effectiveLimit, 5000); // Uses per-asset, not global
@@ -537,24 +454,21 @@ contract ExposureManagerTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_CalculateExposedAmount() public view {
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(operator1, nativeAsset, 5000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(operator1, nativeAsset, 5000);
 
         assertEq(delegated, 100 ether); // Operator1's stake
         assertEq(exposed, 50 ether); // 50% of 100 ether
     }
 
     function test_CalculateExposedAmount_FullExposure() public view {
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(operator1, nativeAsset, 10000);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(operator1, nativeAsset, 10_000);
 
         assertEq(delegated, 100 ether);
         assertEq(exposed, 100 ether); // 100%
     }
 
     function test_CalculateExposedAmount_MinimalExposure() public view {
-        (uint256 delegated, uint256 exposed) =
-            manager.calculateExposedAmount(operator1, nativeAsset, 1);
+        (uint256 delegated, uint256 exposed) = manager.calculateExposedAmount(operator1, nativeAsset, 1);
 
         assertEq(delegated, 100 ether);
         assertEq(exposed, 0.01 ether); // 0.01%
@@ -570,7 +484,7 @@ contract ExposureCalculatorTest is Test {
     }
 
     function test_CalculateExposedAmount_FullExposure() public pure {
-        uint256 exposed = ExposureCalculator.calculateExposedAmount(100 ether, 10000);
+        uint256 exposed = ExposureCalculator.calculateExposedAmount(100 ether, 10_000);
         assertEq(exposed, 100 ether);
     }
 
@@ -611,7 +525,7 @@ contract ExposureCalculatorTest is Test {
 
     function test_CalculateSlashAmount_FullSlash() public pure {
         // 100 ETH delegated, 25% exposure, 100% slash of exposed
-        uint256 slashAmount = ExposureCalculator.calculateSlashAmount(100 ether, 2500, 10000);
+        uint256 slashAmount = ExposureCalculator.calculateSlashAmount(100 ether, 2500, 10_000);
         assertEq(slashAmount, 25 ether); // 100% of 25 ETH exposed = 25 ETH
     }
 
@@ -625,9 +539,9 @@ contract ExposureCalculatorTest is Test {
         // Should get 25% of total rewards
         uint256 share = ExposureCalculator.calculateRewardShare(
             100 ether, // delegated
-            5000,      // 50% exposure
+            5000, // 50% exposure
             100 ether, // total reward
-            200 ether  // total exposed value
+            200 ether // total exposed value
         );
         assertEq(share, 25 ether); // 50 ETH / 200 ETH * 100 ETH reward
     }
@@ -654,12 +568,8 @@ contract ExposureCalculatorTest is Test {
         oracle.setPrice(tokens[0], 2e18); // $2 per unit
         oracle.setPrice(tokens[1], 1e18); // $1 per unit
 
-        (uint16 weighted, uint256 totalUsd) = ExposureCalculator.calculateUSDWeightedExposure(
-            tokens,
-            delegations,
-            exposures,
-            oracle
-        );
+        (uint16 weighted, uint256 totalUsd) =
+            ExposureCalculator.calculateUSDWeightedExposure(tokens, delegations, exposures, oracle);
 
         // USD values: token0 => 20, token1 => 5
         // Weighted = (50% * 20 + 10% * 5) / 25 = 42% (rounded down)
@@ -672,12 +582,8 @@ contract ExposureCalculatorTest is Test {
         uint256[] memory delegations = new uint256[](0);
         uint16[] memory exposures = new uint16[](0);
         MockPriceOracle oracle = new MockPriceOracle();
-        (uint16 weighted, uint256 totalUsd) = ExposureCalculator.calculateUSDWeightedExposure(
-            tokens,
-            delegations,
-            exposures,
-            oracle
-        );
+        (uint16 weighted, uint256 totalUsd) =
+            ExposureCalculator.calculateUSDWeightedExposure(tokens, delegations, exposures, oracle);
         assertEq(weighted, 0);
         assertEq(totalUsd, 0);
     }
@@ -691,7 +597,7 @@ contract ExposureCalculatorTest is Test {
         uint16[] memory exposures = new uint16[](3);
         exposures[0] = 5000; // 50%
         exposures[1] = 2500; // 25%
-        exposures[2] = 10000; // 100%
+        exposures[2] = 10_000; // 100%
 
         uint256 total = ExposureCalculator.calculateTotalExposedValue(delegations, exposures);
         // 50 + 50 + 50 = 150 ETH
@@ -701,7 +607,7 @@ contract ExposureCalculatorTest is Test {
     function test_IsValidExposure() public pure {
         assertTrue(ExposureCalculator.isValidExposure(1)); // MIN
         assertTrue(ExposureCalculator.isValidExposure(5000)); // 50%
-        assertTrue(ExposureCalculator.isValidExposure(10000)); // MAX
+        assertTrue(ExposureCalculator.isValidExposure(10_000)); // MAX
         assertFalse(ExposureCalculator.isValidExposure(0)); // Below MIN
     }
 
@@ -716,19 +622,14 @@ contract ExposureCalculatorTest is Test {
     function test_ClampExposure() public pure {
         assertEq(ExposureCalculator.clampExposure(0), 1); // Clamp up to MIN
         assertEq(ExposureCalculator.clampExposure(5000), 5000); // No change
-        assertEq(ExposureCalculator.clampExposure(15000), 10000); // Clamp down to MAX
+        assertEq(ExposureCalculator.clampExposure(15_000), 10_000); // Clamp down to MAX
     }
 
     function test_BuildCalculatedExposure() public pure {
         Types.Asset memory asset = Types.Asset(Types.AssetKind.Native, address(0));
 
-        ExposureTypes.CalculatedExposure memory exposure = ExposureCalculator.buildCalculatedExposure(
-            address(0x123),
-            asset,
-            100 ether,
-            5000,
-            1
-        );
+        ExposureTypes.CalculatedExposure memory exposure =
+            ExposureCalculator.buildCalculatedExposure(address(0x123), asset, 100 ether, 5000, 1);
 
         assertEq(exposure.operator, address(0x123));
         assertEq(exposure.delegatedAmount, 100 ether);

--- a/test/exposure/MockPriceOracle.sol
+++ b/test/exposure/MockPriceOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {IPriceOracle} from "../../src/oracles/interfaces/IPriceOracle.sol";
+import { IPriceOracle } from "../../src/oracles/interfaces/IPriceOracle.sol";
 
 /// @notice Minimal mock implementing the price oracle interface for testing.
 contract MockPriceOracle is IPriceOracle {
@@ -18,7 +18,7 @@ contract MockPriceOracle is IPriceOracle {
 
     function getPriceData(address token) external view override returns (PriceData memory data) {
         uint256 price = prices[token];
-        return PriceData({price: price, updatedAt: block.timestamp, decimals: 18, isValid: price > 0});
+        return PriceData({ price: price, updatedAt: block.timestamp, decimals: 18, isValid: price > 0 });
     }
 
     function isTokenSupported(address token) external view override returns (bool supported) {
@@ -37,7 +37,10 @@ contract MockPriceOracle is IPriceOracle {
         return (usdValue * 1e18) / price;
     }
 
-    function batchToUSD(address[] calldata tokens, uint256[] calldata amounts)
+    function batchToUSD(
+        address[] calldata tokens,
+        uint256[] calldata amounts
+    )
         external
         view
         override

--- a/test/extensions/BlueprintExtensions.t.sol
+++ b/test/extensions/BlueprintExtensions.t.sol
@@ -1,28 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {BlueprintHookBase} from "../../src/interfaces/IBlueprintHook.sol";
-import {TokenizedBlueprintBase} from "../../src/extensions/TokenizedBlueprintBase.sol";
-import {
-    BuybackBlueprintBase,
-    ISwapRouter,
-    IWETH
-} from "../../src/extensions/BuybackBlueprintBase.sol";
-import {MockERC20} from "../MockERC20.sol";
+import { BlueprintHookBase } from "../../src/interfaces/IBlueprintHook.sol";
+import { TokenizedBlueprintBase } from "../../src/extensions/TokenizedBlueprintBase.sol";
+import { BuybackBlueprintBase, ISwapRouter, IWETH } from "../../src/extensions/BuybackBlueprintBase.sol";
+import { MockERC20 } from "../MockERC20.sol";
 
 // ═════════════════════════════════════════════════════════════════════════════
 // TEST HARNESS CONTRACTS
 // ═════════════════════════════════════════════════════════════════════════════
 
-contract BlueprintHookHarness is BlueprintHookBase {}
+contract BlueprintHookHarness is BlueprintHookBase { }
 
 contract TokenizedBlueprintHarness is TokenizedBlueprintBase {
-    constructor() TokenizedBlueprintBase("Harness Blueprint Token", "HBT") {}
+    constructor() TokenizedBlueprintBase("Harness Blueprint Token", "HBT") { }
 
     function bootstrap(uint64 blueprintId, address owner, address tangle) external {
         this.onBlueprintCreated(blueprintId, owner, tangle);
@@ -43,7 +39,7 @@ contract TokenizedBlueprintHarness is TokenizedBlueprintBase {
 }
 
 contract MockWETH is ERC20("MockWETH", "MWETH"), IWETH {
-    constructor() {}
+    constructor() { }
 
     function deposit() external payable {
         _mint(msg.sender, msg.value);
@@ -51,7 +47,7 @@ contract MockWETH is ERC20("MockWETH", "MWETH"), IWETH {
 
     function withdraw(uint256 amount) external {
         _burn(msg.sender, amount);
-        (bool ok,) = msg.sender.call{value: amount}("");
+        (bool ok,) = msg.sender.call{ value: amount }("");
         require(ok, "ETH send failed");
     }
 
@@ -106,9 +102,7 @@ contract MockSwapRouter is ISwapRouter {
 contract BuybackBlueprintHarness is BuybackBlueprintBase {
     uint256 internal expectedOutOverride;
 
-    constructor(address router, address weth)
-        BuybackBlueprintBase("Buyback Blueprint Token", "BBT", router, weth)
-    {}
+    constructor(address router, address weth) BuybackBlueprintBase("Buyback Blueprint Token", "BBT", router, weth) { }
 
     function bootstrap(uint64 blueprintId, address owner, address tangle) external {
         this.onBlueprintCreated(blueprintId, owner, tangle);
@@ -229,7 +223,7 @@ contract TokenizedBlueprintBaseTest is Test {
         blueprint.stake(80 ether);
 
         vm.deal(address(this), 1 ether);
-        (bool ok,) = address(blueprint).call{value: 1 ether}("");
+        (bool ok,) = address(blueprint).call{ value: 1 ether }("");
         require(ok, "payment failed");
 
         assertEq(staker.balance, 0);
@@ -261,7 +255,7 @@ contract TokenizedBlueprintBaseTest is Test {
         blueprint.stake(50 ether);
 
         vm.deal(address(this), 1 ether);
-        (bool ok,) = address(blueprint).call{value: 1 ether}("");
+        (bool ok,) = address(blueprint).call{ value: 1 ether }("");
         require(ok, "payment failed");
 
         vm.warp(block.timestamp + 3 days);
@@ -290,7 +284,7 @@ contract BuybackBlueprintBaseTest is Test {
     address internal staker = address(0x7777);
 
     function _sendEther(address target, uint256 amount) internal {
-        (bool ok, bytes memory data) = target.call{value: amount}("");
+        (bool ok, bytes memory data) = target.call{ value: amount }("");
         if (!ok) {
             assembly {
                 revert(add(data, 0x20), mload(data))
@@ -304,7 +298,7 @@ contract BuybackBlueprintBaseTest is Test {
         buyback = new BuybackBlueprintHarness(address(router), address(weth));
         buyback.bootstrap(1, owner, tangle);
         buyback.mintToken(address(router), 10_000 ether);
-        buyback.mintToken(staker, 1_000 ether);
+        buyback.mintToken(staker, 1000 ether);
     }
 
     function test_AutoModeExecutesBuybackAndDistributesRewards() public {
@@ -343,7 +337,9 @@ contract BuybackBlueprintBaseTest is Test {
     }
 
     function test_ThresholdModeTriggersWhenBalanceReached() public {
-        buyback.configure(BuybackBlueprintBase.BuybackMode.THRESHOLD, BuybackBlueprintBase.TokenDestination.TREASURY, 1 ether);
+        buyback.configure(
+            BuybackBlueprintBase.BuybackMode.THRESHOLD, BuybackBlueprintBase.TokenDestination.TREASURY, 1 ether
+        );
         buyback.setTreasury(treasury);
         buyback.setExpectedOutput(150 ether);
         router.setFixedAmountOut(150 ether);
@@ -365,7 +361,9 @@ contract BuybackBlueprintBaseTest is Test {
     }
 
     function test_ThresholdModeSlippageFailureKeepsPendingBalance() public {
-        buyback.configure(BuybackBlueprintBase.BuybackMode.THRESHOLD, BuybackBlueprintBase.TokenDestination.DISTRIBUTE, 5 ether);
+        buyback.configure(
+            BuybackBlueprintBase.BuybackMode.THRESHOLD, BuybackBlueprintBase.TokenDestination.DISTRIBUTE, 5 ether
+        );
         buyback.setExpectedOutput(150 ether);
         router.setFixedAmountOut(10 ether);
 

--- a/test/fuzz/PaymentFuzz.t.sol
+++ b/test/fuzz/PaymentFuzz.t.sol
@@ -42,10 +42,7 @@ contract PaymentFuzzTest is BaseTest {
 
         // Set the payment split
         Types.PaymentSplit memory split = Types.PaymentSplit({
-            developerBps: devBps,
-            protocolBps: protoBps,
-            operatorBps: opBps,
-            stakerBps: stakerBps
+            developerBps: devBps, protocolBps: protoBps, operatorBps: opBps, stakerBps: stakerBps
         });
         vm.prank(admin);
         tangle.setPaymentSplit(split);
@@ -84,13 +81,7 @@ contract PaymentFuzzTest is BaseTest {
         uint64 requestId;
         vm.prank(user1);
         requestId = tangle.requestService{ value: payment }(
-            blueprintId,
-            _singleOperator(operator1),
-            "",
-            new address[](0),
-            0,
-            address(0),
-            payment
+            blueprintId, _singleOperator(operator1), "", new address[](0), 0, address(0), payment
         );
 
         // Should not overflow during payment distribution
@@ -107,15 +98,11 @@ contract PaymentFuzzTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Fuzz test exposure-weighted distribution across multiple operators
-    function testFuzz_ExposureWeightedDistribution(
-        uint256 payment,
-        uint16 exposure1,
-        uint16 exposure2
-    ) public {
+    function testFuzz_ExposureWeightedDistribution(uint256 payment, uint16 exposure1, uint16 exposure2) public {
         // Bound inputs
         payment = bound(payment, 1 ether, 100 ether);
-        exposure1 = uint16(bound(uint256(exposure1), 1000, 10000)); // Min 10%, Max 100%
-        exposure2 = uint16(bound(uint256(exposure2), 1000, 10000));
+        exposure1 = uint16(bound(uint256(exposure1), 1000, 10_000)); // Min 10%, Max 100%
+        exposure2 = uint16(bound(uint256(exposure2), 1000, 10_000));
 
         // Register second operator
         _registerOperator(operator2, 10 ether);
@@ -149,8 +136,8 @@ contract PaymentFuzzTest is BaseTest {
 
         // Check that exposure ratios are approximately preserved
         if (totalOpRewards > 0 && totalExposure > 0) {
-            uint256 expectedRatio1 = (uint256(exposure1) * 10000) / totalExposure;
-            uint256 actualRatio1 = totalOpRewards > 0 ? (op1Rewards * 10000) / totalOpRewards : 0;
+            uint256 expectedRatio1 = (uint256(exposure1) * 10_000) / totalExposure;
+            uint256 actualRatio1 = totalOpRewards > 0 ? (op1Rewards * 10_000) / totalOpRewards : 0;
 
             // Allow 1% tolerance for rounding
             assertApproxEqAbs(expectedRatio1, actualRatio1, 100, "Exposure ratio not preserved");
@@ -162,11 +149,7 @@ contract PaymentFuzzTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Fuzz test subscription escrow doesn't go negative
-    function testFuzz_SubscriptionEscrow_NeverNegative(
-        uint256 initialEscrow,
-        uint256 rate,
-        uint8 billCount
-    ) public {
+    function testFuzz_SubscriptionEscrow_NeverNegative(uint256 initialEscrow, uint256 rate, uint8 billCount) public {
         // Bound inputs
         initialEscrow = bound(initialEscrow, 0.1 ether, 100 ether);
         rate = bound(rate, 0.01 ether, 1 ether);

--- a/test/fuzz/SlashingFuzz.t.sol
+++ b/test/fuzz/SlashingFuzz.t.sol
@@ -33,15 +33,11 @@ contract SlashingFuzzTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Fuzz: slashing bps correctly reduces balances proportionally
-    function testFuzz_ProportionalSlashing_BalancesCorrect(
-        uint256 opStake,
-        uint256 d1Stake,
-        uint16 slashBps
-    ) public {
+    function testFuzz_ProportionalSlashing_BalancesCorrect(uint256 opStake, uint256 d1Stake, uint16 slashBps) public {
         // Bound inputs to reasonable ranges
         opStake = bound(opStake, MIN_OPERATOR_STAKE, 50 ether);
         d1Stake = bound(d1Stake, MIN_DELEGATION, 50 ether);
-        slashBps = uint16(bound(uint256(slashBps), 1, 10000));
+        slashBps = uint16(bound(uint256(slashBps), 1, 10_000));
 
         // Fresh operator setup
         _registerOperator(operator2, opStake);
@@ -101,11 +97,7 @@ contract SlashingFuzzTest is BaseTest {
     }
 
     /// @notice Fuzz: multiple delegators slashed proportionally
-    function testFuzz_MultipleDelegators_ProportionalSlash(
-        uint256 d1Stake,
-        uint256 d2Stake,
-        uint256 slashPct
-    ) public {
+    function testFuzz_MultipleDelegators_ProportionalSlash(uint256 d1Stake, uint256 d2Stake, uint256 slashPct) public {
         // Bound inputs
         d1Stake = bound(d1Stake, MIN_DELEGATION, 30 ether);
         d2Stake = bound(d2Stake, MIN_DELEGATION, 30 ether);
@@ -174,14 +166,11 @@ contract SlashingFuzzTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Fuzz: exposure scaling correctly reduces effective slash
-    function testFuzz_ExposureScaling_ReducesSlash(
-        uint16 slashBps,
-        uint16 exposure
-    ) public {
+    function testFuzz_ExposureScaling_ReducesSlash(uint16 slashBps, uint16 exposure) public {
         // Bound to minimum 100 each so that effectiveBps = slashBps * exposure / 10000 >= 1
         // This avoids InvalidSlashAmount when the product rounds to 0
-        slashBps = uint16(bound(uint256(slashBps), 100, 10000));
-        exposure = uint16(bound(uint256(exposure), 100, 10000));
+        slashBps = uint16(bound(uint256(slashBps), 100, 10_000));
+        exposure = uint16(bound(uint256(exposure), 100, 10_000));
 
         // Create service with exposure
         _registerOperator(operator2, 10 ether);
@@ -193,9 +182,8 @@ contract SlashingFuzzTest is BaseTest {
         exposures[0] = exposure;
 
         vm.prank(user1);
-        uint64 reqId = tangle.requestServiceWithExposure(
-            blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0
-        );
+        uint64 reqId =
+            tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
         vm.prank(operator2);
         tangle.approveService(reqId, 0);
         uint64 svcId = tangle.serviceCount() - 1;
@@ -207,7 +195,7 @@ contract SlashingFuzzTest is BaseTest {
         uint64 slashId = tangle.proposeSlash(svcId, operator2, slashBps, keccak256("exp"));
 
         SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
-        uint256 expectedEffective = (uint256(slashBps) * exposure) / 10000;
+        uint256 expectedEffective = (uint256(slashBps) * exposure) / 10_000;
 
         // Verify proposal storage
         assertEq(proposal.slashBps, slashBps, "Proposed bps stored");
@@ -242,10 +230,7 @@ contract SlashingFuzzTest is BaseTest {
         for (uint8 i = 0; i < slashCount; i++) {
             vm.prank(user1);
             slashIds[i] = tangle.proposeSlash(
-                serviceId,
-                operator1,
-                slashBpsPerRound,
-                keccak256(abi.encodePacked("concurrent", i))
+                serviceId, operator1, slashBpsPerRound, keccak256(abi.encodePacked("concurrent", i))
             );
         }
 
@@ -289,7 +274,7 @@ contract SlashingFuzzTest is BaseTest {
         disputeWindow = uint64(bound(uint256(disputeWindow), 1 hours, 30 days));
 
         vm.prank(admin);
-        tangle.setSlashConfig(disputeWindow, false, 10000);
+        tangle.setSlashConfig(disputeWindow, false, 10_000);
 
         uint256 stakeBefore = staking.getOperatorSelfStake(operator1);
         uint256 proposalTime = block.timestamp;
@@ -325,7 +310,7 @@ contract SlashingFuzzTest is BaseTest {
 
     /// @notice Fuzz: slash bps are capped by maxSlashBps
     function testFuzz_SlashCaps_AtMaxBps(uint16 proposedBps) public {
-        proposedBps = uint16(bound(uint256(proposedBps), 1, 10000));
+        proposedBps = uint16(bound(uint256(proposedBps), 1, 10_000));
 
         vm.prank(admin);
         tangle.setSlashConfig(7 days, false, 3000);
@@ -345,7 +330,7 @@ contract SlashingFuzzTest is BaseTest {
     /// @notice Fuzz: invalid config reverts
     function testFuzz_InvalidConfig_Reverts(uint64 disputeWindow, uint16 maxSlashBps) public {
         bool invalidWindow = disputeWindow < 1 hours || disputeWindow > 30 days;
-        bool invalidMax = maxSlashBps == 0 || maxSlashBps > 10000;
+        bool invalidMax = maxSlashBps == 0 || maxSlashBps > 10_000;
 
         if (invalidWindow || invalidMax) {
             vm.prank(admin);
@@ -361,7 +346,7 @@ contract SlashingFuzzTest is BaseTest {
     /// @notice Fuzz: valid config is applied
     function testFuzz_ValidConfig_Applied(uint64 disputeWindow, uint16 maxSlashBps) public {
         disputeWindow = uint64(bound(uint256(disputeWindow), 1 hours, 30 days));
-        maxSlashBps = uint16(bound(uint256(maxSlashBps), 1, 10000));
+        maxSlashBps = uint16(bound(uint256(maxSlashBps), 1, 10_000));
 
         vm.prank(admin);
         tangle.setSlashConfig(disputeWindow, false, maxSlashBps);

--- a/test/helpers/BLSTestHelper.sol
+++ b/test/helpers/BLSTestHelper.sol
@@ -24,10 +24,14 @@ library BLSTestHelper {
     // ═══════════════════════════════════════════════════════════════════════════
 
     // G2 generator coordinates (same as BN254.sol)
-    uint256 constant G2_X0 = 11559732032986387107991004021392285783925812861821192530917403151452391805634;
-    uint256 constant G2_X1 = 10857046999023057135944570762232829481370756359578518086990519993285655852781;
-    uint256 constant G2_Y0 = 4082367875863433681332203403145435568316851327593401208105741076214120093531;
-    uint256 constant G2_Y1 = 8495653923123431417604973247489272438418190587263600148770280649306958101930;
+    uint256 constant G2_X0 =
+        11_559_732_032_986_387_107_991_004_021_392_285_783_925_812_861_821_192_530_917_403_151_452_391_805_634;
+    uint256 constant G2_X1 =
+        10_857_046_999_023_057_135_944_570_762_232_829_481_370_756_359_578_518_086_990_519_993_285_655_852_781;
+    uint256 constant G2_Y0 =
+        4_082_367_875_863_433_681_332_203_403_145_435_568_316_851_327_593_401_208_105_741_076_214_120_093_531;
+    uint256 constant G2_Y1 =
+        8_495_653_923_123_431_417_604_973_247_489_272_438_418_190_587_263_600_148_770_280_649_306_958_101_930;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // PRECOMPUTED G2 POINTS (2*G2, 3*G2)
@@ -35,22 +39,34 @@ library BLSTestHelper {
     // ═══════════════════════════════════════════════════════════════════════════
 
     // 2 * G2 (public key for sk=2)
-    uint256 constant G2_2X_X0 = 18029695676650738226693292988307914797657423701064905010927197838374790804409;
-    uint256 constant G2_2X_X1 = 14583779054894525174450323658765874724019480979794335525732096752006891875705;
-    uint256 constant G2_2X_Y0 = 2140229616977736810657479771656733941598412651537078903776637920509952744750;
-    uint256 constant G2_2X_Y1 = 11474861747383700316476719153975578001603231366361248090558603872215261634898;
+    uint256 constant G2_2X_X0 =
+        18_029_695_676_650_738_226_693_292_988_307_914_797_657_423_701_064_905_010_927_197_838_374_790_804_409;
+    uint256 constant G2_2X_X1 =
+        14_583_779_054_894_525_174_450_323_658_765_874_724_019_480_979_794_335_525_732_096_752_006_891_875_705;
+    uint256 constant G2_2X_Y0 =
+        2_140_229_616_977_736_810_657_479_771_656_733_941_598_412_651_537_078_903_776_637_920_509_952_744_750;
+    uint256 constant G2_2X_Y1 =
+        11_474_861_747_383_700_316_476_719_153_975_578_001_603_231_366_361_248_090_558_603_872_215_261_634_898;
 
     // 3 * G2 (public key for sk=3)
-    uint256 constant G2_3X_X0 = 2725019753478801796453339367788033689375851816420509565303521482350756874229;
-    uint256 constant G2_3X_X1 = 7273165102799931111715871471550377909735733521218303035754523677688038059653;
-    uint256 constant G2_3X_Y0 = 957874124722006818841961785324909313781880061366718538693995380805373202866;
-    uint256 constant G2_3X_Y1 = 2512659008974376214222774206987427162027254181373325676825515531566330959255;
+    uint256 constant G2_3X_X0 =
+        2_725_019_753_478_801_796_453_339_367_788_033_689_375_851_816_420_509_565_303_521_482_350_756_874_229;
+    uint256 constant G2_3X_X1 =
+        7_273_165_102_799_931_111_715_871_471_550_377_909_735_733_521_218_303_035_754_523_677_688_038_059_653;
+    uint256 constant G2_3X_Y0 =
+        957_874_124_722_006_818_841_961_785_324_909_313_781_880_061_366_718_538_693_995_380_805_373_202_866;
+    uint256 constant G2_3X_Y1 =
+        2_512_659_008_974_376_214_222_774_206_987_427_162_027_254_181_373_325_676_825_515_531_566_330_959_255;
 
     // 6 * G2 (aggregate pubkey for sk=1+2+3)
-    uint256 constant G2_6X_X0 = 4082367875863433681332203403145435568316851327593401208105741076214120093531;
-    uint256 constant G2_6X_X1 = 8495653923123431417604973247489272438418190587263600148770280649306958101930;
-    uint256 constant G2_6X_Y0 = 11559732032986387107991004021392285783925812861821192530917403151452391805634;
-    uint256 constant G2_6X_Y1 = 10857046999023057135944570762232829481370756359578518086990519993285655852781;
+    uint256 constant G2_6X_X0 =
+        4_082_367_875_863_433_681_332_203_403_145_435_568_316_851_327_593_401_208_105_741_076_214_120_093_531;
+    uint256 constant G2_6X_X1 =
+        8_495_653_923_123_431_417_604_973_247_489_272_438_418_190_587_263_600_148_770_280_649_306_958_101_930;
+    uint256 constant G2_6X_Y0 =
+        11_559_732_032_986_387_107_991_004_021_392_285_783_925_812_861_821_192_530_917_403_151_452_391_805_634;
+    uint256 constant G2_6X_Y1 =
+        10_857_046_999_023_057_135_944_570_762_232_829_481_370_756_359_578_518_086_990_519_993_285_655_852_781;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // PUBLIC KEY GETTERS
@@ -82,10 +98,7 @@ library BLSTestHelper {
     /// @dev sig = sk * H(message)
     /// @param message The message to sign
     /// @param privateKey The private key (1, 2, or 3 for tests)
-    function sign(
-        bytes memory message,
-        uint256 privateKey
-    ) internal view returns (Types.BN254G1Point memory) {
+    function sign(bytes memory message, uint256 privateKey) internal view returns (Types.BN254G1Point memory) {
         // Hash message to G1 point
         Types.BN254G1Point memory msgPoint = BN254.hashToG1(message);
         // Multiply by private key
@@ -98,7 +111,11 @@ library BLSTestHelper {
     function aggregateSignatures(
         bytes memory message,
         uint256[] memory privateKeys
-    ) internal view returns (Types.BN254G1Point memory aggSig) {
+    )
+        internal
+        view
+        returns (Types.BN254G1Point memory aggSig)
+    {
         require(privateKeys.length > 0, "No private keys");
 
         // First signature
@@ -117,7 +134,11 @@ library BLSTestHelper {
         uint64 serviceId,
         uint64 callId,
         bytes memory output
-    ) internal pure returns (bytes memory) {
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
         return abi.encodePacked(serviceId, callId, keccak256(output));
     }
 
@@ -128,10 +149,11 @@ library BLSTestHelper {
         uint64 serviceId,
         uint64 callId,
         bytes memory output
-    ) internal view returns (
-        Types.BN254G1Point memory sig,
-        Types.BN254G2Point memory pubkey
-    ) {
+    )
+        internal
+        view
+        returns (Types.BN254G1Point memory sig, Types.BN254G2Point memory pubkey)
+    {
         bytes memory message = buildJobResultMessage(serviceId, callId, output);
         sig = sign(message, 1);
         pubkey = getTestPubkey(1);
@@ -142,10 +164,11 @@ library BLSTestHelper {
         uint64 serviceId,
         uint64 callId,
         bytes memory output
-    ) internal view returns (
-        Types.BN254G1Point memory aggSig,
-        Types.BN254G2Point memory aggPubkey
-    ) {
+    )
+        internal
+        view
+        returns (Types.BN254G1Point memory aggSig, Types.BN254G2Point memory aggPubkey)
+    {
         bytes memory message = buildJobResultMessage(serviceId, callId, output);
 
         uint256[] memory privateKeys = new uint256[](3);

--- a/test/libraries/SchemaLibFuzz.t.sol
+++ b/test/libraries/SchemaLibFuzz.t.sol
@@ -159,11 +159,7 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SchemaValidationFailed.selector,
-                uint8(Types.SchemaTarget.Registration),
-                1,
-                0,
-                uint256(0)
+                Errors.SchemaValidationFailed.selector, uint8(Types.SchemaTarget.Registration), 1, 0, uint256(0)
             )
         );
         harness.validateRegistration(payload, 1, 0);
@@ -179,11 +175,7 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SchemaValidationFailed.selector,
-                uint8(Types.SchemaTarget.Request),
-                2,
-                0,
-                uint256(1)
+                Errors.SchemaValidationFailed.selector, uint8(Types.SchemaTarget.Request), 2, 0, uint256(1)
             )
         );
         harness.validateRequest(payload, 2, 0);
@@ -199,11 +191,7 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SchemaValidationFailed.selector,
-                uint8(Types.SchemaTarget.JobParams),
-                3,
-                0,
-                uint256(2)
+                Errors.SchemaValidationFailed.selector, uint8(Types.SchemaTarget.JobParams), 3, 0, uint256(2)
             )
         );
         harness.validateJobParams(payload, 3, 0);
@@ -225,37 +213,25 @@ contract SchemaLibFuzzTest is Test, BlueprintDefinitionHelper {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SchemaValidationFailed.selector,
-                uint8(Types.SchemaTarget.Registration),
-                5,
-                0,
-                uint256(0)
+                Errors.SchemaValidationFailed.selector, uint8(Types.SchemaTarget.Registration), 5, 0, uint256(0)
             )
         );
         harness.validateRegistration(payload, 5, 0);
     }
 
-    /// @notice Extra data after a struct completes is treated as a mixed-type violation and reverts with cursor metadata
+    /// @notice Extra data after a struct completes is treated as a mixed-type violation and reverts with cursor
+    /// metadata
     function test_PathologicalStructTrailingDataReverts() public {
         bytes memory schema = _structBoolUintSchema();
         harness.setRequestSchema(schema);
 
         // Payload encodes the correct struct, then appends stray bytes.
-        bytes memory payload = bytes.concat(
-            _encodeCompactLength(2),
-            bytes1(0x01),
-            bytes4(uint32(11)),
-            bytes1(0xFF)
-        );
+        bytes memory payload = bytes.concat(_encodeCompactLength(2), bytes1(0x01), bytes4(uint32(11)), bytes1(0xFF));
 
         // The trailing byte causes cursor != payloadLength, which is reported as the cursor offset (6).
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.SchemaValidationFailed.selector,
-                uint8(Types.SchemaTarget.Request),
-                8,
-                0,
-                uint256(6)
+                Errors.SchemaValidationFailed.selector, uint8(Types.SchemaTarget.Request), 8, 0, uint256(6)
             )
         );
         harness.validateRequest(payload, 8, 0);

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -5,7 +5,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @notice Simple mock ERC20 for testing
 contract MockERC20 is ERC20 {
-    constructor() ERC20("Mock Token", "MOCK") {}
+    constructor() ERC20("Mock Token", "MOCK") { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);

--- a/test/mocks/MockServiceFeeDistributor.sol
+++ b/test/mocks/MockServiceFeeDistributor.sol
@@ -21,7 +21,11 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         address operator,
         address paymentToken,
         uint256 amount
-    ) external payable override {
+    )
+        external
+        payable
+        override
+    {
         if (paymentToken == address(0)) {
             require(msg.value == amount, "bad msg.value");
         } else {
@@ -36,7 +40,11 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         address operator,
         address paymentToken,
         uint256 amount
-    ) external payable override {
+    )
+        external
+        payable
+        override
+    {
         if (paymentToken == address(0)) {
             require(msg.value == amount, "bad msg.value");
         } else {
@@ -45,11 +53,7 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         emit ServiceFeeReceived(serviceId, blueprintId, operator, paymentToken, amount);
     }
 
-    function claimFor(
-        address,
-        address,
-        Types.Asset calldata
-    ) external pure override returns (uint256 amount) {
+    function claimFor(address, address, Types.Asset calldata) external pure override returns (uint256 amount) {
         return amount;
     }
 
@@ -77,7 +81,12 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         address,
         address,
         bytes32
-    ) external pure override returns (uint8 mode, uint256 principal, uint256 score) {
+    )
+        external
+        pure
+        override
+        returns (uint8 mode, uint256 principal, uint256 score)
+    {
         return (mode, principal, score);
     }
 
@@ -95,20 +104,34 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         uint64[] calldata,
         uint256[] calldata,
         uint16
-    ) external override {}
-
-    function onBlueprintsRebalanced(address, address, Types.Asset calldata, uint64[] calldata, uint256[] calldata)
+    )
         external
         override
-    {}
-    function onAllModeSlashed(address, Types.Asset calldata, uint16) external override {}
-    function onFixedModeSlashed(address, uint64, Types.Asset calldata, uint16) external override {}
+    { }
+
+    function onBlueprintsRebalanced(
+        address,
+        address,
+        Types.Asset calldata,
+        uint64[] calldata,
+        uint256[] calldata
+    )
+        external
+        override
+    { }
+    function onAllModeSlashed(address, Types.Asset calldata, uint16) external override { }
+    function onFixedModeSlashed(address, uint64, Types.Asset calldata, uint16) external override { }
 
     function getPoolScore(
         address,
         uint64,
         Types.Asset calldata
-    ) external pure override returns (uint256 allScore, uint256 fixedScore) {
+    )
+        external
+        pure
+        override
+        returns (uint256 allScore, uint256 fixedScore)
+    {
         return (0, 0);
     }
 
@@ -116,12 +139,17 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         uint64,
         uint64,
         address
-    ) external pure override returns (uint256 totalUsdExposure) {
+    )
+        external
+        pure
+        override
+        returns (uint256 totalUsdExposure)
+    {
         return totalUsdExposure;
     }
 
-    function onOperatorLeaving(uint64, address) external override {}
-    function onServiceTerminated(uint64, address) external override {}
+    function onOperatorLeaving(uint64, address) external override { }
+    function onServiceTerminated(uint64, address) external override { }
 
-    receive() external payable {}
+    receive() external payable { }
 }

--- a/test/oracles/OracleAdaptersTest.t.sol
+++ b/test/oracles/OracleAdaptersTest.t.sol
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {ChainlinkOracle, AggregatorV3Interface as ChainlinkAggregator, IERC20Decimals as IERC20DecimalsChainlink}
-    from "../../src/oracles/ChainlinkOracle.sol";
+import {
+    ChainlinkOracle,
+    AggregatorV3Interface as ChainlinkAggregator,
+    IERC20Decimals as IERC20DecimalsChainlink
+} from "../../src/oracles/ChainlinkOracle.sol";
 import {
     UniswapV3Oracle,
     IUniswapV3Pool,
     AggregatorV3Interface as QuoteAggregator,
     IERC20Decimals as IERC20DecimalsUniswap
 } from "../../src/oracles/UniswapV3Oracle.sol";
-import {IPriceOracle} from "../../src/oracles/interfaces/IPriceOracle.sol";
+import { IPriceOracle } from "../../src/oracles/interfaces/IPriceOracle.sol";
 
 contract MockAggregator is ChainlinkAggregator, QuoteAggregator {
     uint8 internal decimalsValue;
@@ -32,12 +35,7 @@ contract MockAggregator is ChainlinkAggregator, QuoteAggregator {
         shouldRevert = flag;
     }
 
-    function decimals()
-        external
-        view
-        override(ChainlinkAggregator, QuoteAggregator)
-        returns (uint8)
-    {
+    function decimals() external view override(ChainlinkAggregator, QuoteAggregator) returns (uint8) {
         return decimalsValue;
     }
 
@@ -78,12 +76,7 @@ contract MockUniswapV3Pool is IUniswapV3Pool {
         currentTick = tick;
     }
 
-    function slot0()
-        external
-        view
-        override
-        returns (uint160, int24, uint16, uint16, uint16, uint8, bool)
-    {
+    function slot0() external view override returns (uint160, int24, uint16, uint16, uint16, uint8, bool) {
         return (0, currentTick, 0, 0, 0, 0, true);
     }
 
@@ -161,17 +154,19 @@ contract ChainlinkOracleTest is Test {
         tokens[0] = address(token);
         tokens[1] = address(token2);
         amounts[0] = 2_000_000; // 2 tokens with 6 decimals
-        amounts[1] = 1 ether;   // 1 token with 18 decimals
+        amounts[1] = 1 ether; // 1 token with 18 decimals
 
         uint256 totalUsd = oracle.batchToUSD(tokens, amounts);
-        assertEq(totalUsd, 4_500 ether);
+        assertEq(totalUsd, 4500 ether);
     }
 
     function test_getPrice_RevertWhenStale() public {
         uint256 updatedAt = block.timestamp - oracle.maxAge() - 1;
         assetFeed.setData(2000e8, updatedAt);
 
-        vm.expectRevert(abi.encodeWithSelector(IPriceOracle.StalePrice.selector, address(token), updatedAt, oracle.maxAge()));
+        vm.expectRevert(
+            abi.encodeWithSelector(IPriceOracle.StalePrice.selector, address(token), updatedAt, oracle.maxAge())
+        );
         oracle.getPrice(address(token));
     }
 

--- a/test/payments/EffectiveExposureIntegration.t.sol
+++ b/test/payments/EffectiveExposureIntegration.t.sol
@@ -28,44 +28,44 @@ contract EffectiveExposureIntegrationTest is Test {
     /// @notice Test scenario documentation
     function test_documentEffectiveExposureScenario() public pure {
         // This test documents the expected behavior after the fix
-        
+
         // Given: 3 operators with varying delegations
         uint256 aliceDelegation = 500 ether;
         uint256 bobDelegation = 200 ether;
         uint256 charlieDelegation = 0 ether; // No delegation!
-        
+
         // And: All operators commit 10% exposure
         uint256 exposureBps = 1000;
-        
+
         // When: We calculate effective exposures
         uint256 aliceEffective = (aliceDelegation * exposureBps) / BPS_DENOMINATOR;
         uint256 bobEffective = (bobDelegation * exposureBps) / BPS_DENOMINATOR;
         uint256 charlieEffective = (charlieDelegation * exposureBps) / BPS_DENOMINATOR;
-        
+
         // Then: Effective exposures are:
         assertEq(aliceEffective, 50 ether, "Alice: 500 ETH x 10% = 50 ETH");
         assertEq(bobEffective, 20 ether, "Bob: 200 ETH x 10% = 20 ETH");
         assertEq(charlieEffective, 0, "Charlie: 0 ETH x 10% = 0 ETH");
-        
+
         // And: Total effective exposure is 70 ETH
         uint256 totalEffective = aliceEffective + bobEffective + charlieEffective;
         assertEq(totalEffective, 70 ether, "Total: 70 ETH");
-        
+
         // And: Payment shares are proportional to effective exposure
         uint256 aliceShare = (TOTAL_PAYMENT * aliceEffective) / totalEffective;
         uint256 bobShare = (TOTAL_PAYMENT * bobEffective) / totalEffective;
         // Charlie gets remainder (which is 0 because his effective exposure is 0)
         uint256 charlieShare = TOTAL_PAYMENT - aliceShare - bobShare;
-        
+
         // Alice: 50/70 ≈ 714.28 ETH (71.4%)
-        assertApproxEqRel(aliceShare, 714285714285714285714, 0.01e18, "Alice gets ~714 ETH");
-        
+        assertApproxEqRel(aliceShare, 714_285_714_285_714_285_714, 0.01e18, "Alice gets ~714 ETH");
+
         // Bob: 20/70 ≈ 285.71 ETH (28.6%)
-        assertApproxEqRel(bobShare, 285714285714285714285, 0.01e18, "Bob gets ~286 ETH");
-        
+        assertApproxEqRel(bobShare, 285_714_285_714_285_714_285, 0.01e18, "Bob gets ~286 ETH");
+
         // Charlie: 0/70 = 0 ETH (0%) - but may get 1 wei dust from rounding
         assertLe(charlieShare, 1, "Charlie gets 0-1 wei (dust only)");
-        
+
         // Verify total distributed equals input
         assertEq(aliceShare + bobShare + charlieShare, TOTAL_PAYMENT, "Total equals input");
     }
@@ -73,44 +73,44 @@ contract EffectiveExposureIntegrationTest is Test {
     /// @notice Test: Old (buggy) behavior gave equal shares
     function test_oldBuggyBehavior_equalSharesDespiteUnequalDelegation() public pure {
         // OLD BUG: Payment was based only on exposureBps, ignoring delegation
-        
+
         uint16[] memory exposures = new uint16[](3);
         exposures[0] = 1000; // Alice: 10%
         exposures[1] = 1000; // Bob: 10%
         exposures[2] = 1000; // Charlie: 10% (but 0 delegation!)
-        
+
         uint256 totalExposure = 3000; // Sum of exposureBps
-        
+
         // Bug: All operators got equal 33% despite Charlie having no security
         uint256 aliceShareOld = (TOTAL_PAYMENT * exposures[0]) / totalExposure;
         uint256 bobShareOld = (TOTAL_PAYMENT * exposures[1]) / totalExposure;
         uint256 charlieShareOld = TOTAL_PAYMENT - aliceShareOld - bobShareOld;
-        
+
         // This was the BUG - Charlie got paid for security he didn't provide
-        assertEq(aliceShareOld, 333333333333333333333, "OLD BUG: Alice got 33%");
-        assertEq(bobShareOld, 333333333333333333333, "OLD BUG: Bob got 33%");
-        assertEq(charlieShareOld, 333333333333333333334, "OLD BUG: Charlie got 33% for 0 security!");
+        assertEq(aliceShareOld, 333_333_333_333_333_333_333, "OLD BUG: Alice got 33%");
+        assertEq(bobShareOld, 333_333_333_333_333_333_333, "OLD BUG: Bob got 33%");
+        assertEq(charlieShareOld, 333_333_333_333_333_333_334, "OLD BUG: Charlie got 33% for 0 security!");
     }
 
     /// @notice Test: Multi-asset scenario with different exposures per asset
     function test_multiAssetEffectiveExposure() public pure {
         // Scenario: Operator commits to multiple assets with different exposure levels
-        
+
         // Operator has:
         // - 100 ETH delegated, commits 50% exposure → 50 ETH effective
         // - 1000 USDC delegated, commits 20% exposure → 200 USDC effective
-        
+
         uint256 ethDelegation = 100 ether;
         uint256 ethExposureBps = 5000; // 50%
         uint256 ethEffective = (ethDelegation * ethExposureBps) / BPS_DENOMINATOR;
-        
+
         uint256 usdcDelegation = 1000 * 1e6; // 1000 USDC (6 decimals)
         uint256 usdcExposureBps = 2000; // 20%
         uint256 usdcEffective = (usdcDelegation * usdcExposureBps) / BPS_DENOMINATOR;
-        
+
         assertEq(ethEffective, 50 ether, "ETH effective: 100 x 50% = 50");
         assertEq(usdcEffective, 200 * 1e6, "USDC effective: 1000 x 20% = 200");
-        
+
         // Note: Without a price oracle, these can't be directly compared
         // With a price oracle, they'd be normalized to USD
     }
@@ -118,11 +118,11 @@ contract EffectiveExposureIntegrationTest is Test {
     /// @notice Test: Edge case - single operator with 100% exposure
     function test_singleOperatorFullExposure() public pure {
         uint256 delegation = 1000 ether;
-        uint256 exposureBps = 10000; // 100%
-        
+        uint256 exposureBps = 10_000; // 100%
+
         uint256 effective = (delegation * exposureBps) / BPS_DENOMINATOR;
         assertEq(effective, delegation, "100% exposure = full delegation");
-        
+
         // Single operator gets all payment
         uint256 share = (TOTAL_PAYMENT * effective) / effective;
         assertEq(share, TOTAL_PAYMENT, "Single operator gets all");
@@ -132,14 +132,14 @@ contract EffectiveExposureIntegrationTest is Test {
     function test_allOperatorsZeroDelegation() public pure {
         // If all operators have 0 delegation, totalEffectiveExposure = 0
         // Payment distribution should return empty/handle gracefully
-        
+
         uint256[] memory effectiveExposures = new uint256[](3);
         effectiveExposures[0] = 0;
         effectiveExposures[1] = 0;
         effectiveExposures[2] = 0;
-        
+
         uint256 totalEffective = 0;
-        
+
         // In this case, the payment should go elsewhere (e.g., treasury)
         // or revert - depends on implementation
         assertEq(totalEffective, 0, "Total is zero when no operator has delegation");
@@ -148,19 +148,19 @@ contract EffectiveExposureIntegrationTest is Test {
     /// @notice Test: Verify no rounding loss (dust capture)
     function test_dustCaptureInPaymentDistribution() public pure {
         // Test that dust from rounding is properly captured
-        
+
         uint256[] memory effectiveExposures = new uint256[](3);
         effectiveExposures[0] = 33 ether;
         effectiveExposures[1] = 33 ether;
         effectiveExposures[2] = 34 ether;
-        
+
         uint256 totalEffective = 100 ether;
-        
+
         // Calculate shares
         uint256 share0 = (TOTAL_PAYMENT * effectiveExposures[0]) / totalEffective; // 330
         uint256 share1 = (TOTAL_PAYMENT * effectiveExposures[1]) / totalEffective; // 330
         uint256 share2 = TOTAL_PAYMENT - share0 - share1; // Remainder: 340
-        
+
         // Verify total equals input (no dust lost)
         uint256 totalDistributed = share0 + share1 + share2;
         assertEq(totalDistributed, TOTAL_PAYMENT, "Total distributed equals input (dust captured)");

--- a/test/rewards/ServiceFeeDistributor.t.sol
+++ b/test/rewards/ServiceFeeDistributor.t.sol
@@ -34,7 +34,9 @@ contract ServiceFeeDistributorTest is BaseTest {
         ServiceFeeDistributor impl = new ServiceFeeDistributor();
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(impl),
-            abi.encodeCall(ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(oracle)))
+            abi.encodeCall(
+                ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(oracle))
+            )
         );
         distributor = ServiceFeeDistributor(payable(address(proxy)));
 
@@ -42,7 +44,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         tangle.setServiceFeeDistributor(address(distributor));
         tangle.setPriceOracle(address(oracle));
         staking.setServiceFeeDistributor(address(distributor));
-        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
         vm.stopPrank();
 
         vm.prank(developer);
@@ -52,8 +54,8 @@ contract ServiceFeeDistributorTest is BaseTest {
         _registerForBlueprint(operator1, blueprintId);
 
         stakeToken.mint(delegator2, 100 ether);
-        payTokenA.mint(user1, 1_000 ether);
-        payTokenB.mint(user1, 1_000 ether);
+        payTokenA.mint(user1, 1000 ether);
+        payTokenB.mint(user1, 1000 ether);
 
         vm.prank(delegator1);
         staking.depositAndDelegate{ value: 10 ether }(operator1);
@@ -61,16 +63,17 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(delegator2);
         stakeToken.approve(address(staking), 10 ether);
         staking.depositAndDelegateWithOptions(
-            operator1,
-            address(stakeToken),
-            10 ether,
-            Types.BlueprintSelectionMode.All,
-            new uint64[](0)
+            operator1, address(stakeToken), 10 ether, Types.BlueprintSelectionMode.All, new uint64[](0)
         );
         vm.stopPrank();
     }
 
-    function _requestAndApproveWithCommitments(uint16 nativeBps, uint16 erc20Bps, address paymentToken, uint256 paymentAmount)
+    function _requestAndApproveWithCommitments(
+        uint16 nativeBps,
+        uint16 erc20Bps,
+        address paymentToken,
+        uint256 paymentAmount
+    )
         internal
         returns (uint64 serviceId)
     {
@@ -78,12 +81,12 @@ contract ServiceFeeDistributorTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -92,14 +95,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         MockERC20(paymentToken).approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            ops,
-            reqs,
-            "",
-            new address[](0),
-            0,
-            paymentToken,
-            paymentAmount
+            blueprintId, ops, reqs, "", new address[](0), 0, paymentToken, paymentAmount
         );
         vm.stopPrank();
 
@@ -115,8 +111,8 @@ contract ServiceFeeDistributorTest is BaseTest {
 
     function test_Distribution_MultiplePaymentTokens_AccruesSeparately() public {
         // restaker share = 20% of payment, pick amounts divisible.
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenB), 50 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenB), 50 ether);
 
         uint256 d1A = payTokenA.balanceOf(delegator1);
         uint256 d2A = payTokenA.balanceOf(delegator2);
@@ -145,8 +141,8 @@ contract ServiceFeeDistributorTest is BaseTest {
     }
 
     function test_ClaimAllBatch_MultiToken() public {
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenB), 50 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenB), 50 ether);
 
         uint256 pendingA = distributor.pendingRewards(delegator1, address(payTokenA));
         uint256 pendingB = distributor.pendingRewards(delegator1, address(payTokenB));
@@ -175,9 +171,8 @@ contract ServiceFeeDistributorTest is BaseTest {
         uint256 paymentAmount = 110 ether;
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
-        uint64 requestId = tangle.requestService(
-            blueprintId, ops, "", new address[](0), 0, address(payTokenA), paymentAmount
-        );
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(payTokenA), paymentAmount);
         vm.stopPrank();
 
         vm.prank(operator1);
@@ -222,11 +217,7 @@ contract ServiceFeeDistributorTest is BaseTest {
 
         vm.prank(fixedDelA);
         staking.depositAndDelegateWithOptions{ value: 12 ether }(
-            operator2,
-            address(0),
-            12 ether,
-            Types.BlueprintSelectionMode.Fixed,
-            both
+            operator2, address(0), 12 ether, Types.BlueprintSelectionMode.Fixed, both
         );
 
         uint64[] memory onlyFirst = new uint64[](1);
@@ -234,18 +225,14 @@ contract ServiceFeeDistributorTest is BaseTest {
 
         vm.prank(fixedDelB);
         staking.depositAndDelegateWithOptions{ value: 12 ether }(
-            operator2,
-            address(0),
-            12 ether,
-            Types.BlueprintSelectionMode.Fixed,
-            onlyFirst
+            operator2, address(0), 12 ether, Types.BlueprintSelectionMode.Fixed, onlyFirst
         );
 
         Types.AssetSecurityRequirement[] memory reqs = new Types.AssetSecurityRequirement[](1);
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -255,19 +242,12 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            ops,
-            reqs,
-            "",
-            new address[](0),
-            0,
-            address(payTokenA),
-            paymentAmount
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), paymentAmount
         );
         vm.stopPrank();
 
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](1);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
 
         vm.prank(operator2);
         tangle.approveServiceWithCommitments(requestId, commits);
@@ -297,12 +277,12 @@ contract ServiceFeeDistributorTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -312,20 +292,13 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            ops,
-            reqs,
-            "",
-            new address[](0),
-            0,
-            address(payTokenA),
-            paymentAmount
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), paymentAmount
         );
         vm.stopPrank();
 
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](2);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
-        commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
+        commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 10_000 });
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(IPriceOracle.PriceNotAvailable.selector, address(stakeToken)));
@@ -343,9 +316,8 @@ contract ServiceFeeDistributorTest is BaseTest {
         // Create service with operator2 (who has no delegators)
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), 100 ether);
-        uint64 requestId = tangle.requestService(
-            blueprintId, ops, "", new address[](0), 0, address(payTokenA), 100 ether
-        );
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(payTokenA), 100 ether);
         vm.stopPrank();
 
         // Should not revert even though operator has no delegators
@@ -359,7 +331,7 @@ contract ServiceFeeDistributorTest is BaseTest {
     function test_EdgeCase_AsymmetricCommitments_CorrectWeighting() public {
         // Native: 100% commitment (10000 bps)
         // ERC20: 10% commitment (1000 bps)
-        _requestAndApproveWithCommitments(10000, 1000, address(payTokenA), 110 ether);
+        _requestAndApproveWithCommitments(10_000, 1000, address(payTokenA), 110 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
         Types.Asset memory ercAsset = Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) });
@@ -383,7 +355,7 @@ contract ServiceFeeDistributorTest is BaseTest {
     }
 
     function test_EdgeCase_ClaimTwice_SecondClaimReturnsZero() public {
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
 
@@ -399,7 +371,7 @@ contract ServiceFeeDistributorTest is BaseTest {
     }
 
     function test_EdgeCase_ClaimAfterUndelegation_GetsPreviousRewards() public {
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
 
@@ -416,8 +388,8 @@ contract ServiceFeeDistributorTest is BaseTest {
 
     function test_EdgeCase_MultipleServicesAccumulate() public {
         // Create two services with same operator
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
 
@@ -441,7 +413,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         // ERC20: 10 tokens * $1 = $10
         // Native should get ~99.95% of rewards
 
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
         Types.Asset memory ercAsset = Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) });
@@ -466,12 +438,12 @@ contract ServiceFeeDistributorTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -486,7 +458,7 @@ contract ServiceFeeDistributorTest is BaseTest {
 
         // Commit 100% native, 0% ERC20
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](2);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
         commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 0 });
 
         vm.prank(operator1);
@@ -504,7 +476,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -518,7 +490,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.stopPrank();
 
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](1);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
 
         vm.prank(operator1);
         tangle.approveServiceWithCommitments(requestId, commits);
@@ -535,7 +507,7 @@ contract ServiceFeeDistributorTest is BaseTest {
     }
 
     function test_View_PendingRewards_MatchesActualClaim() public {
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         Types.Asset memory nativeAsset = Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
 
@@ -552,7 +524,7 @@ contract ServiceFeeDistributorTest is BaseTest {
     }
 
     function test_View_DelegatorOperators_TracksPositions() public {
-        _requestAndApproveWithCommitments(10000, 10000, address(payTokenA), 100 ether);
+        _requestAndApproveWithCommitments(10_000, 10_000, address(payTokenA), 100 ether);
 
         // Check delegator1 has operator1 tracked
         address[] memory ops = distributor.delegatorOperators(delegator1);
@@ -568,7 +540,7 @@ contract ServiceFeeDistributorTest is BaseTest {
 
         // Enable TNT as a staking asset
         vm.prank(admin);
-        staking.enableAsset(address(tntToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        staking.enableAsset(address(tntToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
 
         // Set TNT score rate: 1 TNT = $1 score (10x boost vs market price)
         vm.prank(admin);
@@ -585,11 +557,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(delegator3);
         tntToken.approve(address(staking), 10 ether);
         staking.depositAndDelegateWithOptions(
-            operator1,
-            address(tntToken),
-            10 ether,
-            Types.BlueprintSelectionMode.All,
-            new uint64[](0)
+            operator1, address(tntToken), 10 ether, Types.BlueprintSelectionMode.All, new uint64[](0)
         );
         vm.stopPrank();
 
@@ -598,17 +566,17 @@ contract ServiceFeeDistributorTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[2] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(tntToken) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -624,9 +592,9 @@ contract ServiceFeeDistributorTest is BaseTest {
 
         // Commit 100% exposure on all assets
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](3);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
-        commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 10000 });
-        commits[2] = Types.AssetSecurityCommitment({ asset: reqs[2].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
+        commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 10_000 });
+        commits[2] = Types.AssetSecurityCommitment({ asset: reqs[2].asset, exposureBps: 10_000 });
 
         vm.prank(operator1);
         tangle.approveServiceWithCommitments(requestId, commits);
@@ -657,7 +625,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         oracle.setPrice(address(tntToken), 0.1e18); // TNT = $0.10
 
         vm.prank(admin);
-        staking.enableAsset(address(tntToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        staking.enableAsset(address(tntToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
 
         // First set TNT score rate, then disable it
         vm.startPrank(admin);

--- a/test/rewards/ServiceFeeDistributorStreaming.t.sol
+++ b/test/rewards/ServiceFeeDistributorStreaming.t.sol
@@ -37,7 +37,9 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         ServiceFeeDistributor impl = new ServiceFeeDistributor();
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(impl),
-            abi.encodeCall(ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(oracle)))
+            abi.encodeCall(
+                ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(oracle))
+            )
         );
         distributor = ServiceFeeDistributor(payable(address(proxy)));
 
@@ -55,7 +57,7 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         tangle.setServiceFeeDistributor(address(distributor));
         tangle.setPriceOracle(address(oracle));
         staking.setServiceFeeDistributor(address(distributor));
-        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
         vm.stopPrank();
 
         // Create blueprint with TTL pricing
@@ -79,7 +81,7 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         vm.prank(delegator1);
         staking.depositAndDelegate{ value: 10 ether }(operator1);
 
-        payToken.mint(user1, 1_000 ether);
+        payToken.mint(user1, 1000 ether);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -91,9 +93,13 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
 
         // Verify stream was created
         (
-            uint64 svcId, , address op, address token,
-            uint256 totalAmount, uint256 distributed,
-            uint64 startTime, uint64 endTime,
+            uint64 svcId,,
+            address op,
+            address token,
+            uint256 totalAmount,
+            uint256 distributed,
+            uint64 startTime,
+            uint64 endTime,
         ) = streamingManager.getStreamingPayment(serviceId, operator1);
 
         assertEq(svcId, serviceId);
@@ -538,7 +544,7 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
     }
 
@@ -546,8 +552,7 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
     function _nativeCommitments() internal pure returns (Types.AssetSecurityCommitment[] memory commits) {
         commits = new Types.AssetSecurityCommitment[](1);
         commits[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: 10000
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: 10_000
         });
     }
 

--- a/test/scenario/FullStackScenario.t.sol
+++ b/test/scenario/FullStackScenario.t.sol
@@ -58,7 +58,7 @@ contract FullStackScenarioTest is DelegationTestHarness {
 
             skip(STEP_SECONDS);
             // Try to advance round - will silently fail if too soon (rate limited)
-            try delegation.advanceRound() {} catch {}
+            try delegation.advanceRound() { } catch { }
         }
 
         // Make rounds ready for earlier withdrawals/unstakes.

--- a/test/scripts/DeploymentScriptsTest.t.sol
+++ b/test/scripts/DeploymentScriptsTest.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 
-import {DeployV2} from "../../script/Deploy.s.sol";
-import {DeployBeaconSlashingL1} from "../../script/DeployBeaconSlashing.s.sol";
-import {DeployL2Slashing} from "../../script/DeployL2Slashing.s.sol";
-import {LocalTestnetSetup} from "../../script/LocalTestnet.s.sol";
-import {L2SlashingReceiver} from "../../src/beacon/L2SlashingReceiver.sol";
-import {TangleL2Slasher} from "../../src/beacon/TangleL2Slasher.sol";
-import {HyperlaneReceiver} from "../../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
-import {LayerZeroReceiver} from "../../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
+import { DeployV2 } from "../../script/Deploy.s.sol";
+import { DeployBeaconSlashingL1 } from "../../script/DeployBeaconSlashing.s.sol";
+import { DeployL2Slashing } from "../../script/DeployL2Slashing.s.sol";
+import { LocalTestnetSetup } from "../../script/LocalTestnet.s.sol";
+import { L2SlashingReceiver } from "../../src/beacon/L2SlashingReceiver.sol";
+import { TangleL2Slasher } from "../../src/beacon/TangleL2Slasher.sol";
+import { HyperlaneReceiver } from "../../src/beacon/bridges/HyperlaneCrossChainMessenger.sol";
+import { LayerZeroReceiver } from "../../src/beacon/bridges/LayerZeroCrossChainMessenger.sol";
 import { IStaking } from "../../src/interfaces/IStaking.sol";
 import { Types } from "../../src/libraries/Types.sol";
 import { MultiAssetDelegation } from "../../src/staking/MultiAssetDelegation.sol";
@@ -74,7 +74,11 @@ contract MockStaking is IStaking {
         uint64,
         uint16 slashBps,
         bytes32 evidence
-    ) external override returns (uint256) {
+    )
+        external
+        override
+        returns (uint256)
+    {
         emit OperatorSlashed(operator, 0, slashBps, evidence);
         return slashBps;
     }
@@ -86,17 +90,16 @@ contract MockStaking is IStaking {
         Types.AssetSecurityCommitment[] calldata,
         uint16 slashBps,
         bytes32 evidence
-    ) external override returns (uint256) {
+    )
+        external
+        override
+        returns (uint256)
+    {
         emit OperatorSlashed(operator, 0, slashBps, evidence);
         return slashBps;
     }
 
-    function slash(
-        address operator,
-        uint64,
-        uint16 slashBps,
-        bytes32 evidence
-    ) external override returns (uint256) {
+    function slash(address operator, uint64, uint16 slashBps, bytes32 evidence) external override returns (uint256) {
         emit OperatorSlashed(operator, 0, slashBps, evidence);
         return slashBps;
     }
@@ -105,27 +108,27 @@ contract MockStaking is IStaking {
         return true;
     }
 
-    function addBlueprintForOperator(address, uint64) external override {}
-    function removeBlueprintForOperator(address, uint64) external override {}
+    function addBlueprintForOperator(address, uint64) external override { }
+    function removeBlueprintForOperator(address, uint64) external override { }
 
     // M-9 FIX: Pending slash tracking (no-op for mock)
-    function incrementPendingSlash(address) external override {}
-    function decrementPendingSlash(address) external override {}
-    function getPendingSlashCount(address) external pure override returns (uint64) { return 0; }
+    function incrementPendingSlash(address) external override { }
+    function decrementPendingSlash(address) external override { }
+
+    function getPendingSlashCount(address) external pure override returns (uint64) {
+        return 0;
+    }
 }
 
 contract DeployV2Harness is DeployV2 {
-    function deployCoreNoPrank(address admin, address treasury)
+    function deployCoreNoPrank(
+        address admin,
+        address treasury
+    )
         external
         returns (address stakingProxy, address tangleProxy, address statusRegistry)
     {
-        (
-            stakingProxy,
-            ,
-            tangleProxy,
-            ,
-            statusRegistry
-        ) = _deployCore(0, admin, admin, treasury, false);
+        (stakingProxy,, tangleProxy,, statusRegistry) = _deployCore(0, admin, admin, treasury, false);
     }
 }
 
@@ -141,18 +144,8 @@ contract DeployBeaconSlashingHarness is DeployBeaconSlashingL1 {
         external
         returns (address podManager, address connector, address messenger)
     {
-        (, podManager, connector, messenger) = _deploy(
-            bridge,
-            0,
-            admin,
-            admin,
-            oracle,
-            tangleChainId,
-            l2Receiver,
-            beaconOracle,
-            true,
-            false
-        );
+        (, podManager, connector, messenger) =
+            _deploy(bridge, 0, admin, admin, oracle, tangleChainId, l2Receiver, beaconOracle, true, false);
     }
 }
 
@@ -192,13 +185,12 @@ contract DeploymentScriptsTest is Test {
     function testDeployV2ScriptRuns() public {
         uint256 privateKey = 0xA11CE;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
         DeployV2Harness script = new DeployV2Harness();
         address admin = deployer;
         address treasury = deployer;
 
-        (address stakingProxy, address tangleProxy, address statusRegistry) =
-            script.deployCoreNoPrank(admin, treasury);
+        (address stakingProxy, address tangleProxy, address statusRegistry) = script.deployCoreNoPrank(admin, treasury);
 
         assertTrue(stakingProxy != address(0), "restaking proxy");
         assertTrue(tangleProxy != address(0), "tangle proxy");
@@ -223,7 +215,7 @@ contract DeploymentScriptsTest is Test {
 
         uint256 privateKey = 0xB0B;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
 
         address admin = deployer;
         address oracle = makeAddr("oracle");
@@ -231,12 +223,7 @@ contract DeploymentScriptsTest is Test {
 
         DeployBeaconSlashingHarness script = new DeployBeaconSlashingHarness();
         (address podManager, address connector, address messenger) = script.deployNoPrank(
-            DeployBeaconSlashingL1.BridgeProtocol.Hyperlane,
-            admin,
-            oracle,
-            3799,
-            receiver,
-            address(0)
+            DeployBeaconSlashingL1.BridgeProtocol.Hyperlane, admin, oracle, 3799, receiver, address(0)
         );
 
         assertTrue(podManager != address(0), "pod manager deployed");
@@ -248,7 +235,7 @@ contract DeploymentScriptsTest is Test {
 
     function testDeployBeaconSlashingScriptRunsLayerZero() public {
         uint256 originalChainId = block.chainid;
-        vm.chainId(11155111); // Sepolia supported by both messengers
+        vm.chainId(11_155_111); // Sepolia supported by both messengers
 
         // Etch dummy code at Sepolia LayerZero endpoint so _verifyBridgeContract passes
         address layerZeroEndpoint = 0x6EDCE65403992e310A62460808c4b910D972f10f;
@@ -256,7 +243,7 @@ contract DeploymentScriptsTest is Test {
 
         uint256 privateKey = 0xCAFE;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
 
         address admin = deployer;
         address oracle = makeAddr("oracle2");
@@ -264,12 +251,7 @@ contract DeploymentScriptsTest is Test {
 
         DeployBeaconSlashingHarness script = new DeployBeaconSlashingHarness();
         (address podManager, address connector, address messenger) = script.deployNoPrank(
-            DeployBeaconSlashingL1.BridgeProtocol.LayerZero,
-            admin,
-            oracle,
-            3799,
-            receiver,
-            address(0)
+            DeployBeaconSlashingL1.BridgeProtocol.LayerZero, admin, oracle, 3799, receiver, address(0)
         );
 
         assertTrue(podManager != address(0), "pod manager deployed");
@@ -282,7 +264,7 @@ contract DeploymentScriptsTest is Test {
     function testDeployL2SlashingScriptRunsDirectMessenger() public {
         uint256 privateKey = 0xC0FFEE;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
 
         MockStaking staking = new MockStaking();
         staking.setStake(makeAddr("operator"), 32 ether);
@@ -292,12 +274,7 @@ contract DeploymentScriptsTest is Test {
         address messenger = makeAddr("messenger");
 
         (address slasher, address receiver) = script.deployNoPrank(
-            DeployL2Slashing.BridgeProtocol.DirectMessenger,
-            admin,
-            address(staking),
-            11155111,
-            address(0),
-            messenger
+            DeployL2Slashing.BridgeProtocol.DirectMessenger, admin, address(staking), 11_155_111, address(0), messenger
         );
 
         assertTrue(slasher != address(0), "slasher deployed");
@@ -310,7 +287,7 @@ contract DeploymentScriptsTest is Test {
     function testDeployL2SlashingScriptRunsHyperlane() public {
         uint256 privateKey = 0xDAD;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
 
         MockStaking staking = new MockStaking();
         staking.setStake(makeAddr("operator"), 32 ether);
@@ -326,12 +303,7 @@ contract DeploymentScriptsTest is Test {
         address l1Connector = makeAddr("l1Connector");
 
         (address slasher, address receiver) = script.deployNoPrank(
-            DeployL2Slashing.BridgeProtocol.Hyperlane,
-            admin,
-            address(staking),
-            1,
-            l1Connector,
-            address(0)
+            DeployL2Slashing.BridgeProtocol.Hyperlane, admin, address(staking), 1, l1Connector, address(0)
         );
 
         assertTrue(slasher != address(0), "slasher deployed");
@@ -344,7 +316,7 @@ contract DeploymentScriptsTest is Test {
     function testDeployL2SlashingScriptRunsLayerZero() public {
         uint256 privateKey = 0xDAD1;
         address deployer = vm.addr(privateKey);
-        vm.deal(deployer, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
 
         MockStaking staking = new MockStaking();
         staking.setStake(makeAddr("operator"), 32 ether);
@@ -355,19 +327,14 @@ contract DeploymentScriptsTest is Test {
         vm.setEnv("LAYERZERO_ENDPOINT", vm.toString(endpoint));
         vm.setEnv("L1_MESSENGER", vm.toString(makeAddr("layerzeroL1Messenger")));
         // Provide the source EID explicitly for the harness (chainId 1 => 30101).
-        vm.setEnv("LAYERZERO_SOURCE_EID", vm.toString(uint256(30101)));
+        vm.setEnv("LAYERZERO_SOURCE_EID", vm.toString(uint256(30_101)));
 
         DeployL2SlashingHarness script = new DeployL2SlashingHarness();
         address admin = deployer;
         address l1Connector = makeAddr("l1ConnectorLZ");
 
         (address slasher, address receiver) = script.deployNoPrank(
-            DeployL2Slashing.BridgeProtocol.LayerZero,
-            admin,
-            address(staking),
-            1,
-            l1Connector,
-            address(0)
+            DeployL2Slashing.BridgeProtocol.LayerZero, admin, address(staking), 1, l1Connector, address(0)
         );
 
         assertTrue(slasher != address(0), "slasher deployed");
@@ -385,10 +352,10 @@ contract DeploymentScriptsTest is Test {
         address operator2 = vm.addr(LOCAL_OPERATOR2_KEY);
         address delegator = vm.addr(LOCAL_DELEGATOR_KEY);
 
-        vm.deal(deployer, 1_000 ether);
-        vm.deal(operator1, 1_000 ether);
-        vm.deal(operator2, 1_000 ether);
-        vm.deal(delegator, 1_000 ether);
+        vm.deal(deployer, 1000 ether);
+        vm.deal(operator1, 1000 ether);
+        vm.deal(operator2, 1000 ether);
+        vm.deal(delegator, 1000 ether);
 
         uint64 serviceId = script.dryRun();
         assertEq(serviceId, script.requestId(), "service/request");

--- a/test/staking/AssetAdapterTest.t.sol
+++ b/test/staking/AssetAdapterTest.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {console2} from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/Test.sol";
 
-import {IAssetAdapter} from "../../src/staking/adapters/IAssetAdapter.sol";
-import {StandardAssetAdapter} from "../../src/staking/adapters/StandardAssetAdapter.sol";
-import {RebasingAssetAdapter} from "../../src/staking/adapters/RebasingAssetAdapter.sol";
-import {AssetAdapterFactory} from "../../src/staking/adapters/AssetAdapterFactory.sol";
+import { IAssetAdapter } from "../../src/staking/adapters/IAssetAdapter.sol";
+import { StandardAssetAdapter } from "../../src/staking/adapters/StandardAssetAdapter.sol";
+import { RebasingAssetAdapter } from "../../src/staking/adapters/RebasingAssetAdapter.sol";
+import { AssetAdapterFactory } from "../../src/staking/adapters/AssetAdapterFactory.sol";
 
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @title MockERC20
 /// @notice Standard ERC20 for testing
 contract MockERC20 is ERC20 {
-    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -27,7 +27,7 @@ contract MockERC20 is ERC20 {
 contract MockRebasingToken is ERC20 {
     uint256 public rebaseMultiplier = 1e18; // 1:1 initially
 
-    constructor() ERC20("Mock stETH", "mstETH") {}
+    constructor() ERC20("Mock stETH", "mstETH") { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -36,7 +36,7 @@ contract MockRebasingToken is ERC20 {
     /// @notice Simulate a rebase (increase all balances by percentage)
     /// @param bps Basis points to increase (100 = 1%)
     function rebase(uint256 bps) external {
-        rebaseMultiplier = (rebaseMultiplier * (10000 + bps)) / 10000;
+        rebaseMultiplier = (rebaseMultiplier * (10_000 + bps)) / 10_000;
     }
 
     /// @notice Override balanceOf to simulate rebasing
@@ -447,7 +447,7 @@ contract AssetAdapterTest is Test {
 
         rebasingToken.rebase(rebaseBps);
 
-        uint256 expectedValue = (amount * (10000 + rebaseBps)) / 10000;
+        uint256 expectedValue = (amount * (10_000 + rebaseBps)) / 10_000;
 
         vm.prank(delegationManager);
         uint256 withdrawn = rebasingAdapter.withdraw(user2, shares);

--- a/test/staking/BlueprintSelectionTest.t.sol
+++ b/test/staking/BlueprintSelectionTest.t.sol
@@ -34,9 +34,11 @@ contract BlueprintSelectionTest is DelegationTestHarness {
         address operator,
         uint256 amount,
         uint64[] memory blueprintIds
-    ) internal {
+    )
+        internal
+    {
         vm.prank(delegator);
-        delegation.depositAndDelegateWithOptions{value: amount}(
+        delegation.depositAndDelegateWithOptions{ value: amount }(
             operator,
             address(0), // native
             amount,
@@ -46,13 +48,9 @@ contract BlueprintSelectionTest is DelegationTestHarness {
     }
 
     /// @notice Deposit and delegate with All mode
-    function _depositAndDelegateAll(
-        address delegator,
-        address operator,
-        uint256 amount
-    ) internal {
+    function _depositAndDelegateAll(address delegator, address operator, uint256 amount) internal {
         vm.prank(delegator);
-        delegation.depositAndDelegateWithOptions{value: amount}(
+        delegation.depositAndDelegateWithOptions{ value: amount }(
             operator,
             address(0), // native
             amount,
@@ -86,7 +84,7 @@ contract BlueprintSelectionTest is DelegationTestHarness {
 
         vm.prank(delegator1);
         vm.expectRevert(DelegationErrors.AllModeDisallowsBlueprints.selector);
-        delegation.depositAndDelegateWithOptions{value: 5 ether}(
+        delegation.depositAndDelegateWithOptions{ value: 5 ether }(
             operator1,
             address(0), // native
             5 ether,
@@ -111,7 +109,7 @@ contract BlueprintSelectionTest is DelegationTestHarness {
     function test_FixedModeRequiresNonEmptyBlueprintList() public {
         vm.prank(delegator1);
         vm.expectRevert(DelegationErrors.FixedModeRequiresBlueprints.selector);
-        delegation.depositAndDelegateWithOptions{value: 5 ether}(
+        delegation.depositAndDelegateWithOptions{ value: 5 ether }(
             operator1,
             address(0), // native
             5 ether,
@@ -127,7 +125,7 @@ contract BlueprintSelectionTest is DelegationTestHarness {
 
         vm.prank(delegator1);
         vm.expectRevert(abi.encodeWithSelector(DelegationErrors.DuplicateBlueprint.selector, BLUEPRINT_1));
-        delegation.depositAndDelegateWithOptions{value: 5 ether}(
+        delegation.depositAndDelegateWithOptions{ value: 5 ether }(
             operator1,
             address(0), // native
             5 ether,
@@ -183,7 +181,9 @@ contract BlueprintSelectionTest is DelegationTestHarness {
 
         // Fixed mode delegator should NOT be slashed (didn't select blueprint 2)
         uint256 delegationAfter = delegation.getDelegation(delegator1, operator1);
-        assertEq(delegationAfter, delegationBefore, "Fixed mode delegator should not be slashed for unselected blueprint");
+        assertEq(
+            delegationAfter, delegationBefore, "Fixed mode delegator should not be slashed for unselected blueprint"
+        );
     }
 
     /// @notice Test that Fixed mode delegators ARE slashed for their selected blueprints
@@ -365,12 +365,8 @@ contract BlueprintSelectionTest is DelegationTestHarness {
         uint64[] memory bp2 = new uint64[](1);
         bp2[0] = BLUEPRINT_2;
         vm.prank(delegator1);
-        delegation.depositAndDelegateWithOptions{value: 5 ether}(
-            operator2,
-            address(0),
-            5 ether,
-            Types.BlueprintSelectionMode.Fixed,
-            bp2
+        delegation.depositAndDelegateWithOptions{ value: 5 ether }(
+            operator2, address(0), 5 ether, Types.BlueprintSelectionMode.Fixed, bp2
         );
 
         // Slash operator1 for blueprint 1 - should affect first delegation

--- a/test/staking/DelegationFlowsTest.t.sol
+++ b/test/staking/DelegationFlowsTest.t.sol
@@ -19,7 +19,8 @@ import { StakingAdminFacet } from "../../src/facets/staking/StakingAdminFacet.so
 
 /// @notice Mock ERC20 for testing
 contract MockToken is ERC20 {
-    constructor() ERC20("Mock", "MCK") {}
+    constructor() ERC20("Mock", "MCK") { }
+
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
@@ -42,10 +43,7 @@ contract DelegationFlowsTest is Test {
     function setUp() public {
         // Deploy
         MultiAssetDelegation impl = new MultiAssetDelegation();
-        bytes memory initData = abi.encodeCall(
-            MultiAssetDelegation.initialize,
-            (admin, MIN_OPERATOR_STAKE, 0, 1000)
-        );
+        bytes memory initData = abi.encodeCall(MultiAssetDelegation.initialize, (admin, MIN_OPERATOR_STAKE, 0, 1000));
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         delegation = IMultiAssetDelegation(payable(address(proxy)));
 
@@ -54,7 +52,7 @@ contract DelegationFlowsTest is Test {
         // Deploy mock token and enable it
         token = new MockToken();
         vm.prank(admin);
-        delegation.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10000);
+        delegation.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10_000);
 
         // Fund accounts
         vm.deal(operator1, 100 ether);
@@ -138,11 +136,7 @@ contract DelegationFlowsTest is Test {
         vm.startPrank(delegator1);
         token.approve(address(delegation), 5 ether);
         delegation.depositAndDelegateWithOptions(
-            operator1,
-            address(token),
-            5 ether,
-            Types.BlueprintSelectionMode.All,
-            new uint64[](0)
+            operator1, address(token), 5 ether, Types.BlueprintSelectionMode.All, new uint64[](0)
         );
         vm.stopPrank();
 
@@ -333,9 +327,7 @@ contract DelegationFlowsTest is Test {
         delegation.deposit{ value: 1 ether }();
 
         vm.prank(delegator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.InsufficientDeposit.selector, 1 ether, 5 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.InsufficientDeposit.selector, 1 ether, 5 ether));
         delegation.delegate(operator1, 5 ether);
     }
 
@@ -344,9 +336,7 @@ contract DelegationFlowsTest is Test {
         delegation.depositAndDelegate{ value: 5 ether }(operator1);
 
         vm.prank(delegator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.InsufficientDelegation.selector, 5 ether, 10 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.InsufficientDelegation.selector, 5 ether, 10 ether));
         delegation.scheduleDelegatorUnstake(operator1, address(0), 10 ether);
     }
 
@@ -359,9 +349,7 @@ contract DelegationFlowsTest is Test {
         // free = deposit - locked = 5 - 0 = 5
         // 5 < 10 → reverts with AmountLocked
         // TODO: Consider changing to InsufficientAvailableBalance for clarity
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.AmountLocked.selector, 0, 10 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.AmountLocked.selector, 0, 10 ether));
         delegation.scheduleWithdraw(address(0), 10 ether);
         vm.stopPrank();
     }
@@ -372,9 +360,7 @@ contract DelegationFlowsTest is Test {
 
         // Can't withdraw delegated funds
         vm.prank(delegator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.InsufficientAvailableBalance.selector, 0, 5 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.InsufficientAvailableBalance.selector, 0, 5 ether));
         delegation.scheduleWithdraw(address(0), 5 ether);
     }
 
@@ -386,9 +372,7 @@ contract DelegationFlowsTest is Test {
 
         // Cannot delegate to unregistered operator
         vm.prank(delegator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.OperatorNotRegistered.selector, unregisteredOp)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.OperatorNotRegistered.selector, unregisteredOp));
         delegation.delegate(unregisteredOp, 5 ether);
     }
 
@@ -411,9 +395,7 @@ contract DelegationFlowsTest is Test {
 
         // Never delegated to operator1
         vm.prank(delegator1);
-        vm.expectRevert(
-            abi.encodeWithSelector(DelegationErrors.DelegationNotFound.selector, delegator1, operator1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(DelegationErrors.DelegationNotFound.selector, delegator1, operator1));
         delegation.scheduleDelegatorUnstake(operator1, address(0), 1 ether);
     }
 

--- a/test/staking/DelegationTestHarness.sol
+++ b/test/staking/DelegationTestHarness.sol
@@ -22,7 +22,7 @@ import { StakingAdminFacet } from "../../src/facets/staking/StakingAdminFacet.so
 
 /// @notice Standard Mock ERC20 for testing
 contract MockERC20 is ERC20 {
-    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -40,7 +40,7 @@ contract ReentrantERC20 is ERC20 {
     bool public attackExecuted;
     bytes public attackCalldata;
 
-    constructor() ERC20("ReentrantToken", "REENT") {}
+    constructor() ERC20("ReentrantToken", "REENT") { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -100,11 +100,11 @@ contract ReentrantReceiver {
 
     // Forward calls to target for testing
     function deposit() external payable {
-        target.deposit{value: msg.value}();
+        target.deposit{ value: msg.value }();
     }
 
     function depositAndDelegate(address operator) external payable {
-        target.depositAndDelegate{value: msg.value}(operator);
+        target.depositAndDelegate{ value: msg.value }(operator);
     }
 
     function scheduleWithdraw(address token, uint256 amount) external {
@@ -128,7 +128,7 @@ contract ReentrantReceiver {
 contract FailingERC20 is ERC20 {
     bool public shouldFail;
 
-    constructor() ERC20("FailingToken", "FAIL") {}
+    constructor() ERC20("FailingToken", "FAIL") { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -183,7 +183,7 @@ abstract contract DelegationTestHarness is Test {
 
     // Precision
     uint256 public constant PRECISION = 1e18;
-    uint256 public constant BPS_DENOMINATOR = 10000;
+    uint256 public constant BPS_DENOMINATOR = 10_000;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SETUP
@@ -211,10 +211,8 @@ abstract contract DelegationTestHarness is Test {
     function _deployContracts() internal {
         // Deploy delegation contract
         MultiAssetDelegation impl = new MultiAssetDelegation();
-        bytes memory initData = abi.encodeCall(
-            MultiAssetDelegation.initialize,
-            (admin, MIN_OPERATOR_STAKE, 0, OPERATOR_COMMISSION_BPS)
-        );
+        bytes memory initData =
+            abi.encodeCall(MultiAssetDelegation.initialize, (admin, MIN_OPERATOR_STAKE, 0, OPERATOR_COMMISSION_BPS));
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         delegation = IMultiAssetDelegation(payable(address(proxy)));
 
@@ -228,8 +226,8 @@ abstract contract DelegationTestHarness is Test {
     function _configureAssets() internal {
         vm.startPrank(admin);
         // Enable ERC20 tokens
-        delegation.enableAsset(address(token), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
-        delegation.enableAsset(address(token2), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        delegation.enableAsset(address(token), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
+        delegation.enableAsset(address(token2), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
         // Add slasher role
         delegation.addSlasher(slasher);
         // Add tangle role for blueprint management
@@ -272,7 +270,7 @@ abstract contract DelegationTestHarness is Test {
 
     function _registerDefaultOperator() internal {
         vm.prank(operator1);
-        delegation.registerOperator{value: 10 ether}();
+        delegation.registerOperator{ value: 10 ether }();
         vm.prank(operator1);
         delegation.setDelegationMode(Types.DelegationMode.Open);
     }
@@ -284,7 +282,7 @@ abstract contract DelegationTestHarness is Test {
     /// @notice Register an operator with specified stake
     function _registerOperator(address operator, uint256 stake) internal {
         vm.prank(operator);
-        delegation.registerOperator{value: stake}();
+        delegation.registerOperator{ value: stake }();
         vm.prank(operator);
         delegation.setDelegationMode(Types.DelegationMode.Open);
     }
@@ -292,24 +290,15 @@ abstract contract DelegationTestHarness is Test {
     /// @notice Deposit and delegate native ETH
     function _depositAndDelegate(address delegator, address operator, uint256 amount) internal {
         vm.prank(delegator);
-        delegation.depositAndDelegate{value: amount}(operator);
+        delegation.depositAndDelegate{ value: amount }(operator);
     }
 
     /// @notice Deposit and delegate ERC20
-    function _depositAndDelegateErc20(
-        address delegator,
-        address operator,
-        address tokenAddr,
-        uint256 amount
-    ) internal {
+    function _depositAndDelegateErc20(address delegator, address operator, address tokenAddr, uint256 amount) internal {
         vm.startPrank(delegator);
         ERC20(tokenAddr).approve(address(delegation), amount);
         delegation.depositAndDelegateWithOptions(
-            operator,
-            tokenAddr,
-            amount,
-            Types.BlueprintSelectionMode.All,
-            new uint64[](0)
+            operator, tokenAddr, amount, Types.BlueprintSelectionMode.All, new uint64[](0)
         );
         vm.stopPrank();
     }
@@ -317,13 +306,13 @@ abstract contract DelegationTestHarness is Test {
     /// @notice Deposit native ETH only (no delegation)
     function _depositNative(address delegator, uint256 amount) internal {
         vm.prank(delegator);
-        delegation.deposit{value: amount}();
+        delegation.deposit{ value: amount }();
     }
 
     /// @notice Deposit native ETH with lock
     function _depositNativeWithLock(address delegator, uint256 amount, Types.LockMultiplier lock) internal {
         vm.prank(delegator);
-        delegation.depositWithLock{value: amount}(lock);
+        delegation.depositWithLock{ value: amount }(lock);
     }
 
     /// @notice Deposit ERC20 only (no delegation)
@@ -421,7 +410,11 @@ abstract contract DelegationTestHarness is Test {
         uint256 slashAmount,
         uint256 operatorStake,
         uint256 delegatedStake
-    ) internal pure returns (uint256 operatorSlash, uint256 delegatorSlash) {
+    )
+        internal
+        pure
+        returns (uint256 operatorSlash, uint256 delegatorSlash)
+    {
         uint256 totalStake = operatorStake + delegatedStake;
         if (totalStake == 0) return (0, 0);
         operatorSlash = (slashAmount * operatorStake) / totalStake;
@@ -439,7 +432,15 @@ abstract contract DelegationTestHarness is Test {
     }
 
     /// @notice Assert delegation is approximately equal (within 1 wei for rounding)
-    function assertDelegationApproxEq(address delegator, address operator, uint256 expected, uint256 tolerance) internal view {
+    function assertDelegationApproxEq(
+        address delegator,
+        address operator,
+        uint256 expected,
+        uint256 tolerance
+    )
+        internal
+        view
+    {
         uint256 actual = _getDelegation(delegator, operator);
         assertApproxEqAbs(actual, expected, tolerance, "Delegation approx mismatch");
     }

--- a/test/staking/LiquidDelegationTest.t.sol
+++ b/test/staking/LiquidDelegationTest.t.sol
@@ -20,7 +20,7 @@ import { StakingAdminFacet } from "../../src/facets/staking/StakingAdminFacet.so
 
 /// @notice Mock ERC20 token for testing
 contract MockERC20 is ERC20 {
-    constructor() ERC20("Mock Token", "MOCK") {}
+    constructor() ERC20("Mock Token", "MOCK") { }
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -72,7 +72,7 @@ contract LiquidDelegationTest is Test {
 
         // Enable mock token as asset
         vm.prank(admin);
-        staking.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10000);
+        staking.enableAsset(address(token), 1 ether, 0.1 ether, 0, 10_000);
 
         // Deploy factory
         factory = new LiquidDelegationFactory(staking);
@@ -133,11 +133,7 @@ contract LiquidDelegationTest is Test {
         vault.deposit(10 ether, user1);
         vm.stopPrank();
 
-        assertEq(
-            uint8(vault.selectionMode()),
-            uint8(Types.BlueprintSelectionMode.All),
-            "Vault should be All mode"
-        );
+        assertEq(uint8(vault.selectionMode()), uint8(Types.BlueprintSelectionMode.All), "Vault should be All mode");
         assertEq(vault.blueprintIds().length, 0, "All mode: no stored blueprint IDs");
 
         Types.BondInfoDelegator[] memory delegations = staking.getDelegations(vaultAddr);

--- a/test/staking/OperatorStatusRegistry.t.sol
+++ b/test/staking/OperatorStatusRegistry.t.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test, Vm} from "forge-std/Test.sol";
+import { Test, Vm } from "forge-std/Test.sol";
 
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-import {OperatorStatusRegistry, IOperatorStatusRegistry} from "../../src/staking/OperatorStatusRegistry.sol";
-import {IMetricsRecorder} from "../../src/interfaces/IMetricsRecorder.sol";
+import { OperatorStatusRegistry, IOperatorStatusRegistry } from "../../src/staking/OperatorStatusRegistry.sol";
+import { IMetricsRecorder } from "../../src/interfaces/IMetricsRecorder.sol";
 
 contract MockMetricsRecorder is IMetricsRecorder {
     uint256 public heartbeatCount;
     address public lastOperator;
     uint64 public lastServiceId;
 
-    function recordStake(address, address, address, uint256) external {}
-    function recordUnstake(address, address, address, uint256) external {}
-    function recordOperatorRegistered(address, address, uint256) external {}
+    function recordStake(address, address, address, uint256) external { }
+    function recordUnstake(address, address, address, uint256) external { }
+    function recordOperatorRegistered(address, address, uint256) external { }
 
     function recordHeartbeat(address operator, uint64 serviceId, uint64) external override {
         heartbeatCount++;
@@ -23,14 +23,14 @@ contract MockMetricsRecorder is IMetricsRecorder {
         lastServiceId = serviceId;
     }
 
-    function recordJobCompletion(address, uint64, uint64, bool) external {}
-    function recordSlash(address, uint64, uint256) external {}
-    function recordServiceCreated(uint64, uint64, address, uint256) external {}
-    function recordServiceTerminated(uint64, uint256) external {}
-    function recordJobCall(uint64, address, uint64) external {}
-    function recordPayment(address, uint64, address, uint256) external {}
-    function recordBlueprintCreated(uint64, address) external {}
-    function recordBlueprintRegistration(uint64, address) external {}
+    function recordJobCompletion(address, uint64, uint64, bool) external { }
+    function recordSlash(address, uint64, uint256) external { }
+    function recordServiceCreated(uint64, uint64, address, uint256) external { }
+    function recordServiceTerminated(uint64, uint256) external { }
+    function recordJobCall(uint64, address, uint64) external { }
+    function recordPayment(address, uint64, address, uint256) external { }
+    function recordBlueprintCreated(uint64, address) external { }
+    function recordBlueprintRegistration(uint64, address) external { }
 }
 
 contract OperatorStatusRegistryTest is Test {
@@ -71,9 +71,7 @@ contract OperatorStatusRegistryTest is Test {
 
     function _signHeartbeat(uint8 statusCode, bytes memory metricsData) internal view returns (bytes memory) {
         bytes32 messageHash = keccak256(abi.encodePacked(SERVICE_ID, BLUEPRINT_ID, statusCode, metricsData));
-        bytes32 ethSignedHash = keccak256(
-            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
-        );
+        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorKey, ethSignedHash);
         return abi.encodePacked(r, s, v);
     }
@@ -85,8 +83,7 @@ contract OperatorStatusRegistryTest is Test {
         vm.prank(operatorAddr);
         registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, metricsData, signature);
 
-        IOperatorStatusRegistry.StatusCode status =
-            registry.getOperatorStatus(SERVICE_ID, operatorAddr);
+        IOperatorStatusRegistry.StatusCode status = registry.getOperatorStatus(SERVICE_ID, operatorAddr);
         assertEq(uint8(status), uint8(IOperatorStatusRegistry.StatusCode.Healthy));
         assertEq(registry.getLastHeartbeat(SERVICE_ID, operatorAddr), block.timestamp);
         assertTrue(registry.isHeartbeatCurrent(SERVICE_ID, operatorAddr));
@@ -121,8 +118,7 @@ contract OperatorStatusRegistryTest is Test {
         vm.warp(block.timestamp + 1 hours);
         registry.checkOperatorStatus(SERVICE_ID, operatorAddr);
 
-        IOperatorStatusRegistry.StatusCode status =
-            registry.getOperatorStatus(SERVICE_ID, operatorAddr);
+        IOperatorStatusRegistry.StatusCode status = registry.getOperatorStatus(SERVICE_ID, operatorAddr);
         assertEq(uint8(status), uint8(IOperatorStatusRegistry.StatusCode.Offline));
     }
 
@@ -130,8 +126,7 @@ contract OperatorStatusRegistryTest is Test {
         vm.startPrank(operatorAddr);
         registry.submitHeartbeatDirect(SERVICE_ID, BLUEPRINT_ID, 0, "");
         registry.goOffline(SERVICE_ID);
-        IOperatorStatusRegistry.StatusCode status =
-            registry.getOperatorStatus(SERVICE_ID, operatorAddr);
+        IOperatorStatusRegistry.StatusCode status = registry.getOperatorStatus(SERVICE_ID, operatorAddr);
         assertEq(uint8(status), uint8(IOperatorStatusRegistry.StatusCode.Exiting));
 
         registry.goOnline(SERVICE_ID);
@@ -189,8 +184,7 @@ contract OperatorStatusRegistryTest is Test {
         vm.prank(slashingOracle);
         registry.reportForSlashing(SERVICE_ID, operatorAddr, "misbehavior");
 
-        IOperatorStatusRegistry.StatusCode status =
-            registry.getOperatorStatus(SERVICE_ID, operatorAddr);
+        IOperatorStatusRegistry.StatusCode status = registry.getOperatorStatus(SERVICE_ID, operatorAddr);
         assertEq(uint8(status), uint8(IOperatorStatusRegistry.StatusCode.Slashed));
     }
 
@@ -437,7 +431,8 @@ contract OperatorStatusRegistryTest is Test {
 
         // Hex produced by Rust alloy-sol-types encoder for:
         //   [("response_time_ms", 150), ("uptime_percent", 99)]
-        bytes memory rustEncoded = hex"00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000960000000000000000000000000000000000000000000000000000000000000010726573706f6e73655f74696d655f6d730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000063000000000000000000000000000000000000000000000000000000000000000e757074696d655f70657263656e74000000000000000000000000000000000000";
+        bytes memory rustEncoded =
+            hex"00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000960000000000000000000000000000000000000000000000000000000000000010726573706f6e73655f74696d655f6d730000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000063000000000000000000000000000000000000000000000000000000000000000e757074696d655f70657263656e74000000000000000000000000000000000000";
 
         vm.prank(operatorAddr);
         registry.submitHeartbeatDirect(SERVICE_ID, BLUEPRINT_ID, 0, rustEncoded);
@@ -731,7 +726,7 @@ contract OperatorStatusRegistryTest is Test {
         vm.prank(operatorAddr);
         registry.submitHeartbeatDirect(SERVICE_ID, BLUEPRINT_ID, 0, "");
 
-        (uint64 interval, uint8 maxMissed, ) = registry.heartbeatConfigs(SERVICE_ID);
+        (uint64 interval, uint8 maxMissed,) = registry.heartbeatConfigs(SERVICE_ID);
         uint64 lowerBound = interval > 1 ? interval / 2 : 1;
         uint64 upperBound = interval * (uint64(maxMissed) + 5);
         warpSeconds = uint64(bound(warpSeconds, lowerBound, upperBound));
@@ -759,14 +754,20 @@ contract OperatorStatusRegistryTest is Test {
 
         vm.prank(slashingOracle);
         registry.reportForSlashing(SERVICE_ID, operatorAddr, "misbehavior");
-        assertEq(uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)), uint8(IOperatorStatusRegistry.StatusCode.Slashed));
+        assertEq(
+            uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)),
+            uint8(IOperatorStatusRegistry.StatusCode.Slashed)
+        );
 
         // Warp way past offline threshold
         vm.warp(block.timestamp + 10_000);
         registry.checkOperatorStatus(SERVICE_ID, operatorAddr);
 
         // Must still be Slashed, not Offline
-        assertEq(uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)), uint8(IOperatorStatusRegistry.StatusCode.Slashed));
+        assertEq(
+            uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)),
+            uint8(IOperatorStatusRegistry.StatusCode.Slashed)
+        );
     }
 
     /// @notice #2 High: Deregistered operators can still be slashed (prevents slash-immunity race)
@@ -786,7 +787,10 @@ contract OperatorStatusRegistryTest is Test {
         // Oracle can still slash — operator is in _allOperators
         vm.prank(slashingOracle);
         registry.reportForSlashing(SERVICE_ID, operatorAddr, "late slash");
-        assertEq(uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)), uint8(IOperatorStatusRegistry.StatusCode.Slashed));
+        assertEq(
+            uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)),
+            uint8(IOperatorStatusRegistry.StatusCode.Slashed)
+        );
     }
 
     /// @notice #3 High: Fail-closed validation — catch block must not store unvalidated metrics
@@ -814,7 +818,9 @@ contract OperatorStatusRegistryTest is Test {
     /// @notice #3 High: Metric name length cap
     function test_addMetricDefinition_NameTooLongReverts() public {
         bytes memory longName = new bytes(65);
-        for (uint256 i = 0; i < 65; i++) longName[i] = "a";
+        for (uint256 i = 0; i < 65; i++) {
+            longName[i] = "a";
+        }
 
         vm.prank(serviceOwner);
         vm.expectRevert("Name too long");
@@ -828,7 +834,9 @@ contract OperatorStatusRegistryTest is Test {
         registry.registerOperator(SERVICE_ID, newOp);
 
         // Should be Offline, not Healthy
-        assertEq(uint8(registry.getOperatorStatus(SERVICE_ID, newOp)), uint8(IOperatorStatusRegistry.StatusCode.Offline));
+        assertEq(
+            uint8(registry.getOperatorStatus(SERVICE_ID, newOp)), uint8(IOperatorStatusRegistry.StatusCode.Offline)
+        );
         // isOnline should return false
         assertFalse(registry.isOnline(SERVICE_ID, newOp));
     }
@@ -843,7 +851,8 @@ contract OperatorStatusRegistryTest is Test {
         address[] memory onlineBefore = registry.getOnlineOperators(SERVICE_ID);
         bool found = false;
         for (uint256 i = 0; i < onlineBefore.length; i++) {
-            if (onlineBefore[i] == newOp) { found = true; break; }
+            if (onlineBefore[i] == newOp) found = true;
+            break;
         }
         assertFalse(found, "Should not be online before heartbeat");
 
@@ -855,7 +864,8 @@ contract OperatorStatusRegistryTest is Test {
         address[] memory onlineAfter = registry.getOnlineOperators(SERVICE_ID);
         found = false;
         for (uint256 i = 0; i < onlineAfter.length; i++) {
-            if (onlineAfter[i] == newOp) { found = true; break; }
+            if (onlineAfter[i] == newOp) found = true;
+            break;
         }
         assertTrue(found, "Should be online after first heartbeat");
         assertTrue(registry.isOnline(SERVICE_ID, newOp));
@@ -891,7 +901,7 @@ contract OperatorStatusRegistryTest is Test {
 
         // Submit a metric with an undefined name
         IOperatorStatusRegistry.MetricPair[] memory pairs = new IOperatorStatusRegistry.MetricPair[](2);
-        pairs[0] = IOperatorStatusRegistry.MetricPair("cpu", 50);           // defined — should be stored
+        pairs[0] = IOperatorStatusRegistry.MetricPair("cpu", 50); // defined — should be stored
         pairs[1] = IOperatorStatusRegistry.MetricPair("rogue_metric", 999); // undefined — should be rejected
         bytes memory metricsData = abi.encode(pairs);
 

--- a/test/staking/ProportionalSlashingTest.t.sol
+++ b/test/staking/ProportionalSlashingTest.t.sol
@@ -99,9 +99,8 @@ contract ProportionalSlashingTest is Test {
         _setupOperatorWithDelegators();
 
         // Total stake = 60 ETH (10 operator + 20 d1 + 30 d2)
-        uint256 totalStake = staking.getOperatorSelfStake(operator1) +
-                             staking.getDelegation(delegator1, operator1) +
-                             staking.getDelegation(delegator2, operator1);
+        uint256 totalStake = staking.getOperatorSelfStake(operator1) + staking.getDelegation(delegator1, operator1)
+            + staking.getDelegation(delegator2, operator1);
         assertEq(totalStake, 60 ether, "Total stake should be 60 ETH");
 
         // Slash 10% of total
@@ -325,9 +324,8 @@ contract ProportionalSlashingTest is Test {
         vm.prank(slasher);
         staking.slash(operator1, 0, 10_000, keccak256("evidence"));
 
-        uint256 totalAfter = staking.getOperatorSelfStake(operator1) +
-                             staking.getDelegation(delegator1, operator1) +
-                             staking.getDelegation(delegator2, operator1);
+        uint256 totalAfter = staking.getOperatorSelfStake(operator1) + staking.getDelegation(delegator1, operator1)
+            + staking.getDelegation(delegator2, operator1);
 
         // Total should be 0 (capped slash)
         assertEq(totalAfter, 0, "Total stake should be 0 after max slash");

--- a/test/staking/SlashingInvariantTest.t.sol
+++ b/test/staking/SlashingInvariantTest.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Test} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import { IMultiAssetDelegation } from "../../src/interfaces/IMultiAssetDelegation.sol";
 import { IFacetSelectors } from "../../src/interfaces/IFacetSelectors.sol";
 import { MultiAssetDelegation } from "../../src/staking/MultiAssetDelegation.sol";
 import { StakingFacetBase } from "../../src/staking/StakingFacetBase.sol";
-import {Types} from "../../src/libraries/Types.sol";
+import { Types } from "../../src/libraries/Types.sol";
 import { StakingOperatorsFacet } from "../../src/facets/staking/StakingOperatorsFacet.sol";
 import { StakingDepositsFacet } from "../../src/facets/staking/StakingDepositsFacet.sol";
 import { StakingDelegationsFacet } from "../../src/facets/staking/StakingDelegationsFacet.sol";
@@ -52,10 +52,7 @@ contract SlashForBlueprintFuzzTest is Test {
 
     function setUp() public {
         MultiAssetDelegation impl = new MultiAssetDelegation();
-        bytes memory initData = abi.encodeCall(
-            MultiAssetDelegation.initialize,
-            (admin, 1 ether, 0.1 ether, 1000)
-        );
+        bytes memory initData = abi.encodeCall(MultiAssetDelegation.initialize, (admin, 1 ether, 0.1 ether, 1000));
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         delegation = IMultiAssetDelegation(payable(address(proxy)));
         exposed = MultiAssetDelegationExposed(payable(address(proxy)));
@@ -70,24 +67,20 @@ contract SlashForBlueprintFuzzTest is Test {
 
         vm.deal(operator, 100 ether);
         vm.prank(operator);
-        delegation.registerOperator{value: 20 ether}();
+        delegation.registerOperator{ value: 20 ether }();
         vm.prank(operator);
         delegation.setDelegationMode(Types.DelegationMode.Open);
 
         vm.deal(delegatorAll, 100 ether);
         vm.prank(delegatorAll);
-        delegation.depositAndDelegate{value: 30 ether}(operator);
+        delegation.depositAndDelegate{ value: 30 ether }(operator);
 
         vm.deal(delegatorFixed, 100 ether);
         uint64[] memory blueprints = new uint64[](1);
         blueprints[0] = BLUEPRINT_ID;
         vm.prank(delegatorFixed);
-        delegation.depositAndDelegateWithOptions{value: 40 ether}(
-            operator,
-            address(0),
-            40 ether,
-            Types.BlueprintSelectionMode.Fixed,
-            blueprints
+        delegation.depositAndDelegateWithOptions{ value: 40 ether }(
+            operator, address(0), 40 ether, Types.BlueprintSelectionMode.Fixed, blueprints
         );
     }
 
@@ -113,13 +106,8 @@ contract SlashForBlueprintFuzzTest is Test {
         uint16 slashBps = uint16(bound(uint256(rawBps), 1, 10_000));
 
         vm.prank(slasher);
-        uint256 actualSlashed = delegation.slashForBlueprint(
-            operator,
-            BLUEPRINT_ID,
-            99,
-            slashBps,
-            keccak256("evidence")
-        );
+        uint256 actualSlashed =
+            delegation.slashForBlueprint(operator, BLUEPRINT_ID, 99, slashBps, keccak256("evidence"));
 
         uint256 operatorStakeAfter = exposed.operatorStake(operator);
         uint256 allAssetsAfter = exposed.rewardPoolTotals(operator);

--- a/test/support/BlueprintDefinitionHelper.sol
+++ b/test/support/BlueprintDefinitionHelper.sol
@@ -13,7 +13,11 @@ abstract contract BlueprintDefinitionHelper {
     function _blueprintDefinition(
         string memory metadataUri,
         address manager
-    ) internal pure returns (Types.BlueprintDefinition memory def) {
+    )
+        internal
+        pure
+        returns (Types.BlueprintDefinition memory def)
+    {
         bytes memory emptySchema = _emptySchema();
         def.metadataUri = metadataUri;
         def.manager = manager;
@@ -54,7 +58,11 @@ abstract contract BlueprintDefinitionHelper {
         string memory metadataUri,
         address manager,
         Types.BlueprintConfig memory config
-    ) internal pure returns (Types.BlueprintDefinition memory def) {
+    )
+        internal
+        pure
+        returns (Types.BlueprintDefinition memory def)
+    {
         def = _blueprintDefinition(metadataUri, manager);
         def.config = config;
         def.hasConfig = true;
@@ -64,7 +72,11 @@ abstract contract BlueprintDefinitionHelper {
         string memory metadataUri,
         address manager,
         uint256 jobCount
-    ) internal pure returns (Types.BlueprintDefinition memory def) {
+    )
+        internal
+        pure
+        returns (Types.BlueprintDefinition memory def)
+    {
         def = _blueprintDefinition(metadataUri, manager);
         if (jobCount == def.jobs.length) {
             return def;
@@ -155,7 +167,8 @@ abstract contract BlueprintDefinitionHelper {
 
     function _defaultBlueprintSource() internal pure returns (Types.BlueprintSource memory source) {
         source.kind = Types.BlueprintSourceKind.Container;
-        source.container = Types.ImageRegistrySource({ registry: "registry.tangle.local", image: "blueprint", tag: "latest" });
+        source.container =
+            Types.ImageRegistrySource({ registry: "registry.tangle.local", image: "blueprint", tag: "latest" });
         source.wasm.runtime = Types.WasmRuntime.Wasmtime;
         source.wasm.fetcher = Types.BlueprintFetcherKind.None;
         source.native.fetcher = Types.BlueprintFetcherKind.None;
@@ -169,7 +182,10 @@ abstract contract BlueprintDefinitionHelper {
         });
     }
 
-    function _buildJobDefinitions(uint256 count, bytes memory schema)
+    function _buildJobDefinitions(
+        uint256 count,
+        bytes memory schema
+    )
         private
         pure
         returns (Types.JobDefinition[] memory jobs)

--- a/test/support/SchemaTestUtils.sol
+++ b/test/support/SchemaTestUtils.sol
@@ -56,7 +56,10 @@ library SchemaTestUtils {
     // FIELD GENERATION
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function _buildFieldDefinition(uint256 seed, uint8 depth)
+    function _buildFieldDefinition(
+        uint256 seed,
+        uint8 depth
+    )
         private
         pure
         returns (Types.BlueprintFieldType memory field, uint256 nextSeed)
@@ -131,7 +134,10 @@ library SchemaTestUtils {
         return (field, nextSeed);
     }
 
-    function _encodeValue(Types.BlueprintFieldType memory field, uint256 seed)
+    function _encodeValue(
+        Types.BlueprintFieldType memory field,
+        uint256 seed
+    )
         private
         pure
         returns (bytes memory good, bytes memory bad, uint256 nextSeed)

--- a/test/tangle/HeartbeatConfig.t.sol
+++ b/test/tangle/HeartbeatConfig.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BaseTest} from "../BaseTest.sol";
-import {BlueprintServiceManagerBase} from "../../src/BlueprintServiceManagerBase.sol";
-import {IOperatorStatusRegistry} from "../../src/staking/OperatorStatusRegistry.sol";
+import { BaseTest } from "../BaseTest.sol";
+import { BlueprintServiceManagerBase } from "../../src/BlueprintServiceManagerBase.sol";
+import { IOperatorStatusRegistry } from "../../src/staking/OperatorStatusRegistry.sol";
 
 contract MockStatusRegistry is IOperatorStatusRegistry {
     bool public registerCalled;
@@ -13,13 +13,7 @@ contract MockStatusRegistry is IOperatorStatusRegistry {
     uint64 public configuredInterval;
     uint8 public configuredMaxMissed;
 
-    function submitHeartbeat(
-        uint64,
-        uint64,
-        uint8,
-        bytes calldata,
-        bytes calldata
-    ) external override {}
+    function submitHeartbeat(uint64, uint64, uint8, bytes calldata, bytes calldata) external override { }
 
     function isOnline(uint64, address) external pure override returns (bool) {
         return false;
@@ -46,31 +40,79 @@ contract MockStatusRegistry is IOperatorStatusRegistry {
         configuredMaxMissed = maxMissed;
     }
 
-    function submitHeartbeatDirect(uint64, uint64, uint8, bytes calldata) external override {}
-    function getOperatorState(uint64, address) external pure override returns (IOperatorStatusRegistry.OperatorState memory) {
+    function submitHeartbeatDirect(uint64, uint64, uint8, bytes calldata) external override { }
+
+    function getOperatorState(
+        uint64,
+        address
+    )
+        external
+        pure
+        override
+        returns (IOperatorStatusRegistry.OperatorState memory)
+    {
         return IOperatorStatusRegistry.OperatorState(0, 0, 0, IOperatorStatusRegistry.StatusCode.Healthy, bytes32(0));
     }
-    function getOnlineOperators(uint64) external pure override returns (address[] memory) { return new address[](0); }
-    function getHeartbeatConfig(uint64) external pure override returns (IOperatorStatusRegistry.HeartbeatConfig memory) {
+
+    function getOnlineOperators(uint64) external pure override returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function getHeartbeatConfig(uint64)
+        external
+        pure
+        override
+        returns (IOperatorStatusRegistry.HeartbeatConfig memory)
+    {
         return IOperatorStatusRegistry.HeartbeatConfig(0, 0, false);
     }
-    function isHeartbeatCurrent(uint64, address) external pure override returns (bool) { return false; }
-    function getMetricValue(uint64, address, string calldata) external pure override returns (uint256) { return 0; }
-    function getMetricDefinitions(uint64) external pure override returns (IOperatorStatusRegistry.MetricDefinition[] memory) {
+
+    function isHeartbeatCurrent(uint64, address) external pure override returns (bool) {
+        return false;
+    }
+
+    function getMetricValue(uint64, address, string calldata) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function getMetricDefinitions(uint64)
+        external
+        pure
+        override
+        returns (IOperatorStatusRegistry.MetricDefinition[] memory)
+    {
         return new IOperatorStatusRegistry.MetricDefinition[](0);
     }
-    function enableCustomMetrics(uint64, bool) external override {}
-    function setMetricDefinitions(uint64, IOperatorStatusRegistry.MetricDefinition[] calldata) external override {}
-    function addMetricDefinition(uint64, string calldata, uint256, uint256, bool) external override {}
-    function reportForSlashing(uint64, address, string calldata) external override {}
-    function getSlashableOperators(uint64) external pure override returns (address[] memory) { return new address[](0); }
-    function getSlashableOperatorsPaginated(uint64, uint256, uint256) external pure override returns (address[] memory, uint256) { return (new address[](0), 0); }
-    function removeInactiveOperator(uint64, address) external override {}
-    function goOffline(uint64) external override {}
-    function goOnline(uint64) external override {}
-    function registerOperator(uint64, address) external override {}
-    function deregisterOperator(uint64, address) external override {}
-    function isRegisteredOperator(uint64, address) external pure override returns (bool) { return true; }
+    function enableCustomMetrics(uint64, bool) external override { }
+    function setMetricDefinitions(uint64, IOperatorStatusRegistry.MetricDefinition[] calldata) external override { }
+    function addMetricDefinition(uint64, string calldata, uint256, uint256, bool) external override { }
+    function reportForSlashing(uint64, address, string calldata) external override { }
+
+    function getSlashableOperators(uint64) external pure override returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function getSlashableOperatorsPaginated(
+        uint64,
+        uint256,
+        uint256
+    )
+        external
+        pure
+        override
+        returns (address[] memory, uint256)
+    {
+        return (new address[](0), 0);
+    }
+    function removeInactiveOperator(uint64, address) external override { }
+    function goOffline(uint64) external override { }
+    function goOnline(uint64) external override { }
+    function registerOperator(uint64, address) external override { }
+    function deregisterOperator(uint64, address) external override { }
+
+    function isRegisteredOperator(uint64, address) external pure override returns (bool) {
+        return true;
+    }
 }
 
 contract HeartbeatBSM is BlueprintServiceManagerBase {

--- a/test/tangle/OperatorLifecycle.t.sol
+++ b/test/tangle/OperatorLifecycle.t.sol
@@ -98,9 +98,7 @@ contract OperatorLifecycleTest is BaseTest {
         bytes4 selector = bytes4(keccak256("registerOperator(uint64,bytes,string)"));
 
         vm.prank(operator1);
-        (bool ok,) = address(tangle).call{ value: 1 ether }(
-            abi.encodeWithSelector(selector, blueprintId, key, "")
-        );
+        (bool ok,) = address(tangle).call{ value: 1 ether }(abi.encodeWithSelector(selector, blueprintId, key, ""));
         assertFalse(ok);
     }
 
@@ -287,9 +285,8 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -310,7 +307,7 @@ contract OperatorLifecycleTest is BaseTest {
 
         uint64 serviceId = tangle.serviceCount() - 1;
         Types.ServiceOperator memory opInfo = tangle.getServiceOperator(serviceId, operator1);
-        assertEq(opInfo.exposureBps, 10000); // 100%
+        assertEq(opInfo.exposureBps, 10_000); // 100%
     }
 
     function test_RequestService_AddsDefaultTntSecurityRequirement() public {
@@ -327,7 +324,7 @@ contract OperatorLifecycleTest is BaseTest {
         assertEq(uint8(reqs[0].asset.kind), uint8(Types.AssetKind.ERC20));
         assertEq(reqs[0].asset.token, address(tnt));
         assertEq(reqs[0].minExposureBps, 1000); // 10%
-        assertEq(reqs[0].maxExposureBps, 10000);
+        assertEq(reqs[0].maxExposureBps, 10_000);
     }
 
     function test_ApproveService_AutoCommitsDefaultTntExposure() public {
@@ -362,7 +359,7 @@ contract OperatorLifecycleTest is BaseTest {
         requirements[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 5000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory operators = new address[](1);
@@ -370,15 +367,13 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, operators, requirements, "", callers, 0, address(0), 0
-        );
+        uint64 requestId =
+            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.SecurityCommitmentsRequired.selector, requestId));
         tangle.approveService(requestId, 0);
     }
-
 
     // ═══════════════════════════════════════════════════════════════════════════
     // DYNAMIC SERVICE MEMBERSHIP
@@ -436,7 +431,7 @@ contract OperatorLifecycleTest is BaseTest {
         // Blueprint is Fixed, not Dynamic
         vm.prank(operator2);
         vm.expectRevert(Errors.InvalidState.selector);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
     }
 
     function test_LeaveService() public {
@@ -479,11 +474,11 @@ contract OperatorLifecycleTest is BaseTest {
         // Schedule exit
         vm.prank(operator2);
         tangle.scheduleExit(serviceId);
-        assertEq(uint(tangle.getExitStatus(serviceId, operator2)), uint(Types.ExitStatus.Scheduled));
+        assertEq(uint256(tangle.getExitStatus(serviceId, operator2)), uint256(Types.ExitStatus.Scheduled));
 
         // Warp past exit queue duration (7 days default)
         vm.warp(block.timestamp + 7 days + 1);
-        assertEq(uint(tangle.getExitStatus(serviceId, operator2)), uint(Types.ExitStatus.Executable));
+        assertEq(uint256(tangle.getExitStatus(serviceId, operator2)), uint256(Types.ExitStatus.Executable));
 
         // Execute exit
         vm.prank(operator2);
@@ -654,9 +649,7 @@ contract OperatorLifecycleTest is BaseTest {
         uint64 validTtl = 1 hours;
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(
-            blueprintId, operators, "", callers, validTtl, address(0), 0
-        );
+        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, validTtl, address(0), 0);
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 

--- a/test/tangle/Payments.t.sol
+++ b/test/tangle/Payments.t.sol
@@ -46,20 +46,16 @@ contract PaymentsTest is BaseTest {
 
     function test_PaymentSplit_DefaultValues() public view {
         (uint16 dev, uint16 proto, uint16 op, uint16 rest) = tangle.paymentSplit();
-        assertEq(dev, 2000);   // 20%
+        assertEq(dev, 2000); // 20%
         assertEq(proto, 2000); // 20%
-        assertEq(op, 4000);    // 40%
-        assertEq(rest, 2000);  // 20%
-        assertEq(dev + proto + op + rest, 10000);
+        assertEq(op, 4000); // 40%
+        assertEq(rest, 2000); // 20%
+        assertEq(dev + proto + op + rest, 10_000);
     }
 
     function test_SetPaymentSplit_ValidConfiguration() public {
-        Types.PaymentSplit memory newSplit = Types.PaymentSplit({
-            developerBps: 4000,
-            protocolBps: 2000,
-            operatorBps: 2500,
-            stakerBps: 1500
-        });
+        Types.PaymentSplit memory newSplit =
+            Types.PaymentSplit({ developerBps: 4000, protocolBps: 2000, operatorBps: 2500, stakerBps: 1500 });
 
         vm.prank(admin);
         tangle.setPaymentSplit(newSplit);
@@ -72,12 +68,8 @@ contract PaymentsTest is BaseTest {
     }
 
     function test_SetPaymentSplit_RevertNotAdmin() public {
-        Types.PaymentSplit memory newSplit = Types.PaymentSplit({
-            developerBps: 4000,
-            protocolBps: 2000,
-            operatorBps: 2500,
-            stakerBps: 1500
-        });
+        Types.PaymentSplit memory newSplit =
+            Types.PaymentSplit({ developerBps: 4000, protocolBps: 2000, operatorBps: 2500, stakerBps: 1500 });
 
         vm.prank(user1);
         vm.expectRevert();
@@ -85,12 +77,8 @@ contract PaymentsTest is BaseTest {
     }
 
     function test_SetPaymentSplit_RevertTotalNot100Percent() public {
-        Types.PaymentSplit memory newSplit = Types.PaymentSplit({
-            developerBps: 5000,
-            protocolBps: 5000,
-            operatorBps: 5000,
-            stakerBps: 5000
-        });
+        Types.PaymentSplit memory newSplit =
+            Types.PaymentSplit({ developerBps: 5000, protocolBps: 5000, operatorBps: 5000, stakerBps: 5000 });
 
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidPaymentSplit.selector);
@@ -98,18 +86,14 @@ contract PaymentsTest is BaseTest {
     }
 
     function test_SetPaymentSplit_AllToDeveloper() public {
-        Types.PaymentSplit memory newSplit = Types.PaymentSplit({
-            developerBps: 10000,
-            protocolBps: 0,
-            operatorBps: 0,
-            stakerBps: 0
-        });
+        Types.PaymentSplit memory newSplit =
+            Types.PaymentSplit({ developerBps: 10_000, protocolBps: 0, operatorBps: 0, stakerBps: 0 });
 
         vm.prank(admin);
         tangle.setPaymentSplit(newSplit);
 
         (uint16 dev, uint16 proto, uint16 op, uint16 rest) = tangle.paymentSplit();
-        assertEq(dev, 10000);
+        assertEq(dev, 10_000);
         assertEq(proto, 0);
         assertEq(op, 0);
         assertEq(rest, 0);
@@ -131,8 +115,8 @@ contract PaymentsTest is BaseTest {
         tangle.approveService(requestId, 0);
 
         // Check distribution
-        uint256 developerExpected = (payment * 2000) / 10000; // 20%
-        uint256 protocolExpected = (payment * 2000) / 10000;  // 20%
+        uint256 developerExpected = (payment * 2000) / 10_000; // 20%
+        uint256 protocolExpected = (payment * 2000) / 10_000; // 20%
 
         assertEq(developer.balance, developerBefore + developerExpected, "Developer payment incorrect");
         assertEq(treasury.balance, treasuryBefore + protocolExpected, "Protocol payment incorrect");
@@ -192,12 +176,9 @@ contract PaymentsTest is BaseTest {
         tangle.setTntPaymentDiscountBps(1000); // 10%
 
         // Everything goes to treasury, so discount is easy to verify.
-        tangle.setPaymentSplit(Types.PaymentSplit({
-            developerBps: 0,
-            protocolBps: 10000,
-            operatorBps: 0,
-            stakerBps: 0
-        }));
+        tangle.setPaymentSplit(
+            Types.PaymentSplit({ developerBps: 0, protocolBps: 10_000, operatorBps: 0, stakerBps: 0 })
+        );
         vm.stopPrank();
 
         uint256 payment = 100 ether;
@@ -222,12 +203,9 @@ contract PaymentsTest is BaseTest {
         tangle.setTntPaymentDiscountBps(1000); // 10%
 
         // Protocol share is only 5%; discount should be capped to 5%.
-        tangle.setPaymentSplit(Types.PaymentSplit({
-            developerBps: 9500,
-            protocolBps: 500,
-            operatorBps: 0,
-            stakerBps: 0
-        }));
+        tangle.setPaymentSplit(
+            Types.PaymentSplit({ developerBps: 9500, protocolBps: 500, operatorBps: 0, stakerBps: 0 })
+        );
         vm.stopPrank();
 
         uint256 payment = 100 ether;
@@ -258,9 +236,8 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: payment }(
-            blueprintId, operators, "", callers, 0, address(0), payment
-        );
+        uint64 requestId =
+            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -420,9 +397,8 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 1 ether }(
-            subBlueprintId, operators, "", callers, 0, address(0), 1 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 1 ether }(subBlueprintId, operators, "", callers, 0, address(0), 1 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -514,7 +490,8 @@ contract PaymentsTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 ercBlueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://erc20-subscription", address(0), config));
+        uint64 ercBlueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://erc20-subscription", address(0), config));
         _registerForBlueprint(operator1, ercBlueprintId);
 
         address[] memory operators = new address[](1);
@@ -524,15 +501,8 @@ contract PaymentsTest is BaseTest {
         uint256 initialDeposit = 100 ether;
         vm.startPrank(user1);
         token.approve(address(tangle), initialDeposit);
-        uint64 requestId = tangle.requestService(
-            ercBlueprintId,
-            operators,
-            "",
-            callers,
-            0,
-            address(token),
-            initialDeposit
-        );
+        uint64 requestId =
+            tangle.requestService(ercBlueprintId, operators, "", callers, 0, address(token), initialDeposit);
         vm.stopPrank();
 
         vm.prank(operator1);
@@ -591,9 +561,8 @@ contract PaymentsTest is BaseTest {
 
         // Only deposit 0.5 ETH but rate is 1 ETH
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 0.5 ether }(
-            bp, operators, "", callers, 0, address(0), 0.5 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 0.5 ether }(bp, operators, "", callers, 0, address(0), 0.5 ether);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -637,7 +606,8 @@ contract PaymentsTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 expBlueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://expiring-sub", address(0), config));
+        uint64 expBlueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://expiring-sub", address(0), config));
         _registerForBlueprint(operator1, expBlueprintId);
 
         address[] memory operators = new address[](1);
@@ -646,13 +616,7 @@ contract PaymentsTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: 1 ether }(
-            expBlueprintId,
-            operators,
-            "",
-            callers,
-            1 days,
-            address(0),
-            1 ether
+            expBlueprintId, operators, "", callers, 1 days, address(0), 1 ether
         );
 
         vm.prank(operator1);
@@ -789,9 +753,9 @@ contract PaymentsTest is BaseTest {
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 
-        uint256 devExpected = (uint256(333) * 2000) / 10000; // 66
-        uint256 protoExpected = (uint256(333) * 2000) / 10000; // 66
-        uint256 opAmount = (uint256(333) * 4000) / 10000; // 133
+        uint256 devExpected = (uint256(333) * 2000) / 10_000; // 66
+        uint256 protoExpected = (uint256(333) * 2000) / 10_000; // 66
+        uint256 opAmount = (uint256(333) * 4000) / 10_000; // 133
         uint256 stakerAmount = 333 - devExpected - protoExpected - opAmount; // 68
         // No security commitments: operator gets op + staker = 201
 
@@ -816,10 +780,7 @@ contract PaymentsTest is BaseTest {
         return _setupSubscriptionServiceWithDepositAndTTL(1 ether, ttl);
     }
 
-    function _setupSubscriptionServiceWithDepositAndTTL(uint256 initialDeposit, uint64 ttl)
-        internal
-        returns (uint64)
-    {
+    function _setupSubscriptionServiceWithDepositAndTTL(uint256 initialDeposit, uint64 ttl) internal returns (uint64) {
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
             membership: Types.MembershipModel.Fixed,
             pricing: Types.PricingModel.Subscription,

--- a/test/tangle/PerAssetExposureIntegration.t.sol
+++ b/test/tangle/PerAssetExposureIntegration.t.sol
@@ -34,8 +34,7 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(impl),
             abi.encodeCall(
-                ServiceFeeDistributor.initialize,
-                (admin, address(staking), address(tangle), address(oracle))
+                ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(oracle))
             )
         );
         distributor = ServiceFeeDistributor(payable(address(proxy)));
@@ -46,7 +45,7 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         staking.setServiceFeeDistributor(address(distributor));
 
         // Enable stake ERC20 asset in restaking
-        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10000);
+        staking.enableAsset(address(stakeToken), MIN_OPERATOR_STAKE, MIN_DELEGATION, 0, 10_000);
         vm.stopPrank();
 
         // Setup blueprint + operator
@@ -68,11 +67,7 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         vm.startPrank(delegator2);
         stakeToken.approve(address(staking), 10 ether);
         staking.depositAndDelegateWithOptions(
-            operator1,
-            address(stakeToken),
-            10 ether,
-            Types.BlueprintSelectionMode.All,
-            new uint64[](0)
+            operator1, address(stakeToken), 10 ether, Types.BlueprintSelectionMode.All, new uint64[](0)
         );
         vm.stopPrank();
     }
@@ -83,12 +78,12 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -99,20 +94,13 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            ops,
-            reqs,
-            "",
-            new address[](0),
-            0,
-            address(payToken),
-            paymentAmount
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payToken), paymentAmount
         );
         vm.stopPrank();
 
         // Commit 100% native exposure, 10% ERC20 exposure.
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](2);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
         commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 1000 });
 
         vm.prank(operator1);
@@ -137,12 +125,12 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         reqs[0] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
             minExposureBps: 1000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
         reqs[1] = Types.AssetSecurityRequirement({
             asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
             minExposureBps: 1000,
-            maxExposureBps: 10000
+            maxExposureBps: 10_000
         });
 
         address[] memory ops = new address[](1);
@@ -151,19 +139,12 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), 1 ether);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId,
-            ops,
-            reqs,
-            "",
-            new address[](0),
-            0,
-            address(payToken),
-            1 ether
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payToken), 1 ether
         );
         vm.stopPrank();
 
         Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](2);
-        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10000 });
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
         commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 1000 });
 
         vm.prank(operator1);
@@ -179,6 +160,6 @@ contract PerAssetExposureIntegrationTest is BaseTest {
 
         SlashingLib.SlashProposal memory p = tangle.getSlashProposal(slashId);
         assertEq(p.slashBps, slashBps);
-        assertEq(p.effectiveSlashBps, (uint256(slashBps) * 5500) / 10000);
+        assertEq(p.effectiveSlashBps, (uint256(slashBps) * 5500) / 10_000);
     }
 }

--- a/test/tangle/QuoteEdgeCases.t.sol
+++ b/test/tangle/QuoteEdgeCases.t.sol
@@ -53,13 +53,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
 
         assertTrue(tangle.isServiceActive(serviceId));
     }
@@ -67,19 +61,14 @@ contract QuoteEdgeCasesTest is BaseTest {
     function test_CreateServiceFromQuotes_ExpiredQuote_Reverts() public {
         uint64 ttl = 30 days;
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = _createSignedQuote(operator1Key, operator1, 1 ether, uint64(block.timestamp - 1), uint64(ttl)); // Already expired
+        quotes[0] = _createSignedQuote(operator1Key, operator1, 1 ether, uint64(block.timestamp - 1), uint64(ttl)); // Already
+        // expired
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
         vm.expectRevert(); // Quote expired
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
     }
 
     function test_CreateServiceFromQuotes_QuoteExpiresExactlyAtTimestamp() public {
@@ -93,15 +82,10 @@ contract QuoteEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         // Behavior at exact boundary - depends on implementation (< vs <=)
-        try tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        ) {
-            // Success case - deadline is inclusive
-        } catch {
+        try tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl) {
+        // Success case - deadline is inclusive
+        }
+            catch {
             // Failure case - deadline is exclusive
         }
     }
@@ -117,7 +101,8 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
@@ -135,13 +120,7 @@ contract QuoteEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(); // Invalid signature
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
     }
 
     function test_CreateServiceFromQuotes_ReusedQuote_Reverts() public {
@@ -153,24 +132,12 @@ contract QuoteEdgeCasesTest is BaseTest {
 
         // First use - should succeed
         vm.prank(user1);
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
 
         // Second use - should fail (quote already used)
         vm.prank(user1);
         vm.expectRevert(); // Quote already used
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
     }
 
     function test_CreateServiceFromQuotes_WrongBlueprintId_Reverts() public {
@@ -182,18 +149,15 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(operator1Key, digest);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            operator: operator1,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        quotes[0] = Types.SignedQuote({ operator: operator1, details: details, signature: abi.encodePacked(r, s, v) });
 
         address[] memory callers = new address[](0);
 
@@ -201,7 +165,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         vm.expectRevert(); // Blueprint mismatch or not found
         tangle.createServiceFromQuotes{ value: 1 ether }(
             blueprintId, // Trying to create for blueprintId
-            quotes,      // But quote is for blueprintId + 1
+            quotes, // But quote is for blueprintId + 1
             "",
             callers,
             ttl
@@ -222,11 +186,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.InsufficientPaymentForQuotes.selector, 1 ether, 0.5 ether));
         tangle.createServiceFromQuotes{ value: 0.5 ether }( // Insufficient
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
+            blueprintId, quotes, "", callers, ttl
         );
     }
 
@@ -241,11 +201,7 @@ contract QuoteEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         tangle.createServiceFromQuotes{ value: 2 ether }( // 1 ETH excess
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
+            blueprintId, quotes, "", callers, ttl
         );
 
         // User should have received 1 ETH refund
@@ -280,20 +236,15 @@ contract QuoteEdgeCasesTest is BaseTest {
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](3);
         quotes[0] = _createSignedQuote(operator1Key, operator1, 1 ether, uint64(block.timestamp + 1 hours), uint64(ttl));
         quotes[1] = _createSignedQuote(operator2Key, operator2, 2 ether, uint64(block.timestamp + 1 hours), uint64(ttl));
-        quotes[2] = _createSignedQuote(operator3Key, operator3, 1.5 ether, uint64(block.timestamp + 1 hours), uint64(ttl));
+        quotes[2] =
+            _createSignedQuote(operator3Key, operator3, 1.5 ether, uint64(block.timestamp + 1 hours), uint64(ttl));
 
         address[] memory callers = new address[](0);
 
         uint256 totalCost = 4.5 ether;
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: totalCost }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: totalCost }(blueprintId, quotes, "", callers, ttl);
 
         assertTrue(tangle.isServiceActive(serviceId));
         assertTrue(tangle.isServiceOperator(serviceId, operator1));
@@ -313,13 +264,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         vm.prank(user1);
         // Should revert - same operator twice
         vm.expectRevert(); // Duplicate operator or quote already used
-        tangle.createServiceFromQuotes{ value: 2 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 2 ether }(blueprintId, quotes, "", callers, ttl);
     }
 
     function test_CreateServiceFromQuotes_UnregisteredOperator_Reverts() public {
@@ -340,29 +285,21 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(unregisteredKey, digest);
 
-        quotes[0] = Types.SignedQuote({
-            operator: unregisteredOp,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        quotes[0] =
+            Types.SignedQuote({ operator: unregisteredOp, details: details, signature: abi.encodePacked(r, s, v) });
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, blueprintId, unregisteredOp));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -383,29 +320,20 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: commitments
+            securityCommitments: commitments,
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(operator1Key, digest);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            operator: operator1,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        quotes[0] = Types.SignedQuote({ operator: operator1, details: details, signature: abi.encodePacked(r, s, v) });
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
 
         assertTrue(tangle.isServiceActive(serviceId));
 
@@ -446,13 +374,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, ttl);
 
         Types.Service memory svc = tangle.getService(serviceId);
         assertEq(svc.ttl, type(uint64).max);
@@ -468,13 +390,7 @@ contract QuoteEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(); // No operators
-        tangle.createServiceFromQuotes(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            30 days
-        );
+        tangle.createServiceFromQuotes(blueprintId, quotes, "", callers, 30 days);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -493,13 +409,7 @@ contract QuoteEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 3 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            ttl
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: 3 ether }(blueprintId, quotes, "", callers, ttl);
 
         assertTrue(tangle.isServiceActive(serviceId));
     }
@@ -514,53 +424,64 @@ contract QuoteEdgeCasesTest is BaseTest {
         uint256 totalCost,
         uint64 expiry,
         uint64 ttl
-    ) internal view returns (Types.SignedQuote memory) {
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: ttl, // Must match the TTL passed to createServiceFromQuotes
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
-        return Types.SignedQuote({
-            operator: operator,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        return Types.SignedQuote({ operator: operator, details: details, signature: abi.encodePacked(r, s, v) });
     }
 
     function _computeQuoteDigest(Types.QuoteDetails memory details) internal view returns (bytes32) {
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
-        bytes32 structHash = keccak256(abi.encode(
-            keccak256("QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"),
-            details.blueprintId,
-            details.ttlBlocks,
-            details.totalCost,
-            details.timestamp,
-            details.expiry,
-            commitmentsHash
-        ));
+        bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256(
+                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+                ),
+                details.blueprintId,
+                details.ttlBlocks,
+                details.totalCost,
+                details.timestamp,
+                details.expiry,
+                commitmentsHash,
+                resourcesHash
+            )
+        );
 
         // Get domain separator from contract (if exposed) or compute it
-        bytes32 domainSeparator = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256("TangleQuote"),
-            keccak256("1"),
-            block.chainid,
-            address(tangle)
-        ));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("TangleQuote"),
+                keccak256("1"),
+                block.chainid,
+                address(tangle)
+            )
+        );
 
         return MessageHashUtils.toTypedDataHash(domainSeparator, structHash);
     }
 
-    function _hashSecurityCommitments(
-        Types.AssetSecurityCommitment[] memory commitments
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitments(Types.AssetSecurityCommitment[] memory commitments)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32[] memory hashes = new bytes32[](commitments.length);
         for (uint256 i = 0; i < commitments.length; i++) {
             hashes[i] = _hashSecurityCommitment(commitments[i]);
@@ -572,16 +493,24 @@ contract QuoteEdgeCasesTest is BaseTest {
         return out;
     }
 
-    function _hashSecurityCommitment(
-        Types.AssetSecurityCommitment memory commitment
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitment(Types.AssetSecurityCommitment memory commitment) internal pure returns (bytes32) {
         bytes32 ASSET_TYPEHASH = keccak256("Asset(uint8 kind,address token)");
-        bytes32 COMMITMENT_TYPEHASH = keccak256(
-            "AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
-        );
-        bytes32 assetHash = keccak256(
-            abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token)
-        );
+        bytes32 COMMITMENT_TYPEHASH =
+            keccak256("AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)");
+        bytes32 assetHash = keccak256(abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token));
         return keccak256(abi.encode(COMMITMENT_TYPEHASH, assetHash, commitment.exposureBps));
+    }
+
+    function _hashResourceCommitments(Types.ResourceCommitment[] memory commitments) internal pure returns (bytes32) {
+        bytes32 RC_TYPEHASH = keccak256("ResourceCommitment(uint8 kind,uint64 count)");
+        bytes32[] memory hashes = new bytes32[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            hashes[i] = keccak256(abi.encode(RC_TYPEHASH, commitments[i].kind, commitments[i].count));
+        }
+        bytes32 out;
+        assembly ("memory-safe") {
+            out := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+        return out;
     }
 }

--- a/test/tangle/QuoteExtension.t.sol
+++ b/test/tangle/QuoteExtension.t.sol
@@ -172,18 +172,15 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: 0.5 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp - 1), // Expired
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(operator1Key, digest);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            operator: operator1,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        quotes[0] = Types.SignedQuote({ operator: operator1, details: details, signature: abi.encodePacked(r, s, v) });
 
         vm.prank(user1);
         vm.expectRevert(); // Quote expired
@@ -276,18 +273,13 @@ contract QuoteExtensionTest is BaseTest {
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](2);
         // Use different costs to make quote hashes unique
         quotes[0] = _createSignedQuote(operator1Key, operator1, 1 ether, uint64(block.timestamp + 1 hours), INITIAL_TTL);
-        quotes[1] = _createSignedQuote(operator2Key, operator2, 1.1 ether, uint64(block.timestamp + 1 hours), INITIAL_TTL);
+        quotes[1] =
+            _createSignedQuote(operator2Key, operator2, 1.1 ether, uint64(block.timestamp + 1 hours), INITIAL_TTL);
 
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        return tangle.createServiceFromQuotes{ value: 2.1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            INITIAL_TTL
-        );
+        return tangle.createServiceFromQuotes{ value: 2.1 ether }(blueprintId, quotes, "", callers, INITIAL_TTL);
     }
 
     function _createServiceWithoutTTL() internal returns (uint64) {
@@ -297,13 +289,7 @@ contract QuoteExtensionTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        return tangle.createServiceFromQuotes(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            0
-        );
+        return tangle.createServiceFromQuotes(blueprintId, quotes, "", callers, 0);
     }
 
     function _createExtensionQuote(
@@ -311,24 +297,25 @@ contract QuoteExtensionTest is BaseTest {
         address operator,
         uint256 totalCost,
         uint64 additionalTtl
-    ) internal view returns (Types.SignedQuote memory) {
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: additionalTtl,
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
-        return Types.SignedQuote({
-            operator: operator,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        return Types.SignedQuote({ operator: operator, details: details, signature: abi.encodePacked(r, s, v) });
     }
 
     function _createSignedQuoteForOperator(
@@ -336,24 +323,25 @@ contract QuoteExtensionTest is BaseTest {
         address operator,
         uint256 totalCost,
         uint64 ttl
-    ) internal view returns (Types.SignedQuote memory) {
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: ttl,
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
-        return Types.SignedQuote({
-            operator: operator,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        return Types.SignedQuote({ operator: operator, details: details, signature: abi.encodePacked(r, s, v) });
     }
 
     function _createSignedQuoteWithDifferentExpiry(
@@ -361,24 +349,25 @@ contract QuoteExtensionTest is BaseTest {
         address operator,
         uint256 totalCost,
         uint64 ttl
-    ) internal view returns (Types.SignedQuote memory) {
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: ttl,
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 2 hours), // Different expiry
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
-        return Types.SignedQuote({
-            operator: operator,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        return Types.SignedQuote({ operator: operator, details: details, signature: abi.encodePacked(r, s, v) });
     }
 
     function _createSignedQuote(
@@ -387,52 +376,63 @@ contract QuoteExtensionTest is BaseTest {
         uint256 totalCost,
         uint64 expiry,
         uint64 ttl
-    ) internal view returns (Types.SignedQuote memory) {
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: ttl,
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes32 digest = _computeQuoteDigest(details);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
 
-        return Types.SignedQuote({
-            operator: operator,
-            details: details,
-            signature: abi.encodePacked(r, s, v)
-        });
+        return Types.SignedQuote({ operator: operator, details: details, signature: abi.encodePacked(r, s, v) });
     }
 
     function _computeQuoteDigest(Types.QuoteDetails memory details) internal view returns (bytes32) {
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
-        bytes32 structHash = keccak256(abi.encode(
-            keccak256("QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"),
-            details.blueprintId,
-            details.ttlBlocks,
-            details.totalCost,
-            details.timestamp,
-            details.expiry,
-            commitmentsHash
-        ));
+        bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
+        bytes32 structHash = keccak256(
+            abi.encode(
+                keccak256(
+                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+                ),
+                details.blueprintId,
+                details.ttlBlocks,
+                details.totalCost,
+                details.timestamp,
+                details.expiry,
+                commitmentsHash,
+                resourcesHash
+            )
+        );
 
-        bytes32 domainSeparator = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256("TangleQuote"),
-            keccak256("1"),
-            block.chainid,
-            address(tangle)
-        ));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("TangleQuote"),
+                keccak256("1"),
+                block.chainid,
+                address(tangle)
+            )
+        );
 
         return MessageHashUtils.toTypedDataHash(domainSeparator, structHash);
     }
 
-    function _hashSecurityCommitments(
-        Types.AssetSecurityCommitment[] memory commitments
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitments(Types.AssetSecurityCommitment[] memory commitments)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32[] memory hashes = new bytes32[](commitments.length);
         for (uint256 i = 0; i < commitments.length; i++) {
             hashes[i] = _hashSecurityCommitment(commitments[i]);
@@ -444,16 +444,24 @@ contract QuoteExtensionTest is BaseTest {
         return out;
     }
 
-    function _hashSecurityCommitment(
-        Types.AssetSecurityCommitment memory commitment
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitment(Types.AssetSecurityCommitment memory commitment) internal pure returns (bytes32) {
         bytes32 ASSET_TYPEHASH = keccak256("Asset(uint8 kind,address token)");
-        bytes32 COMMITMENT_TYPEHASH = keccak256(
-            "AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
-        );
-        bytes32 assetHash = keccak256(
-            abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token)
-        );
+        bytes32 COMMITMENT_TYPEHASH =
+            keccak256("AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)");
+        bytes32 assetHash = keccak256(abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token));
         return keccak256(abi.encode(COMMITMENT_TYPEHASH, assetHash, commitment.exposureBps));
+    }
+
+    function _hashResourceCommitments(Types.ResourceCommitment[] memory commitments) internal pure returns (bytes32) {
+        bytes32 RC_TYPEHASH = keccak256("ResourceCommitment(uint8 kind,uint64 count)");
+        bytes32[] memory hashes = new bytes32[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            hashes[i] = keccak256(abi.encode(RC_TYPEHASH, commitments[i].kind, commitments[i].count));
+        }
+        bytes32 out;
+        assembly ("memory-safe") {
+            out := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+        return out;
     }
 }

--- a/test/tangle/QuoteVerification.t.sol
+++ b/test/tangle/QuoteVerification.t.sol
@@ -35,7 +35,12 @@ contract MockQuoteManager is BlueprintServiceManagerBase {
         uint64 ttl,
         address,
         uint256 cost
-    ) external payable override onlyFromTangle {
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    {
         requestCalled = true;
         lastRequestConfig = config;
         lastRequestTTL = ttl;
@@ -53,7 +58,11 @@ contract MockQuoteManager is BlueprintServiceManagerBase {
         address,
         address[] calldata permittedCallers,
         uint64
-    ) external override onlyFromTangle {
+    )
+        external
+        override
+        onlyFromTangle
+    {
         initCalled = true;
         delete _initializedCallers;
         for (uint256 i = 0; i < permittedCallers.length; i++) {
@@ -117,13 +126,8 @@ contract QuoteVerificationTest is BaseTest {
         );
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
 
         assertTrue(tangle.isServiceActive(serviceId));
         assertTrue(tangle.isServiceOperator(serviceId, operator1));
@@ -137,7 +141,8 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         // Sign with wrong key
@@ -152,13 +157,7 @@ contract QuoteVerificationTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.InvalidQuoteSignature.selector, operator1));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     function test_CreateFromQuote_RevertExpiredQuote() public {
@@ -168,27 +167,18 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp - 1), // Already expired
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuote(details, OPERATOR1_PK);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator1
-        });
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator1 });
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.QuoteExpired.selector, operator1, details.expiry));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     function test_CreateFromQuote_RevertBlueprintMismatch() public {
@@ -198,27 +188,18 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuote(details, OPERATOR1_PK);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator1
-        });
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator1 });
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.QuoteBlueprintMismatch.selector, operator1, blueprintId, 999));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     function test_CreateFromQuote_RevertTTLMismatch() public {
@@ -228,49 +209,29 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuote(details, OPERATOR1_PK);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator1
-        });
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator1 });
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.QuoteTTLMismatch.selector, operator1, 100, 50));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     function test_CreateFromQuote_AddsPermittedCallers() public {
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            blueprintId,
-            100,
-            1 ether
-        );
+        Types.SignedQuote[] memory quotes = _createSingleQuote(operator1, OPERATOR1_PK, blueprintId, 100, 1 ether);
         address[] memory extraCallers = new address[](2);
         extraCallers[0] = user2;
         extraCallers[1] = operator2;
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            bytes("perm"),
-            extraCallers,
-            100
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, bytes("perm"), extraCallers, 100);
 
         assertTrue(tangle.isPermittedCaller(serviceId, user1));
         assertTrue(tangle.isPermittedCaller(serviceId, user2));
@@ -284,13 +245,8 @@ contract QuoteVerificationTest is BaseTest {
         quotes[1] = _createQuoteWithExposure(operator2, OPERATOR2_PK, blueprintId, 100, 2 ether, 8000);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 3 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 3 ether }(blueprintId, quotes, "", new address[](0), 100);
 
         Types.ServiceOperator memory op1Data = tangle.getServiceOperator(serviceId, operator1);
         Types.ServiceOperator memory op2Data = tangle.getServiceOperator(serviceId, operator2);
@@ -310,13 +266,8 @@ contract QuoteVerificationTest is BaseTest {
         quotes[1] = _createQuoteWithExposure(operator2, OPERATOR2_PK, blueprintId, 150, 1 ether, exposureB);
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 2 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            150
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 2 ether }(blueprintId, quotes, "", new address[](0), 150);
 
         Types.ServiceOperator memory op1Data = tangle.getServiceOperator(serviceId, operator1);
         Types.ServiceOperator memory op2Data = tangle.getServiceOperator(serviceId, operator2);
@@ -337,13 +288,8 @@ contract QuoteVerificationTest is BaseTest {
         uint256 totalCost = 4.5 ether;
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: totalCost }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: totalCost }(blueprintId, quotes, "", new address[](0), 100);
 
         assertTrue(tangle.isServiceActive(serviceId));
         assertTrue(tangle.isServiceOperator(serviceId, operator1));
@@ -359,13 +305,7 @@ contract QuoteVerificationTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.DuplicateOperatorQuote.selector, operator1));
-        tangle.createServiceFromQuotes{ value: 2 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 2 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     function test_CreateFromQuote_RevertNoQuotes() public {
@@ -373,13 +313,7 @@ contract QuoteVerificationTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(Errors.NoQuotes.selector);
-        tangle.createServiceFromQuotes(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes(blueprintId, quotes, "", new address[](0), 100);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -398,32 +332,18 @@ contract QuoteVerificationTest is BaseTest {
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.InsufficientPaymentForQuotes.selector, 2 ether, 1 ether));
         tangle.createServiceFromQuotes{ value: 1 ether }( // Only sending 1 ETH
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
+            blueprintId, quotes, "", new address[](0), 100
         );
     }
 
     function test_CreateFromQuote_RefundsExcessPayment() public {
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            blueprintId,
-            100,
-            1 ether
-        );
+        Types.SignedQuote[] memory quotes = _createSingleQuote(operator1, OPERATOR1_PK, blueprintId, 100, 1 ether);
 
         uint256 userBalanceBefore = user1.balance;
 
         vm.prank(user1);
         tangle.createServiceFromQuotes{ value: 5 ether }( // Overpaying
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
+            blueprintId, quotes, "", new address[](0), 100
         );
 
         // Should have been refunded 4 ETH
@@ -440,13 +360,7 @@ contract QuoteVerificationTest is BaseTest {
         );
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes(blueprintId, quotes, "", new address[](0), 100);
 
         assertTrue(tangle.isServiceActive(serviceId));
     }
@@ -457,25 +371,15 @@ contract QuoteVerificationTest is BaseTest {
         uint64 managedBlueprintId = _createBlueprintAsSender("ipfs://managed-rfq", address(manager));
         _registerForBlueprint(operator1, managedBlueprintId);
 
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            managedBlueprintId,
-            200,
-            2 ether
-        );
+        Types.SignedQuote[] memory quotes =
+            _createSingleQuote(operator1, OPERATOR1_PK, managedBlueprintId, 200, 2 ether);
         address[] memory permitted = new address[](1);
         permitted[0] = user2;
         bytes memory config = bytes("managed-config");
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 2 ether }(
-            managedBlueprintId,
-            quotes,
-            config,
-            permitted,
-            200
-        );
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 2 ether }(managedBlueprintId, quotes, config, permitted, 200);
 
         assertTrue(manager.requestCalled());
         assertTrue(manager.initCalled());
@@ -500,23 +404,12 @@ contract QuoteVerificationTest is BaseTest {
         uint64 managedBlueprintId = _createBlueprintAsSender("ipfs://managed-rfq-deny", address(manager));
         _registerForBlueprint(operator1, managedBlueprintId);
 
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            managedBlueprintId,
-            100,
-            1 ether
-        );
+        Types.SignedQuote[] memory quotes =
+            _createSingleQuote(operator1, OPERATOR1_PK, managedBlueprintId, 100, 1 ether);
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.TokenNotAllowed.selector, address(0)));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            managedBlueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(managedBlueprintId, quotes, "", new address[](0), 100);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -524,34 +417,16 @@ contract QuoteVerificationTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_CreateFromQuote_RevertReplayAttack() public {
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            blueprintId,
-            100,
-            1 ether
-        );
+        Types.SignedQuote[] memory quotes = _createSingleQuote(operator1, OPERATOR1_PK, blueprintId, 100, 1 ether);
 
         // First use succeeds
         vm.prank(user1);
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
 
         // Replay attack fails
         vm.prank(user2);
         vm.expectRevert(abi.encodeWithSelector(Errors.QuoteAlreadyUsed.selector, operator1));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
-        );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -567,27 +442,20 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuoteWithKey(details, unregisteredPk);
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
-        quotes[0] = Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: vm.addr(unregisteredPk)
-        });
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: vm.addr(unregisteredPk) });
 
         vm.prank(user1);
-        vm.expectRevert(abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, blueprintId, vm.addr(unregisteredPk)));
-        tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            new address[](0),
-            100
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, blueprintId, vm.addr(unregisteredPk))
         );
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -595,26 +463,14 @@ contract QuoteVerificationTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_CreateFromQuote_WithPermittedCallers() public {
-        Types.SignedQuote[] memory quotes = _createSingleQuote(
-            operator1,
-            OPERATOR1_PK,
-            blueprintId,
-            100,
-            1 ether
-        );
+        Types.SignedQuote[] memory quotes = _createSingleQuote(operator1, OPERATOR1_PK, blueprintId, 100, 1 ether);
 
         address[] memory callers = new address[](2);
         callers[0] = makeAddr("caller1");
         callers[1] = makeAddr("caller2");
 
         vm.prank(user1);
-        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(
-            blueprintId,
-            quotes,
-            "",
-            callers,
-            100
-        );
+        uint64 serviceId = tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", callers, 100);
 
         assertTrue(tangle.isPermittedCaller(serviceId, user1)); // Owner always permitted
         assertTrue(tangle.isPermittedCaller(serviceId, callers[0]));
@@ -631,7 +487,10 @@ contract QuoteVerificationTest is BaseTest {
         uint64 bpId,
         uint64 ttl,
         uint256 cost
-    ) internal returns (Types.SignedQuote[] memory) {
+    )
+        internal
+        returns (Types.SignedQuote[] memory)
+    {
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
         quotes[0] = _createQuote(operator, privateKey, bpId, ttl, cost);
         return quotes;
@@ -643,7 +502,10 @@ contract QuoteVerificationTest is BaseTest {
         uint64 bpId,
         uint64 ttl,
         uint256 cost
-    ) internal returns (Types.SignedQuote memory) {
+    )
+        internal
+        returns (Types.SignedQuote memory)
+    {
         uint64 baseTimestamp = uint64(block.timestamp) + quoteNonce;
         quoteNonce++;
         Types.QuoteDetails memory details = Types.QuoteDetails({
@@ -652,16 +514,13 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: cost,
             timestamp: baseTimestamp,
             expiry: baseTimestamp + 1 hours,
-            securityCommitments: new Types.AssetSecurityCommitment[](0)
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
 
         bytes memory signature = _signQuote(details, privateKey);
 
-        return Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator
-        });
+        return Types.SignedQuote({ details: details, signature: signature, operator: operator });
     }
 
     function _createQuoteWithExposure(
@@ -671,7 +530,10 @@ contract QuoteVerificationTest is BaseTest {
         uint64 ttl,
         uint256 cost,
         uint16 exposureBps
-    ) internal returns (Types.SignedQuote memory) {
+    )
+        internal
+        returns (Types.SignedQuote memory)
+    {
         uint64 baseTimestamp = uint64(block.timestamp) + quoteNonce;
         quoteNonce++;
         Types.QuoteDetails memory details = Types.QuoteDetails({
@@ -680,68 +542,69 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: cost,
             timestamp: baseTimestamp,
             expiry: baseTimestamp + 1 hours,
-            securityCommitments: new Types.AssetSecurityCommitment[](1)
+            securityCommitments: new Types.AssetSecurityCommitment[](1),
+            resourceCommitments: new Types.ResourceCommitment[](0)
         });
         details.securityCommitments[0] = Types.AssetSecurityCommitment({
-            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
-            exposureBps: exposureBps
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }), exposureBps: exposureBps
         });
 
         bytes memory signature = _signQuote(details, privateKey);
-        return Types.SignedQuote({
-            details: details,
-            signature: signature,
-            operator: operator
-        });
+        return Types.SignedQuote({ details: details, signature: signature, operator: operator });
     }
 
-    function _signQuote(
-        Types.QuoteDetails memory details,
-        uint256 privateKey
-    ) internal view returns (bytes memory) {
+    function _signQuote(Types.QuoteDetails memory details, uint256 privateKey) internal view returns (bytes memory) {
         return _signQuoteWithKey(details, privateKey);
     }
 
     function _signQuoteWithKey(
         Types.QuoteDetails memory details,
         uint256 privateKey
-    ) internal view returns (bytes memory) {
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
         bytes32 QUOTE_TYPEHASH = keccak256(
-            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
         );
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
+        bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
 
-        bytes32 domainSeparator = keccak256(abi.encode(
-            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-            keccak256("TangleQuote"),
-            keccak256("1"),
-            block.chainid,
-            address(tangle)
-        ));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("TangleQuote"),
+                keccak256("1"),
+                block.chainid,
+                address(tangle)
+            )
+        );
 
-        bytes32 structHash = keccak256(abi.encode(
-            QUOTE_TYPEHASH,
-            details.blueprintId,
-            details.ttlBlocks,
-            details.totalCost,
-            details.timestamp,
-            details.expiry,
-            commitmentsHash
-        ));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                QUOTE_TYPEHASH,
+                details.blueprintId,
+                details.ttlBlocks,
+                details.totalCost,
+                details.timestamp,
+                details.expiry,
+                commitmentsHash,
+                resourcesHash
+            )
+        );
 
-        bytes32 digest = keccak256(abi.encodePacked(
-            "\x19\x01",
-            domainSeparator,
-            structHash
-        ));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
     }
 
-    function _hashSecurityCommitments(
-        Types.AssetSecurityCommitment[] memory commitments
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitments(Types.AssetSecurityCommitment[] memory commitments)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32[] memory hashes = new bytes32[](commitments.length);
         for (uint256 i = 0; i < commitments.length; i++) {
             hashes[i] = _hashSecurityCommitment(commitments[i]);
@@ -753,16 +616,24 @@ contract QuoteVerificationTest is BaseTest {
         return out;
     }
 
-    function _hashSecurityCommitment(
-        Types.AssetSecurityCommitment memory commitment
-    ) internal pure returns (bytes32) {
+    function _hashSecurityCommitment(Types.AssetSecurityCommitment memory commitment) internal pure returns (bytes32) {
         bytes32 ASSET_TYPEHASH = keccak256("Asset(uint8 kind,address token)");
-        bytes32 COMMITMENT_TYPEHASH = keccak256(
-            "AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)"
-        );
-        bytes32 assetHash = keccak256(
-            abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token)
-        );
+        bytes32 COMMITMENT_TYPEHASH =
+            keccak256("AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)");
+        bytes32 assetHash = keccak256(abi.encode(ASSET_TYPEHASH, uint8(commitment.asset.kind), commitment.asset.token));
         return keccak256(abi.encode(COMMITMENT_TYPEHASH, assetHash, commitment.exposureBps));
+    }
+
+    function _hashResourceCommitments(Types.ResourceCommitment[] memory commitments) internal pure returns (bytes32) {
+        bytes32 RC_TYPEHASH = keccak256("ResourceCommitment(uint8 kind,uint64 count)");
+        bytes32[] memory hashes = new bytes32[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            hashes[i] = keccak256(abi.encode(RC_TYPEHASH, commitments[i].kind, commitments[i].count));
+        }
+        bytes32 out;
+        assembly ("memory-safe") {
+            out := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+        return out;
     }
 }

--- a/test/tangle/RFQPaymentDistribution.t.sol
+++ b/test/tangle/RFQPaymentDistribution.t.sol
@@ -100,7 +100,7 @@ contract RFQPaymentDistributionTest is BaseTest {
         tangle.submitResult(serviceId, callId, "result");
 
         // Developer should receive developerBps share
-        uint256 expectedDev = (payment * DEV_BPS) / 10000;
+        uint256 expectedDev = (payment * DEV_BPS) / 10_000;
         assertEq(developer.balance - devBalBefore, expectedDev, "developer should get 20% of RFQ payment");
     }
 
@@ -117,7 +117,7 @@ contract RFQPaymentDistributionTest is BaseTest {
         vm.prank(operator1);
         tangle.submitResult(serviceId, callId, "result");
 
-        uint256 expectedProtocol = (payment * PROTOCOL_BPS) / 10000;
+        uint256 expectedProtocol = (payment * PROTOCOL_BPS) / 10_000;
         assertEq(treasury.balance - treasuryBalBefore, expectedProtocol, "treasury should get 20% of RFQ payment");
     }
 
@@ -135,8 +135,8 @@ contract RFQPaymentDistributionTest is BaseTest {
 
         // Operator should have pending rewards.
         // No restakers → operator gets operatorBps + stakerBps (merged).
-        uint256 expectedOp = (payment * OPERATOR_BPS) / 10000;
-        uint256 expectedStaker = payment - (payment * DEV_BPS) / 10000 - (payment * PROTOCOL_BPS) / 10000 - expectedOp;
+        uint256 expectedOp = (payment * OPERATOR_BPS) / 10_000;
+        uint256 expectedStaker = payment - (payment * DEV_BPS) / 10_000 - (payment * PROTOCOL_BPS) / 10_000 - expectedOp;
         uint256 expectedTotal = expectedOp + expectedStaker; // No restakers → merged
         uint256 pending = tangle.pendingRewards(operator1);
 
@@ -243,8 +243,8 @@ contract RFQPaymentDistributionTest is BaseTest {
         tangle.submitResult(serviceId, callId, "result");
 
         // Developer gets DEV_BPS of each operator's price (applied independently)
-        uint256 expectedDev = (price1 * DEV_BPS) / 10000 + (price2 * DEV_BPS) / 10000;
-        uint256 expectedTreasury = (price1 * PROTOCOL_BPS) / 10000 + (price2 * PROTOCOL_BPS) / 10000;
+        uint256 expectedDev = (price1 * DEV_BPS) / 10_000 + (price2 * DEV_BPS) / 10_000;
+        uint256 expectedTreasury = (price1 * PROTOCOL_BPS) / 10_000 + (price2 * PROTOCOL_BPS) / 10_000;
 
         assertEq(developer.balance - devBefore, expectedDev, "dev gets split from each op's price");
         assertEq(treasury.balance - treasuryBefore, expectedTreasury, "treasury gets split from each op's price");
@@ -415,14 +415,12 @@ contract RFQPaymentDistributionTest is BaseTest {
         assertEq(tangle.pendingRewards(operator2), 0, "zero-price operator should get nothing");
 
         // Full payment distributed to operator1's split
-        uint256 devExpected = (price1 * DEV_BPS) / 10000;
-        uint256 treasuryExpected = (price1 * PROTOCOL_BPS) / 10000;
+        uint256 devExpected = (price1 * DEV_BPS) / 10_000;
+        uint256 treasuryExpected = (price1 * PROTOCOL_BPS) / 10_000;
         uint256 op1Pending = tangle.pendingRewards(operator1);
 
         assertEq(
-            devExpected + treasuryExpected + op1Pending,
-            price1,
-            "all funds accounted for with zero-price operator"
+            devExpected + treasuryExpected + op1Pending, price1, "all funds accounted for with zero-price operator"
         );
     }
 
@@ -448,11 +446,7 @@ contract RFQPaymentDistributionTest is BaseTest {
 
         // Excess sits in contract
         uint256 excess = overpay - quotePrice;
-        assertEq(
-            address(tangleProxy).balance,
-            contractBefore + overpay,
-            "contract holds full msg.value"
-        );
+        assertEq(address(tangleProxy).balance, contractBefore + overpay, "contract holds full msg.value");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -461,12 +455,8 @@ contract RFQPaymentDistributionTest is BaseTest {
 
     function test_RFQPayment_CustomSplitApplied() public {
         // Set a custom split: 10% dev, 5% protocol, 80% operator, 5% staker
-        Types.PaymentSplit memory customSplit = Types.PaymentSplit({
-            developerBps: 1000,
-            protocolBps: 500,
-            operatorBps: 8000,
-            stakerBps: 500
-        });
+        Types.PaymentSplit memory customSplit =
+            Types.PaymentSplit({ developerBps: 1000, protocolBps: 500, operatorBps: 8000, stakerBps: 500 });
         vm.prank(admin);
         tangle.setPaymentSplit(customSplit);
 
@@ -483,8 +473,8 @@ contract RFQPaymentDistributionTest is BaseTest {
         vm.prank(operator1);
         tangle.submitResult(serviceId, callId, "result");
 
-        assertEq(developer.balance - devBefore, (payment * 1000) / 10000, "custom dev split");
-        assertEq(treasury.balance - treasuryBefore, (payment * 500) / 10000, "custom protocol split");
+        assertEq(developer.balance - devBefore, (payment * 1000) / 10_000, "custom dev split");
+        assertEq(treasury.balance - treasuryBefore, (payment * 500) / 10_000, "custom protocol split");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -517,8 +507,8 @@ contract RFQPaymentDistributionTest is BaseTest {
         assertEq(devGot + treasuryGot + opPending, payment, "fuzz: total distributed must equal payment");
 
         // Dev gets floor(payment * 2000 / 10000)
-        assertEq(devGot, (payment * DEV_BPS) / 10000, "fuzz: developer share");
-        assertEq(treasuryGot, (payment * PROTOCOL_BPS) / 10000, "fuzz: protocol share");
+        assertEq(devGot, (payment * DEV_BPS) / 10_000, "fuzz: developer share");
+        assertEq(treasuryGot, (payment * PROTOCOL_BPS) / 10_000, "fuzz: protocol share");
     }
 
     function testFuzz_MultiOpRFQPaymentSplit(uint64 rawPrice1, uint64 rawPrice2) public {
@@ -549,11 +539,7 @@ contract RFQPaymentDistributionTest is BaseTest {
         uint256 op2Pending = tangle.pendingRewards(operator2);
 
         // All funds accounted for
-        assertEq(
-            devGot + treasuryGot + op1Pending + op2Pending,
-            total,
-            "fuzz multi-op: total must equal payment"
-        );
+        assertEq(devGot + treasuryGot + op1Pending + op2Pending, total, "fuzz multi-op: total must equal payment");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -577,9 +563,9 @@ contract RFQPaymentDistributionTest is BaseTest {
         vm.prank(operator1);
         tangle.submitResult(serviceId, callId, "result");
 
-        uint256 expectedDev = (payment * DEV_BPS) / 10000;
-        uint256 expectedProtocol = (payment * PROTOCOL_BPS) / 10000;
-        uint256 expectedOpBase = (payment * OPERATOR_BPS) / 10000;
+        uint256 expectedDev = (payment * DEV_BPS) / 10_000;
+        uint256 expectedProtocol = (payment * PROTOCOL_BPS) / 10_000;
+        uint256 expectedOpBase = (payment * OPERATOR_BPS) / 10_000;
         uint256 expectedStaker = payment - expectedDev - expectedProtocol - expectedOpBase;
 
         // No restakers → staker share merges into operator pending rewards
@@ -593,7 +579,7 @@ contract RFQPaymentDistributionTest is BaseTest {
 
     function test_RFQPayment_OddPaymentNoFundsLost() public {
         // Payment not cleanly divisible by split denominator (10000)
-        uint256 payment = 10001;
+        uint256 payment = 10_001;
 
         Types.SignedJobQuote[] memory quotes = new Types.SignedJobQuote[](1);
         quotes[0] = _createJobQuote(operator1, OPERATOR1_PK, serviceId, 0, payment);

--- a/test/tangle/ResourceCommitments.t.sol
+++ b/test/tangle/ResourceCommitments.t.sol
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BaseTest } from "../BaseTest.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { SignatureLib } from "../../src/libraries/SignatureLib.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
+/// @title ResourceCommitmentsTest
+/// @notice Tests for resource commitment storage and hashing during RFQ flows
+contract ResourceCommitmentsTest is BaseTest {
+    uint256 constant OPERATOR1_PK = 0x1;
+    uint256 constant OPERATOR2_PK = 0x2;
+
+    uint64 blueprintId;
+
+    function setUp() public override {
+        super.setUp();
+
+        operator1 = vm.addr(OPERATOR1_PK);
+        operator2 = vm.addr(OPERATOR2_PK);
+
+        vm.deal(operator1, 100 ether);
+        vm.deal(operator2, 100 ether);
+
+        vm.prank(developer);
+        blueprintId = _createBlueprintAsSender("ipfs://resource-test", address(0));
+
+        _registerOperator(operator1, 5 ether);
+        _registerOperator(operator2, 5 ether);
+        _registerForBlueprint(operator1, blueprintId);
+        _registerForBlueprint(operator2, blueprintId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // RESOURCE COMMITMENT HASH STORED ON-CHAIN
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_ResourceCommitmentHash_StoredOnCreation() public {
+        Types.ResourceCommitment[] memory resources = new Types.ResourceCommitment[](2);
+        resources[0] = Types.ResourceCommitment({ kind: 0, count: 4 }); // 4 CPU
+        resources[1] = Types.ResourceCommitment({ kind: 1, count: 8192 }); // 8192 MB memory
+
+        Types.SignedQuote[] memory quotes =
+            _createQuoteWithResources(OPERATOR1_PK, operator1, blueprintId, 100, 1 ether, resources);
+
+        vm.prank(user1);
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
+
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        bytes32 expectedHash = SignatureLib.hashResourceCommitments(resources);
+        assertEq(storedHash, expectedHash, "stored hash should match computed hash");
+        assertTrue(storedHash != bytes32(0), "hash should be non-zero");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENT EMITTED
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_ResourcesCommitted_EventEmitted() public {
+        Types.ResourceCommitment[] memory resources = new Types.ResourceCommitment[](1);
+        resources[0] = Types.ResourceCommitment({ kind: 5, count: 2 }); // 2 GPU
+
+        Types.SignedQuote[] memory quotes =
+            _createQuoteWithResources(OPERATOR1_PK, operator1, blueprintId, 100, 1 ether, resources);
+
+        vm.prank(user1);
+        tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
+
+        // Event is checked via the fact that no revert occurred and hash is stored
+        uint64 serviceId = tangle.serviceCount() - 1;
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        assertTrue(storedHash != bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EMPTY COMMITMENTS = NO HASH STORED (BACKWARD COMPAT)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_EmptyResourceCommitments_NoHashStored() public {
+        Types.SignedQuote[] memory quotes = _createQuoteNoResources(OPERATOR1_PK, operator1, blueprintId, 100, 1 ether);
+
+        vm.prank(user1);
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, quotes, "", new address[](0), 100);
+
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        assertEq(storedHash, bytes32(0), "empty commitments should not store hash");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EXTENSION UPDATES COMMITMENT HASH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_ExtensionUpdatesResourceCommitmentHash() public {
+        // Create service with initial resources
+        Types.ResourceCommitment[] memory resources1 = new Types.ResourceCommitment[](1);
+        resources1[0] = Types.ResourceCommitment({ kind: 0, count: 2 }); // 2 CPU
+
+        Types.SignedQuote[] memory createQuotes =
+            _createQuoteWithResources(OPERATOR1_PK, operator1, blueprintId, 100, 1 ether, resources1);
+
+        vm.prank(user1);
+        uint64 serviceId =
+            tangle.createServiceFromQuotes{ value: 1 ether }(blueprintId, createQuotes, "", new address[](0), 100);
+
+        bytes32 initialHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+
+        // Extend with new resources
+        Types.ResourceCommitment[] memory resources2 = new Types.ResourceCommitment[](1);
+        resources2[0] = Types.ResourceCommitment({ kind: 0, count: 8 }); // 8 CPU (upgraded)
+
+        Types.SignedQuote[] memory extendQuotes =
+            _createQuoteWithResources(OPERATOR1_PK, operator1, blueprintId, 50, 0.5 ether, resources2);
+
+        vm.prank(user1);
+        tangle.extendServiceFromQuotes{ value: 0.5 ether }(serviceId, extendQuotes, 50);
+
+        bytes32 updatedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        bytes32 expectedHash = SignatureLib.hashResourceCommitments(resources2);
+        assertEq(updatedHash, expectedHash, "hash should match new resources");
+        assertTrue(updatedHash != initialHash, "hash should have changed");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // HASH MATCHES LIBRARY OUTPUT
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_HashMatchesSignatureLibOutput() public {
+        Types.ResourceCommitment[] memory resources = new Types.ResourceCommitment[](3);
+        resources[0] = Types.ResourceCommitment({ kind: 0, count: 4 }); // CPU
+        resources[1] = Types.ResourceCommitment({ kind: 1, count: 16_384 }); // Memory
+        resources[2] = Types.ResourceCommitment({ kind: 2, count: 102_400 }); // Storage
+
+        bytes32 libHash = SignatureLib.hashResourceCommitments(resources);
+
+        // Manually compute expected hash
+        bytes32 RC_TYPEHASH = keccak256("ResourceCommitment(uint8 kind,uint64 count)");
+        bytes32[] memory hashes = new bytes32[](3);
+        hashes[0] = keccak256(abi.encode(RC_TYPEHASH, uint8(0), uint64(4)));
+        hashes[1] = keccak256(abi.encode(RC_TYPEHASH, uint8(1), uint64(16_384)));
+        hashes[2] = keccak256(abi.encode(RC_TYPEHASH, uint8(2), uint64(102_400)));
+
+        bytes32 expected;
+        assembly ("memory-safe") {
+            expected := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+
+        assertEq(libHash, expected, "library hash should match manual computation");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // GETTER RETURNS CORRECT HASH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_GetterReturnsZeroForUnknownService() public view {
+        bytes32 hash = tangle.getServiceResourceCommitmentHash(999, operator1);
+        assertEq(hash, bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function _createQuoteWithResources(
+        uint256 privateKey,
+        address operator,
+        uint64 bpId,
+        uint64 ttl,
+        uint256 cost,
+        Types.ResourceCommitment[] memory resources
+    )
+        internal
+        view
+        returns (Types.SignedQuote[] memory quotes)
+    {
+        Types.QuoteDetails memory details = Types.QuoteDetails({
+            blueprintId: bpId,
+            ttlBlocks: ttl,
+            totalCost: cost,
+            timestamp: uint64(block.timestamp),
+            expiry: uint64(block.timestamp + 1 hours),
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: resources
+        });
+
+        bytes memory signature = _signQuote(details, privateKey);
+        quotes = new Types.SignedQuote[](1);
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator });
+    }
+
+    function _createQuoteNoResources(
+        uint256 privateKey,
+        address operator,
+        uint64 bpId,
+        uint64 ttl,
+        uint256 cost
+    )
+        internal
+        view
+        returns (Types.SignedQuote[] memory quotes)
+    {
+        Types.QuoteDetails memory details = Types.QuoteDetails({
+            blueprintId: bpId,
+            ttlBlocks: ttl,
+            totalCost: cost,
+            timestamp: uint64(block.timestamp),
+            expiry: uint64(block.timestamp + 1 hours),
+            securityCommitments: new Types.AssetSecurityCommitment[](0),
+            resourceCommitments: new Types.ResourceCommitment[](0)
+        });
+
+        bytes memory signature = _signQuote(details, privateKey);
+        quotes = new Types.SignedQuote[](1);
+        quotes[0] = Types.SignedQuote({ details: details, signature: signature, operator: operator });
+    }
+
+    function _signQuote(Types.QuoteDetails memory details, uint256 privateKey) internal view returns (bytes memory) {
+        bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
+        bytes32 resourcesHash = SignatureLib.hashResourceCommitments(details.resourceCommitments);
+
+        bytes32 QUOTE_TYPEHASH = keccak256(
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+        );
+
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("TangleQuote"),
+                keccak256("1"),
+                block.chainid,
+                address(tangle)
+            )
+        );
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                QUOTE_TYPEHASH,
+                details.blueprintId,
+                details.ttlBlocks,
+                details.totalCost,
+                details.timestamp,
+                details.expiry,
+                commitmentsHash,
+                resourcesHash
+            )
+        );
+
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _hashSecurityCommitments(Types.AssetSecurityCommitment[] memory commitments)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes32[] memory hashes = new bytes32[](commitments.length);
+        for (uint256 i = 0; i < commitments.length; i++) {
+            bytes32 ASSET_TYPEHASH = keccak256("Asset(uint8 kind,address token)");
+            bytes32 COMMITMENT_TYPEHASH =
+                keccak256("AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)");
+            bytes32 assetHash =
+                keccak256(abi.encode(ASSET_TYPEHASH, uint8(commitments[i].asset.kind), commitments[i].asset.token));
+            hashes[i] = keccak256(abi.encode(COMMITMENT_TYPEHASH, assetHash, commitments[i].exposureBps));
+        }
+        bytes32 out;
+        assembly ("memory-safe") {
+            out := keccak256(add(hashes, 0x20), mul(mload(hashes), 0x20))
+        }
+        return out;
+    }
+}

--- a/test/tangle/ResourceRequirementsApproval.t.sol
+++ b/test/tangle/ResourceRequirementsApproval.t.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BaseTest } from "../BaseTest.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { SignatureLib } from "../../src/libraries/SignatureLib.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+
+/// @title ResourceRequirementsApprovalTest
+/// @notice Tests for resource requirements in the approval-based service request flow
+contract ResourceRequirementsApprovalTest is BaseTest {
+    uint64 blueprintId;
+
+    function setUp() public override {
+        super.setUp();
+
+        blueprintId = _createBlueprint(developer);
+
+        _registerOperator(operator1, 5 ether);
+        _registerOperator(operator2, 5 ether);
+        _registerForBlueprint(operator1, blueprintId);
+        _registerForBlueprint(operator2, blueprintId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT RESOURCE REQUIREMENTS — SET / GET
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_SetAndGetBlueprintResourceRequirements() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](2);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 }); // 4 CPU
+        reqs[1] = Types.ResourceCommitment({ kind: 1, count: 8192 }); // 8192 MB memory
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        Types.ResourceCommitment[] memory stored = tangle.getBlueprintResourceRequirements(blueprintId);
+        assertEq(stored.length, 2);
+        assertEq(stored[0].kind, 0);
+        assertEq(stored[0].count, 4);
+        assertEq(stored[1].kind, 1);
+        assertEq(stored[1].count, 8192);
+    }
+
+    function test_SetBlueprintResourceRequirements_RevertsNonOwner() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](1);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotBlueprintOwner.selector, blueprintId, user1));
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+    }
+
+    function test_SetBlueprintResourceRequirements_RevertsDuplicateKind() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](2);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+        reqs[1] = Types.ResourceCommitment({ kind: 0, count: 8 }); // duplicate kind
+
+        vm.prank(developer);
+        vm.expectRevert(Errors.InvalidState.selector);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+    }
+
+    function test_SetBlueprintResourceRequirements_RevertsZeroCount() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](1);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 0 });
+
+        vm.prank(developer);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+    }
+
+    function test_SetBlueprintResourceRequirements_CanClear() public {
+        // Set requirements
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](1);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        // Clear by setting empty array
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, new Types.ResourceCommitment[](0));
+
+        Types.ResourceCommitment[] memory stored = tangle.getBlueprintResourceRequirements(blueprintId);
+        assertEq(stored.length, 0);
+    }
+
+    function test_SetBlueprintResourceRequirements_CanOverwrite() public {
+        Types.ResourceCommitment[] memory reqs1 = new Types.ResourceCommitment[](1);
+        reqs1[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs1);
+
+        // Overwrite with different requirements
+        Types.ResourceCommitment[] memory reqs2 = new Types.ResourceCommitment[](2);
+        reqs2[0] = Types.ResourceCommitment({ kind: 0, count: 8 });
+        reqs2[1] = Types.ResourceCommitment({ kind: 5, count: 2 }); // GPU
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs2);
+
+        Types.ResourceCommitment[] memory stored = tangle.getBlueprintResourceRequirements(blueprintId);
+        assertEq(stored.length, 2);
+        assertEq(stored[0].count, 8);
+        assertEq(stored[1].kind, 5);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // APPROVAL FLOW — RESOURCE DEFAULTS AUTO-APPLIED
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_RequestService_AutoAppliesBlueprintDefaults() public {
+        // Set blueprint resource requirements
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](2);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 }); // CPU
+        reqs[1] = Types.ResourceCommitment({ kind: 1, count: 8192 }); // Memory
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        // Request service
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Check request-level resource requirements
+        Types.ResourceCommitment[] memory stored = tangle.getServiceRequestResourceRequirements(requestId);
+        assertEq(stored.length, 2);
+        assertEq(stored[0].kind, 0);
+        assertEq(stored[0].count, 4);
+        assertEq(stored[1].kind, 1);
+        assertEq(stored[1].count, 8192);
+    }
+
+    function test_ApprovalFlow_ResourceHashStoredOnActivation() public {
+        // Set blueprint resource requirements
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](2);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+        reqs[1] = Types.ResourceCommitment({ kind: 1, count: 8192 });
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        // Request + approve → activate
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+        _approveService(operator1, requestId);
+
+        uint64 serviceId = tangle.serviceCount() - 1;
+
+        // Verify hash stored for operator
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        bytes32 expectedHash = SignatureLib.hashResourceCommitments(reqs);
+        assertEq(storedHash, expectedHash, "stored hash should match computed hash");
+        assertTrue(storedHash != bytes32(0), "hash should be non-zero");
+    }
+
+    function test_ApprovalFlow_AllOperatorsGetSameHash() public {
+        // Set blueprint resource requirements
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](1);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        // Request with two operators
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        address[] memory callers = new address[](0);
+
+        vm.prank(user1);
+        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+
+        // Both approve
+        _approveService(operator1, requestId);
+        _approveService(operator2, requestId);
+
+        uint64 serviceId = tangle.serviceCount() - 1;
+
+        bytes32 hash1 = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        bytes32 hash2 = tangle.getServiceResourceCommitmentHash(serviceId, operator2);
+        assertEq(hash1, hash2, "all operators should get same hash");
+        assertTrue(hash1 != bytes32(0), "hash should be non-zero");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BACKWARD COMPATIBILITY — NO DEFAULTS = NO HASH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_NoResourceDefaults_NoHashStored() public {
+        // Blueprint has no resource requirements (default state)
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+        _approveService(operator1, requestId);
+
+        uint64 serviceId = tangle.serviceCount() - 1;
+
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        assertEq(storedHash, bytes32(0), "no resource defaults should mean no hash");
+    }
+
+    function test_NoResourceDefaults_EmptyRequestRequirements() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        Types.ResourceCommitment[] memory stored = tangle.getServiceRequestResourceRequirements(requestId);
+        assertEq(stored.length, 0, "no defaults should mean empty request requirements");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENT EMISSION
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_ResourcesCommitted_EventEmittedOnActivation() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](1);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+
+        vm.prank(developer);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Approve triggers activation — verify event is emitted via side effects
+        _approveService(operator1, requestId);
+
+        uint64 serviceId = tangle.serviceCount() - 1;
+        bytes32 storedHash = tangle.getServiceResourceCommitmentHash(serviceId, operator1);
+        assertTrue(storedHash != bytes32(0), "hash stored confirms activation with resources happened");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT RESOURCE REQUIREMENTS EVENT
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_BlueprintResourceRequirementsSet_EventEmitted() public {
+        Types.ResourceCommitment[] memory reqs = new Types.ResourceCommitment[](2);
+        reqs[0] = Types.ResourceCommitment({ kind: 0, count: 4 });
+        reqs[1] = Types.ResourceCommitment({ kind: 1, count: 8192 });
+
+        vm.prank(developer);
+        vm.expectEmit(true, false, false, true);
+        // event BlueprintResourceRequirementsSet(uint64 indexed blueprintId, uint256 count)
+        emit BlueprintResourceRequirementsSet(blueprintId, 2);
+        tangle.setBlueprintResourceRequirements(blueprintId, reqs);
+    }
+
+    // Re-declare event for expectEmit
+    event BlueprintResourceRequirementsSet(uint64 indexed blueprintId, uint256 count);
+}

--- a/test/tangle/ServiceLifecycleEdgeCases.t.sol
+++ b/test/tangle/ServiceLifecycleEdgeCases.t.sol
@@ -36,39 +36,85 @@ contract LifecycleMockBSM is BlueprintServiceManagerBase {
         tangleCore = _tangleCore;
     }
 
-    function onRegister(address, bytes calldata) external payable override onlyFromTangle {}
-    function onUnregister(address) external override onlyFromTangle {}
-    function onUpdatePreferences(address, bytes calldata) external payable override onlyFromTangle {}
+    function onRegister(address, bytes calldata) external payable override onlyFromTangle { }
+    function onUnregister(address) external override onlyFromTangle { }
+    function onUpdatePreferences(address, bytes calldata) external payable override onlyFromTangle { }
 
-    function onRequest(uint64, address, address[] calldata, bytes calldata, uint64, address, uint256) external payable override onlyFromTangle {
+    function onRequest(
+        uint64,
+        address,
+        address[] calldata,
+        bytes calldata,
+        uint64,
+        address,
+        uint256
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    {
         if (rejectRequests) revert("Request rejected by BSM");
     }
 
-    function onApprove(address, uint64, uint8) external payable override onlyFromTangle {}
-    function onReject(address, uint64) external override onlyFromTangle {}
+    function onApprove(address, uint64, uint8) external payable override onlyFromTangle { }
+    function onReject(address, uint64) external override onlyFromTangle { }
 
-    function onServiceInitialized(uint64, uint64, uint64, address, address[] calldata, uint64) external override onlyFromTangle {}
+    function onServiceInitialized(
+        uint64,
+        uint64,
+        uint64,
+        address,
+        address[] calldata,
+        uint64
+    )
+        external
+        override
+        onlyFromTangle
+    { }
 
     function onServiceTermination(uint64 serviceId, address) external override onlyFromTangle {
         terminationCount++;
         terminatedServices[serviceId] = true;
     }
 
-    function onJobCall(uint64 serviceId, uint8, uint64 jobCallId, bytes calldata) external payable override onlyFromTangle {
+    function onJobCall(
+        uint64 serviceId,
+        uint8,
+        uint64 jobCallId,
+        bytes calldata
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    {
         jobCallCount++;
         pendingJobs[serviceId][jobCallId] = true;
     }
 
-    function onJobResult(uint64 serviceId, uint8, uint64 jobCallId, address, bytes calldata, bytes calldata) external payable override onlyFromTangle {
+    function onJobResult(
+        uint64 serviceId,
+        uint8,
+        uint64 jobCallId,
+        address,
+        bytes calldata,
+        bytes calldata
+    )
+        external
+        payable
+        override
+        onlyFromTangle
+    {
         jobResultCount++;
         pendingJobs[serviceId][jobCallId] = false;
     }
 
-    function onUnappliedSlash(uint64, bytes calldata, uint8) external override onlyFromTangle {}
-    function onSlash(uint64, bytes calldata, uint8) external override onlyFromTangle {}
+    function onUnappliedSlash(uint64, bytes calldata, uint8) external override onlyFromTangle { }
+    function onSlash(uint64, bytes calldata, uint8) external override onlyFromTangle { }
 
-    function onOperatorJoined(uint64, address, uint16) external override onlyFromTangle {}
-    function onOperatorLeft(uint64, address) external override onlyFromTangle {}
+    function onOperatorJoined(uint64, address, uint16) external override onlyFromTangle { }
+    function onOperatorLeft(uint64, address) external override onlyFromTangle { }
 
     function canJoin(uint64, address) external view override returns (bool) {
         return !rejectJoins;
@@ -79,12 +125,12 @@ contract LifecycleMockBSM is BlueprintServiceManagerBase {
     }
 
     /// @notice Allow immediate exits for testing (no commitment/queue durations)
-    function getExitConfig(uint64) external pure override returns (
-        bool useDefault,
-        uint64 minCommitmentDuration,
-        uint64 exitQueueDuration,
-        bool forceExitAllowed
-    ) {
+    function getExitConfig(uint64)
+        external
+        pure
+        override
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed)
+    {
         return (false, 0, 0, false);
     }
 }
@@ -122,7 +168,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         });
 
         vm.prank(developer);
-        dynamicBlueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(mockBsm), dynamicConfig));
+        dynamicBlueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(mockBsm), dynamicConfig));
 
         // Register operators for both blueprints
         _registerForBlueprint(operator1, blueprintId);
@@ -180,7 +227,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 subBlueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://sub", address(0), subConfig));
+        uint64 subBlueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://sub", address(0), subConfig));
 
         _registerForBlueprint(operator1, subBlueprintId);
 
@@ -189,9 +237,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService{ value: 5 ether }(
-            subBlueprintId, ops, "", callers, 365 days, address(0), 5 ether
-        );
+        uint64 requestId =
+            tangle.requestService{ value: 5 ether }(subBlueprintId, ops, "", callers, 365 days, address(0), 5 ether);
 
         _approveService(operator1, requestId);
 
@@ -284,7 +331,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 limitedBpId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://limited", address(0), config));
+        uint64 limitedBpId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://limited", address(0), config));
 
         _registerForBlueprint(operator1, limitedBpId);
         _registerForBlueprint(operator2, limitedBpId);
@@ -307,7 +355,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         // operator3 tries to join but max reached
         vm.prank(operator3);
         vm.expectRevert(Errors.InvalidState.selector);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
     }
 
     function test_LeaveService_AtMinOperators_Reverts() public {
@@ -324,7 +372,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         LifecycleMockBSM localBsm = new LifecycleMockBSM();
         vm.prank(developer);
-        uint64 minOpBpId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://minop", address(localBsm), config));
+        uint64 minOpBpId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://minop", address(localBsm), config));
 
         _registerForBlueprint(operator1, minOpBpId);
         _registerForBlueprint(operator2, minOpBpId);
@@ -356,7 +405,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         vm.prank(operator2);
         vm.expectRevert(Errors.Unauthorized.selector);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
     }
 
     function test_LeaveService_BSMRejects() public {
@@ -364,7 +413,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         // operator2 joins
         vm.prank(operator2);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
 
         mockBsm.setRejectLeaves(true);
 
@@ -384,8 +433,10 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         // Operator is registered with staking but not for this blueprint
         vm.prank(unregisteredOp);
-        vm.expectRevert(abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, dynamicBlueprintId, unregisteredOp));
-        tangle.joinService(serviceId, 10000);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, dynamicBlueprintId, unregisteredOp)
+        );
+        tangle.joinService(serviceId, 10_000);
     }
 
     function test_JoinService_AlreadyInService_Reverts() public {
@@ -394,7 +445,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         // operator1 is already in service from creation
         vm.prank(operator1);
         vm.expectRevert(Errors.InvalidState.selector);
-        tangle.joinService(serviceId, 10000);
+        tangle.joinService(serviceId, 10_000);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -514,8 +565,9 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         // Behavior depends on implementation - may allow or reject duplicates
         // This tests the actual behavior
         try tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0) {
-            // If it succeeds, verify service state
-        } catch {
+        // If it succeeds, verify service state
+        }
+            catch {
             // If it fails, that's also a valid behavior
         }
     }

--- a/test/tangle/ServicesExitFlow.t.sol
+++ b/test/tangle/ServicesExitFlow.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {BaseTest} from "../BaseTest.sol";
-import {Types} from "../../src/libraries/Types.sol";
-import {Errors} from "../../src/libraries/Errors.sol";
-import {BlueprintServiceManagerBase} from "../../src/BlueprintServiceManagerBase.sol";
+import { BaseTest } from "../BaseTest.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+import { BlueprintServiceManagerBase } from "../../src/BlueprintServiceManagerBase.sol";
 
 contract CustomExitManager is BlueprintServiceManagerBase {
     uint64 public constant MIN_COMMITMENT = 0;
@@ -135,7 +135,8 @@ contract ServicesExitFlowTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 blueprintId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic-exit", manager, config));
+        uint64 blueprintId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic-exit", manager, config));
 
         _registerOperator(operator1, 5 ether);
         _registerOperator(operator2, 5 ether);

--- a/test/tangle/Slashing.t.sol
+++ b/test/tangle/Slashing.t.sol
@@ -441,7 +441,7 @@ contract SlashingTest is BaseTest {
 
     function test_SetSlashConfig_UpdatesDisputeWindow() public {
         vm.prank(admin);
-        tangle.setSlashConfig(14 days, false, 10000);
+        tangle.setSlashConfig(14 days, false, 10_000);
 
         // New proposal should use updated window
         vm.prank(user1);
@@ -455,12 +455,12 @@ contract SlashingTest is BaseTest {
         // Too short
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(30 minutes, false, 10000);
+        tangle.setSlashConfig(30 minutes, false, 10_000);
 
         // Too long
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(60 days, false, 10000);
+        tangle.setSlashConfig(60 days, false, 10_000);
     }
 
     function test_SetSlashConfig_RevertInvalidMaxSlash() public {
@@ -470,7 +470,7 @@ contract SlashingTest is BaseTest {
 
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(7 days, false, 15000); // > 100%
+        tangle.setSlashConfig(7 days, false, 15_000); // > 100%
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/tangle/SlashingEdgeCases.t.sol
+++ b/test/tangle/SlashingEdgeCases.t.sol
@@ -246,7 +246,8 @@ contract SlashingEdgeCasesTest is BaseTest {
             subscriptionInterval: 0,
             eventRate: 0
         });
-        uint64 dynamicBpId = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
+        uint64 dynamicBpId =
+            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://dynamic", address(0), config));
 
         // Register operator2
         _registerOperator(operator2, 5 ether);
@@ -329,7 +330,7 @@ contract SlashingEdgeCasesTest is BaseTest {
     function test_CustomSlashingWindow_ShortWindow() public {
         // Set short dispute window
         vm.prank(admin);
-        tangle.setSlashConfig(1 hours, false, 10000);
+        tangle.setSlashConfig(1 hours, false, 10_000);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
@@ -347,7 +348,7 @@ contract SlashingEdgeCasesTest is BaseTest {
     function test_CustomSlashingWindow_LongWindow() public {
         // Set long dispute window
         vm.prank(admin);
-        tangle.setSlashConfig(30 days, false, 10000);
+        tangle.setSlashConfig(30 days, false, 10_000);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
@@ -381,7 +382,8 @@ contract SlashingEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(exposureBpId, ops, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestServiceWithExposure(exposureBpId, ops, exposures, "", callers, 0, address(0), 0);
 
         _approveService(operator1, requestId);
 


### PR DESCRIPTION
## Summary

- Operators can now include `ResourceCommitment[]` (CPU, memory, storage, GPU, etc.) in their EIP-712 signed quotes
- Commitment hash stored on-chain per operator per service for QoS dispute evidence
- `getServiceResourceCommitmentHash()` view function for dispute resolution
- Includes `forge fmt` across codebase

## Key changes

- `Types.sol`: New `ResourceCommitment` struct, extended `QuoteDetails`, removed unused `ResourcePricing`
- `SignatureLib.sol`: Updated EIP-712 typehashes and hashing for `ResourceCommitment[]`
- `TangleStorage.sol`: New `_serviceResourceCommitmentHash` mapping
- `Quotes.sol`, `QuotesCreate.sol`, `QuotesExtend.sol`: Store hashes + emit `ResourcesCommitted` events
- Facet selectors updated for new ABI
- New `ResourceCommitments.t.sol` test suite (6 tests)

## Test plan

- [x] All 1416 existing tests pass
- [x] 6 new resource commitment tests pass
- [x] `forge build` succeeds
- [x] `forge fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)