### PR TITLE
docs: whitepaper audit fixes — 4 critical corrections, 10 missing sections

### DIFF
--- a/whitepaper/tangle-cloud.tex
+++ b/whitepaper/tangle-cloud.tex
@@ -67,7 +67,7 @@ Every interaction with Tangle Cloud products generates economic activity that ac
     \item[Operators] provide compute by staking tokens and running infrastructure. They earn fees proportional to services provided, and can serve more services as they accumulate more stake.
     \item[Developers] create blueprints defining service behavior and earn from fee splits and inflation rewards proportional to adoption.
     \item[Delegators] provide additional stake to operators and share in operator rewards proportional to their delegation.
-    \item[Protocol] captures a governance-controlled fee (currently 10\%) funding development, security audits, and ecosystem growth.
+    \item[Protocol] captures a governance-controlled fee (currently 20\%) funding development, security audits, and ecosystem growth.
 \end{description}
 
 \subsection{Network Effects}
@@ -234,18 +234,20 @@ Users return to ongoing projects, review agent work, provide feedback, and itera
 
 \subsection{Technical Architecture}
 
-The workbench connects to the sandbox runtime through the protocol:
+The current workbench implementation uses a centralized client-server architecture:
 
 \begin{enumerate}[noitemsep]
-    \item User initiates coding session
-    \item Workbench requests service from operator via RFQ
-    \item Operator provisions sandbox container with specified isolation
-    \item P2P connection established (see \textit{Blueprint SDK Guide}, P2P Networking)
-    \item User inputs flow to agent; outputs flow back via gossipsub
+    \item User initiates coding session via the web application
+    \item An orchestrator service provisions and manages sandbox containers
+    \item WebSocket connections carry user inputs to the agent and stream outputs back
+    \item The orchestrator handles container lifecycle, auto-scaling, and resource allocation
+    \item A collaboration server enables real-time multiplayer features
     \item Protocol handles payment splits (developer, operator, delegator, protocol)
 \end{enumerate}
 
-The user sees a seamless environment; the decentralized infrastructure operates through the same mechanisms described in the \textit{Tangle Protocol Specification}, blueprints define the workbench service, operators stake to provide compute, and slashing conditions enforce isolation guarantees.
+The orchestrator manages container provisioning, health monitoring, and session routing. This centralized architecture provides reliable performance and simplified operations during the current phase of development.
+
+\textbf{Target architecture.} The roadmap calls for progressive decentralization of the workbench infrastructure. In the target architecture, session provisioning will use the protocol's RFQ marketplace for operator selection, operators will stake assets and compete to serve workbench sessions, and P2P communication (gossipsub) will replace the centralized WebSocket relay. This transition will bring the workbench in line with the cryptoeconomic accountability model described in the \textit{Tangle Protocol Specification}. The centralized orchestrator will be replaced by protocol-level coordination, where blueprints define the workbench service, operators stake to provide compute, and slashing conditions enforce isolation guarantees.
 
 \subsection{Collaborative Features}
 

--- a/whitepaper/tangle-protocol.tex
+++ b/whitepaper/tangle-protocol.tex
@@ -98,7 +98,7 @@ Six principles guide Tangle's design. Each addresses a specific failure mode in 
 
 The dominant model for AI infrastructure concentrates value in platform operators. Cloud providers capture margin on every API call. Platforms retain customer relationships, reducing developers and operators to commoditized inputs.
 
-Tangle inverts this model. Value flows to those who create it: developers earn from blueprints, operators earn from compute, delegators earn from stake. The protocol captures only a governance-controlled fee (currently 10\%) funding ongoing development. This fee is not rent but payment for coordination.
+Tangle inverts this model. Value flows to those who create it: developers earn from blueprints, operators earn from compute, delegators earn from stake. The protocol captures only a governance-controlled fee (currently 20\%) funding ongoing development. This fee is not rent but payment for coordination.
 
 The inflation distribution allocates 25\% to developers and 25\% to operators, ensuring both blueprint creators and compute providers share in network growth. Payment splits route value to participants who earned it. Governance grants voting power proportional to stake.
 
@@ -279,11 +279,19 @@ Operators configure delegation mode:
     \item \textbf{Open}: Any address may delegate
 \end{itemize}
 
+\subsection{Liquid Delegation Vaults}
+
+Tangle implements liquid delegation through \texttt{LiquidDelegationVault}, an ERC-7540 compliant vault enabling asynchronous deposit and redemption of delegation positions. Delegators deposit assets and receive vault shares representing their proportional claim on the operator's staked position. These shares are transferable, enabling liquid delegation positions that can be used in DeFi while the underlying assets remain staked.
+
+The vault uses asynchronous request-fulfill flow per ERC-7540: delegators submit deposit or redemption requests, which are fulfilled after the protocol's delay periods (28 rounds for delegators). A virtual share offset ($V = 10^3$) prevents first-depositor attacks on the share exchange rate. When slashing occurs, total vault assets decrease while shares remain constant, automatically distributing losses proportionally across all vault participants.
+
 \subsection{Exposure Selection}
 
 When operators approve service requests, they commit an exposure in basis points (0-10000). This determines what fraction of stake backs the service.
 
 Exposure has two consequences: it determines reward share (higher exposure = more rewards) and bounds slashing (operators lose at most their committed percentage).
+
+The protocol's \texttt{ExposureManager} implements granular per-asset exposure tracking. Rather than a single exposure value per operator per service, the system maintains exposure limits for each staked asset independently. Operators can configure per-asset exposure caps, and services can specify minimum and maximum exposure requirements per asset type. The \texttt{ExposureCalculator} computes effective exposure across an operator's portfolio, enabling precise risk management when operators participate in multiple services with different collateral compositions.
 
 This design enables participation in multiple services with bounded total risk.
 
@@ -482,6 +490,12 @@ Six Months & 1.6x \\
 
 A delegator's score is amount $\times$ multiplier. Rewards distribute proportionally using accumulated-per-share accounting for O(1) efficiency.
 
+\subsection{Streaming Payments}
+
+For subscription-based services, the \texttt{StreamingPaymentManager} distributes payments continuously over the service's time-to-live (TTL) rather than as a lump sum. When a customer funds a service, the payment enters a stream that releases tokens proportionally as time elapses. Operators can claim accrued payments at any point. If a service terminates early, unstreamed funds return to the customer.
+
+This mechanism aligns payment with service delivery: operators earn as they work, customers pay only for time consumed, and early termination automatically handles refunds without manual intervention.
+
 \subsection{Developer Rewards}
 
 Developers earn from service fees and inflation rewards through scoring:
@@ -523,11 +537,12 @@ Stakers (delegators) & 40\% \\
 Operators (performance) & 25\% \\
 Developers (merit) & 25\% \\
 Customers (usage) & 10\% \\
+Restakers (exposure rewards) & 0\% \\
 \bottomrule
 \end{tabular}
 \end{center}
 
-Governance can adjust weights to steer network growth.
+The protocol defines five distribution categories. The restaker category exists for future activation via governance to reward participants who restake assets from external protocols (e.g., beacon chain validators). It is currently set to 0\% but can be activated by adjusting weights. Governance can adjust all weights to steer network growth.
 
 \subsection{Operator Scoring}
 
@@ -550,7 +565,7 @@ Slashing provides consequences for misbehavior, making economic security meaning
 
 The protocol provides slashing mechanism; developers define when to use it. Each service type has different requirements the protocol cannot anticipate.
 
-Developers implement conditions through hooks: \texttt{querySlashingOrigin} specifies who may propose slashes; \texttt{onSlash} executes when slashing finalizes.
+Developers implement conditions through hooks: \texttt{querySlashingOrigin} specifies who may propose slashes; \texttt{onUnappliedSlash} executes when slashing finalizes.
 
 \subsection{The Dispute Window}
 
@@ -675,6 +690,10 @@ Governance controls comprehensive protocol parameters:
 Contract upgrades use UUPS (Universal Upgradeable Proxy Standard). Each upgradeable contract (Tangle, MultiAssetDelegation, InflationPool) deploys behind a proxy. Upgrading replaces implementation while preserving storage.
 
 UUPS places upgrade logic in implementation rather than proxy, reducing proxy size and attack surface. UUPS allows disabling upgradeability if desired. Upgrades follow standard governance with longest timelock (7 days) and highest scrutiny.
+
+\subsubsection{Diamond/Facet Architecture}
+
+The core Tangle contracts use a diamond pattern (EIP-2535) to manage code complexity. The protocol's functionality is split across approximately 20 facets, each handling a specific domain: staking, delegation, slashing, service lifecycle, blueprint management, exposure, rewards, and governance. Facets share storage through a unified diamond proxy, enabling atomic cross-domain operations while keeping individual facet code auditable and upgradeable independently. Developers interacting with the protocol should be aware that function selectors route through the diamond proxy to the appropriate facet implementation.
 
 Upgrades are the most powerful governance action. A malicious upgrade could drain funds or disable slashing. Every upgrade proposal should be treated as dangerous until proven otherwise.
 
@@ -889,6 +908,14 @@ Developer rewards & Protocol inflation & None & None & None \\
 \textbf{Choose Karak} when: your application spans multiple chains and needs unified security across them.
 
 \textbf{Choose Tangle} when: you're building compute services (AI, data processing, automation), you want SDK tooling for rapid development, you need granular exposure control, or you're building at scale requiring O(1) operations.
+
+%==============================================================================
+\section{Beacon Chain Integration}
+%==============================================================================
+
+Tangle includes a beacon chain module enabling Ethereum validators to restake their beacon chain credentials. The \texttt{ValidatorPodManager} manages \texttt{ValidatorPod} contracts that verify beacon chain proofs (withdrawal credentials, balance snapshots, validator status) to attest restaked ETH positions. Validators deploy a pod, point their withdrawal credentials to it, and gain restaking capacity proportional to their beacon chain balance.
+
+For cross-layer slashing enforcement, the \texttt{L2SlashingConnector} and \texttt{L2SlashingReceiver} bridge slashing decisions between L1 and L2 deployments. A \texttt{TangleL2Slasher} executes slashing on L2 based on L1-originated proofs. This architecture enables ETH validator restaking on Tangle regardless of which layer the services operate on.
 
 %==============================================================================
 \section{Conclusion}

--- a/whitepaper/tangle-protocol.tex
+++ b/whitepaper/tangle-protocol.tex
@@ -323,15 +323,30 @@ Request-for-quote asks operators to provide binding prices for specific requests
 
 \subsection{The RFQ Flow}
 
-Operators register with ECDSA keys and RPC endpoints. They run software that listens for quote requests and returns signed quotes containing:
+Operators register with ECDSA and BLS keys and RPC endpoints. They run software that listens for quote requests and returns signed quotes containing:
 \begin{itemize}[noitemsep]
     \item Blueprint ID and service duration (TTL)
     \item Total cost and payment token
     \item Timestamp and expiry
-    \item Security commitments (exposure per asset)
+    \item Security commitments (per-asset exposure commitments)
+    \item Resource pricing breakdown
 \end{itemize}
 
 Customers collect quotes, verify terms, and submit all quotes in a single transaction. The protocol verifies signatures, checks expiry and replay protection, validates registrations, and confirms payment.
+
+\subsection{Resource Pricing}
+
+Quotes include granular resource pricing via \texttt{ResourcePricing} entries. Each entry specifies a resource kind (CPU, MemoryMB, StorageMB, GPU), a quantity, and a per-unit price in the payment token. This enables customers to compare operators on a per-resource basis rather than opaque flat rates.
+
+Operators competing for the same blueprint quote different resource prices based on their hardware, utilization, and margins. A GPU-heavy AI inference operator prices GPU cycles competitively but charges more for storage; a lightweight oracle operator offers low CPU prices. The market discovers efficient pricing without protocol-imposed schedules.
+
+\subsection{Security Commitments and Developer Requirements}
+
+Quotes include \texttt{AssetSecurityCommitment} entries specifying the exact exposure (in basis points) the operator pledges per staked asset. These commitments are binding: once accepted, the operator's stake is locked at the committed exposure level for the service duration.
+
+Blueprint developers control the security floor through \texttt{AssetSecurityRequirement} entries on their blueprint, specifying minimum and maximum exposure per asset type. An AI training blueprint might require at least 50\% exposure on staked ETH; a lightweight notification service might cap exposure at 5\%. Quotes that fail to meet these requirements are rejected at the protocol level.
+
+This two-sided mechanism gives developers fine-grained control over the economic security backing their service, while operators retain flexibility to differentiate on price and risk appetite within those bounds.
 
 \subsection{Quote Security}
 
@@ -566,6 +581,8 @@ Slashing provides consequences for misbehavior, making economic security meaning
 The protocol provides slashing mechanism; developers define when to use it. Each service type has different requirements the protocol cannot anticipate.
 
 Developers implement conditions through hooks: \texttt{querySlashingOrigin} specifies who may propose slashes; \texttt{onUnappliedSlash} executes when slashing finalizes.
+
+Combined with the SDK's QoS package (see \textit{Blueprint SDK Guide}, Quality of Service), developers can build automated SLA enforcement. QoS monitors collect operator metrics (heartbeat, latency, availability, throughput). When metrics breach developer-defined thresholds, the monitor proposes a slash through the protocol. The blueprint's \texttt{querySlashingOrigin} hook authorizes the monitor, and the dispute window gives operators recourse. This creates a closed loop: developers set quality requirements, operators commit resources, QoS measures compliance, and slashing enforces consequences.
 
 \subsection{The Dispute Window}
 

--- a/whitepaper/tangle-sdk.tex
+++ b/whitepaper/tangle-sdk.tex
@@ -213,7 +213,7 @@ Blueprints customize protocol behavior through hooks, functions called at specif
     \item[onRegister] validates operator registrations. A blueprint for AI services might require operators to prove GPU capability.
     \item[onRequest] validates service requests. A membership service might verify the customer's eligibility.
     \item[onApprove] processes operator approvals. A DeFi service might lock collateral or initialize state.
-    \item[onSlash] executes custom slashing logic. A threshold service might redistribute key shares.
+    \item[onUnappliedSlash] executes custom slashing logic when a slash is finalized. A threshold service might redistribute key shares.
     \item[onServiceTermination] handles cleanup. A subscription service might finalize billing.
 \end{description}
 
@@ -266,7 +266,7 @@ contract MyBlueprintBSM is BlueprintServiceManagerBase {
     }
 
     // Handle slashing events
-    function onSlash(
+    function onUnappliedSlash(
         uint64 serviceId,
         bytes calldata offender,
         uint8 slashPercent
@@ -282,6 +282,16 @@ contract MyBlueprintBSM is BlueprintServiceManagerBase {
     }
 }
 \end{lstlisting}
+
+\subsection{Blueprint Extensions}
+
+The SDK provides base contracts that extend \texttt{BlueprintServiceManagerBase} with reusable economic mechanics:
+
+\textbf{TokenizedBlueprintBase} enables blueprints to issue community tokens tied to their service. Operators and users can stake these tokens to earn Synthetix-style staking rewards, creating aligned incentives around blueprint adoption. The base contract handles token issuance, staking accounting, and reward distribution.
+
+\textbf{BuybackBlueprintBase} adds AMM buyback mechanics. A portion of service fees is automatically used to buy back the blueprint's community token on decentralized exchanges, creating sustained demand. Blueprint developers configure the buyback percentage and target AMM pool.
+
+These extensions compose with each other and with custom hooks, enabling blueprints to build sophisticated token economies around their services.
 
 \subsection{Slashing Customization}
 


### PR DESCRIPTION
## Summary

Automated audit cross-referenced all three whitepapers against the codebase. This PR fixes every finding.

### Critical Fixes (4)
- **Protocol fee:** 10% → 20% (intro contradicted fee table, code confirms 20%)
- **`onSlash` → `onUnappliedSlash`** — hook name was wrong in SDK guide
- **Workbench architecture:** P2P gossipsub → client-server WebSocket (reflects reality, decentralization framed as roadmap)
- **Decentralization status:** honest about current centralized orchestrator

### Added Sections (10)
- Liquid Delegation Vaults (ERC-7540)
- Diamond/facet architecture (EIP-2535)
- Restaker inflation category (5th bucket, currently 0%)
- Per-asset ExposureManager
- Blueprint extensions (TokenizedBlueprintBase, BuybackBlueprintBase)
- Beacon chain integration (ValidatorPodManager, L2 slashing bridge)
- Streaming payments over service TTL
- Resource pricing (per-resource granular pricing in RFQ)
- Security commitments + developer requirements
- QoS → slashing enforcement loop

### Also
- Removed the original 78-page monolithic whitepaper from the repo

Audit notes: `memory/whitepaper-audit.md` in workspace