### PR TITLE
Harden payment semantics and add subscription escrow withdrawal

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,16 @@ evm_version = "cancun"
 via_ir = true
 allow_internal_expect_revert = true
 
+[profile.fast]
+# Local iteration profile: much faster compile/test cycles.
+# Use with: `FOUNDRY_PROFILE=fast forge test ...`
+via_ir = true
+optimizer = false
+sparse_mode = true
+gas_reports = []
+fuzz = { runs = 256 }
+invariant = { runs = 64, depth = 64, fail_on_revert = false }
+
 [profile.coverage]
 via_ir = true
 optimizer = true

--- a/src/core/JobsRFQ.sol
+++ b/src/core/JobsRFQ.sol
@@ -84,6 +84,10 @@ abstract contract JobsRFQ is Base {
         uint64 effectiveMaxQuoteAge = _maxQuoteAge > 0 ? _maxQuoteAge : ProtocolConfig.MAX_QUOTE_AGE;
         uint256 totalPrice = _verifyQuotesAndRecordOperators(serviceId, jobIndex, quotes, effectiveMaxQuoteAge);
 
+        if (totalPrice > 0 && !_isPaymentAssetAllowedByManager(bp.manager, serviceId, address(0))) {
+            revert Errors.TokenNotAllowed(address(0));
+        }
+
         // Collect payment
         PaymentLib.collectPayment(address(0), totalPrice, msg.value);
         _recordPayment(msg.sender, serviceId, address(0), totalPrice);

--- a/src/core/JobsSubmission.sol
+++ b/src/core/JobsSubmission.sol
@@ -156,6 +156,10 @@ abstract contract JobsSubmission is Base {
         if (svc.pricing == Types.PricingModel.EventDriven) {
             uint256 perJob = _jobEventRates[svc.blueprintId][jobIndex];
             payment = perJob > 0 ? perJob : _blueprintConfigs[svc.blueprintId].eventRate;
+            address manager = _blueprints[svc.blueprintId].manager;
+            if (payment > 0 && !_isPaymentAssetAllowedByManager(manager, serviceId, address(0))) {
+                revert Errors.TokenNotAllowed(address(0));
+            }
             PaymentLib.collectPayment(address(0), payment, msgValue);
             _recordPayment(payer, serviceId, address(0), payment);
         }

--- a/src/facets/tangle/TanglePaymentsFacet.sol
+++ b/src/facets/tangle/TanglePaymentsFacet.sol
@@ -10,25 +10,26 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 /// @dev Implements effective exposure payment distribution for accurate security-weighted payments
 contract TanglePaymentsFacet is Payments, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](18);
+        selectorList = new bytes4[](19);
         selectorList[0] = this.fundService.selector;
-        selectorList[1] = this.billSubscription.selector;
-        selectorList[2] = this.billSubscriptionBatch.selector;
-        selectorList[3] = this.getBillableServices.selector;
-        selectorList[4] = bytes4(keccak256("claimRewards()"));
-        selectorList[5] = bytes4(keccak256("claimRewards(address)"));
-        selectorList[6] = bytes4(keccak256("claimRewardsBatch(address[])"));
-        selectorList[7] = bytes4(keccak256("claimRewardsAll()"));
-        selectorList[8] = bytes4(keccak256("pendingRewards(address)"));
-        selectorList[9] = bytes4(keccak256("pendingRewards(address,address)"));
-        selectorList[10] = bytes4(keccak256("rewardTokens(address)"));
-        selectorList[11] = this.setPaymentSplit.selector;
-        selectorList[12] = this.setTreasury.selector;
-        selectorList[13] = this.paymentSplit.selector;
-        selectorList[14] = this.treasury.selector;
-        selectorList[15] = this.getServiceEscrow.selector;
-        selectorList[16] = this.distributePayment.selector;
-        selectorList[17] = this.depositToEscrow.selector;
+        selectorList[1] = this.withdrawRemainingEscrow.selector;
+        selectorList[2] = this.billSubscription.selector;
+        selectorList[3] = this.billSubscriptionBatch.selector;
+        selectorList[4] = this.getBillableServices.selector;
+        selectorList[5] = bytes4(keccak256("claimRewards()"));
+        selectorList[6] = bytes4(keccak256("claimRewards(address)"));
+        selectorList[7] = bytes4(keccak256("claimRewardsBatch(address[])"));
+        selectorList[8] = bytes4(keccak256("claimRewardsAll()"));
+        selectorList[9] = bytes4(keccak256("pendingRewards(address)"));
+        selectorList[10] = bytes4(keccak256("pendingRewards(address,address)"));
+        selectorList[11] = bytes4(keccak256("rewardTokens(address)"));
+        selectorList[12] = this.setPaymentSplit.selector;
+        selectorList[13] = this.setTreasury.selector;
+        selectorList[14] = this.paymentSplit.selector;
+        selectorList[15] = this.treasury.selector;
+        selectorList[16] = this.getServiceEscrow.selector;
+        selectorList[17] = this.distributePayment.selector;
+        selectorList[18] = this.depositToEscrow.selector;
     }
 
     /// @notice Distribute payment using effective exposures (delegation × exposureBps)

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -212,6 +212,9 @@ interface ITangleServices {
     /// @notice Fund a service escrow balance
     function fundService(uint64 serviceId, uint256 amount) external payable;
 
+    /// @notice Withdraw remaining escrow after termination
+    function withdrawRemainingEscrow(uint64 serviceId) external;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -121,6 +121,9 @@ library Errors {
     /// @notice Service is not active
     error ServiceNotActive(uint64 serviceId);
 
+    /// @notice Service is not terminated
+    error ServiceNotTerminated(uint64 serviceId);
+
     /// @notice Service has expired
     error ServiceExpired(uint64 serviceId);
 
@@ -221,6 +224,11 @@ library Errors {
     /// @notice Insufficient payment sent
     error InsufficientPayment(uint256 required, uint256 sent);
 
+    /// @notice msg.value does not match expected payment semantics
+    /// @dev For native payments: expected == required amount.
+    ///      For ERC20 payments: expected == 0.
+    error InvalidMsgValue(uint256 expected, uint256 sent);
+
     /// @notice Payment transfer failed
     error PaymentFailed();
 
@@ -293,10 +301,6 @@ library Errors {
 
     /// @notice Quote already used (replay protection)
     error QuoteAlreadyUsed(address operator);
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // ESCROW
-    // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Insufficient escrow balance
     error InsufficientEscrowBalance(uint256 required, uint256 available);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -1272,7 +1272,7 @@ contract RFQTest is BaseTest {
         assertEq(tangle.getService(serviceId).operatorCount, 2);
     }
 
-    function test_CreateServiceFromQuotes_RefundsExcessPayment() public {
+    function test_CreateServiceFromQuotes_ExcessPaymentReverts() public {
         vm.prank(developer);
         uint64 blueprintId = tangle.createBlueprint(_blueprintDefinition("ipfs://rfq-refund", address(0)));
 
@@ -1303,12 +1303,11 @@ contract RFQTest is BaseTest {
         address[] memory callers = new address[](0);
         uint256 userBalanceBefore = user1.balance;
 
-        // Send more than required
         vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidMsgValue.selector, cost, 5 ether));
         tangle.createServiceFromQuotes{ value: 5 ether }(blueprintId, quotes, "", callers, ttl);
 
-        // User should get excess back (5 - 1 = 4 ETH refund)
-        assertEq(user1.balance, userBalanceBefore - cost);
+        assertEq(user1.balance, userBalanceBefore);
     }
 
     function test_CreateServiceFromQuotes_RevertExpiredQuote() public {

--- a/test/tangle/QuoteExtension.t.sol
+++ b/test/tangle/QuoteExtension.t.sol
@@ -87,7 +87,7 @@ contract QuoteExtensionTest is BaseTest {
         tangle.extendServiceFromQuotes{ value: 0.5 ether }(serviceId, quotes, additionalTtl);
     }
 
-    function test_ExtendService_ExcessPaymentRefunded() public {
+    function test_ExtendService_ExcessPaymentReverts() public {
         uint64 additionalTtl = 15 days;
 
         Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
@@ -96,10 +96,10 @@ contract QuoteExtensionTest is BaseTest {
         uint256 balBefore = user1.balance;
 
         vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidMsgValue.selector, 1 ether, 2 ether));
         tangle.extendServiceFromQuotes{ value: 2 ether }(serviceId, quotes, additionalTtl);
 
-        // User should get 1 ether back
-        assertEq(user1.balance, balBefore - 1 ether, "Excess should be refunded");
+        assertEq(user1.balance, balBefore, "User balance unchanged on revert");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/tangle/QuoteVerification.t.sol
+++ b/test/tangle/QuoteVerification.t.sol
@@ -336,18 +336,16 @@ contract QuoteVerificationTest is BaseTest {
         );
     }
 
-    function test_CreateFromQuote_RefundsExcessPayment() public {
+    function test_CreateFromQuote_OverpaymentReverts() public {
         Types.SignedQuote[] memory quotes = _createSingleQuote(operator1, OPERATOR1_PK, blueprintId, 100, 1 ether);
 
         uint256 userBalanceBefore = user1.balance;
 
         vm.prank(user1);
-        tangle.createServiceFromQuotes{ value: 5 ether }( // Overpaying
-            blueprintId, quotes, "", new address[](0), 100
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidMsgValue.selector, 1 ether, 5 ether));
+        tangle.createServiceFromQuotes{ value: 5 ether }(blueprintId, quotes, "", new address[](0), 100);
 
-        // Should have been refunded 4 ETH
-        assertEq(user1.balance, userBalanceBefore - 1 ether);
+        assertEq(user1.balance, userBalanceBefore);
     }
 
     function test_CreateFromQuote_ZeroCost() public {


### PR DESCRIPTION
## Summary
This PR brings the payment model to stricter protocol-grade invariants while keeping the design minimal and coherent across request, activation, quote, and job flows.

### 1) Core protocol hardening
- Add `withdrawRemainingEscrow(uint64 serviceId)` in `Payments` with:
  - `ServiceNotTerminated` guard
  - `ZeroAmount` guard
  - `EscrowRefunded` event
- Expose withdraw function in `ITangleServices` and `TanglePaymentsFacet` selectors.
- Enforce strict value invariants in `PaymentLib`:
  - native: `msg.value == amount`
  - ERC20: `msg.value == 0`
  - zero-amount calls with non-zero `msg.value` now revert (`InvalidMsgValue`).
- Fix EventDriven request/activation semantics:
  - EventDriven requests must use native settlement token (`paymentToken == address(0)`).
  - Initial non-zero EventDriven payment is distributed on activation.
- Fix subscription zero-initial-deposit ERC20 path by initializing escrow token at activation even when initial deposit is zero.
- Add manager payment-asset context helper and apply contextual checks in request/quote/job flows.
- Change quote overpayment behavior from refunding to strict exact-value requirement (`InvalidMsgValue`).

### 2) Tests
- Add E2E tests for `withdrawRemainingEscrow`:
  - withdraw after termination
  - revert before termination
  - revert on zero escrow
- Update/add tests for strict `msg.value` invariants across service funding, quote creation/extension, and RFQ job submission.
- Add tests for EventDriven setup fee distribution and EventDriven native-token-only request enforcement.
- Add test for subscription ERC20 zero-initial-deposit escrow token initialization.

### 3) Docs and dev tooling
- Update `docs/PRICING.md` to reflect exact-value semantics and EventDriven settlement behavior.
- Add `[profile.fast]` in `foundry.toml` for faster local iteration.

## Commits
1. `0195cd6` protocol: harden payment flows and add escrow withdrawal
2. `2b6d428` test: cover escrow refund and strict payment invariants
3. `2d3bed3` docs: align pricing semantics and add fast foundry profile

## Validation
Executed targeted suites with `FOUNDRY_PROFILE=fast`:
- `test/EndToEndSubscriptionTest.t.sol`
- `test/tangle/Payments.t.sol`
- `test/tangle/QuoteExtension.t.sol`
- `test/tangle/QuoteEdgeCases.t.sol`
- `test/tangle/QuoteVerification.t.sol`
- `test/tangle/RFQPaymentDistribution.t.sol`
- `test/Integration.t.sol` (`test_CreateServiceFromQuotes_ExcessPaymentReverts`)
- `test/StakeRequirementTests.t.sol` (`test_FundService_ExcessETH_Reverts`)
