### PR TITLE
feat: custom TNT exposure bps on service approval

### DIFF
--- a/script/LocalTestnet.s.sol
+++ b/script/LocalTestnet.s.sol
@@ -113,6 +113,7 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
     bool public operatorQaRegistrationMode; // If true, create registration-specific QA blueprints
     uint64 public operatorQaEmptySchemaBlueprintId;
     uint64 public operatorQaRequiredSchemaBlueprintId;
+    uint64 public operatorQaRequiredRequestSchemaBlueprintId;
 
     function run() external {
         _executeSetup(true);
@@ -145,7 +146,7 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
         }
         if (_envBoolOrFalse("OPERATOR_QA_REGISTRATION")) {
             operatorQaRegistrationMode = true;
-            console2.log("Operator QA registration mode enabled: creating extra registration fixture blueprints");
+            console2.log("Operator QA fixture mode enabled: creating registration + deploy fixture blueprints");
         }
 
         // Derive addresses
@@ -244,7 +245,9 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
             console2.log("\n=== Operator Registration QA Fixtures ===");
             console2.log("Empty-schema blueprint ID:", operatorQaEmptySchemaBlueprintId);
             console2.log("Required-schema blueprint ID:", operatorQaRequiredSchemaBlueprintId);
+            console2.log("Required request-schema blueprint ID:", operatorQaRequiredRequestSchemaBlueprintId);
             console2.log("Required schema fields: bool(flag), uint32(value)");
+            console2.log("Sample request args JSON for deploy fixture: [true, 42]");
             console2.log("Operator1/Operator2 are intentionally not pre-registered on these fixtures");
         }
         if (rewardsQaMode) {
@@ -1122,6 +1125,22 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
 
         operatorQaRequiredSchemaBlueprintId = tangle.createBlueprint(requiredSchemaDef);
         console2.log("Operator QA required-schema blueprint created:", operatorQaRequiredSchemaBlueprintId);
+
+        // Fixture C: required request schema (bool + uint32), for deploy request-arg QA.
+        Types.BlueprintDefinition memory requiredRequestSchemaDef =
+            _blueprintDefinition("http://localhost:3337/deploy-qa-required-request-schema", address(0));
+        requiredRequestSchemaDef.config.membership = Types.MembershipModel.Dynamic;
+        requiredRequestSchemaDef.config.minOperators = 1;
+        requiredRequestSchemaDef.config.maxOperators = 0;
+        requiredRequestSchemaDef.requestSchema = _boolUintSchema();
+        requiredRequestSchemaDef.metadata.name = "Deploy QA Required Request Schema";
+        requiredRequestSchemaDef.metadata.description =
+            "Fixture blueprint for deploy QA with required request params (bool flag, uint32 value).";
+
+        operatorQaRequiredRequestSchemaBlueprintId = tangle.createBlueprint(requiredRequestSchemaDef);
+        console2.log(
+            "Deploy QA required-request-schema blueprint created:", operatorQaRequiredRequestSchemaBlueprintId
+        );
 
         if (useBroadcastKeys) vm.stopBroadcast();
         else vm.stopPrank();

--- a/script/sh/local-env/start-local-dev.sh
+++ b/script/sh/local-env/start-local-dev.sh
@@ -42,7 +42,7 @@ SERVICE_LEAVABLE="${SERVICE_LEAVABLE:-false}"
 # Rewards QA flag (seeds Tangle Payments rewards and executes claims for frontend QA)
 REWARDS_QA="${REWARDS_QA:-false}"
 
-# Operator registration QA fixtures (adds extra blueprints for operator registration cases)
+# Operator QA fixtures (adds extra blueprints for registration + deploy request-schema cases)
 OPERATOR_QA_REGISTRATION="${OPERATOR_QA_REGISTRATION:-false}"
 
 # Operator slashing QA fixtures (seeds a single pending slash with readable context)
@@ -54,11 +54,14 @@ ANVIL_KEY="${ANVIL_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5e
 MULTICALL3_ADDRESS="${MULTICALL3_ADDRESS:-0xcA11bde05977b3631167028862bE2a173976CA11}"
 
 # Indexer settings
-ENVIO_PG_PORT="${ENVIO_PG_PORT:-5433}"
+ENVIO_PG_PORT="${ENVIO_PG_PORT:-5435}"
 ENVIO_PG_USER="${ENVIO_PG_USER:-postgres}"
 ENVIO_PG_PASSWORD="${ENVIO_PG_PASSWORD:-testing}"
 ENVIO_PG_DATABASE="${ENVIO_PG_DATABASE:-envio-dev}"
 HASURA_PORT="${HASURA_PORT:-8080}"
+
+# Export so docker compose and child processes pick up the values
+export ENVIO_PG_PORT ENVIO_PG_USER ENVIO_PG_PASSWORD ENVIO_PG_DATABASE HASURA_PORT
 
 log() {
     echo "[local-dev] $*"
@@ -308,7 +311,7 @@ run_local_testnet_setup() {
         log "Rewards QA mode: Will seed Tangle Payments rewards for frontend testing"
     fi
     if [[ "$OPERATOR_QA_REGISTRATION" == "true" ]]; then
-        log "Operator QA registration fixtures: Will create extra empty + required-schema blueprints"
+        log "Operator QA fixtures: Will create empty + required-registration-schema + required-request-schema blueprints"
     fi
     if [[ "$OPERATOR_QA_SLASHING" == "true" ]]; then
         log "Operator QA slashing fixtures: Will seed one pending slash with readable claim context"
@@ -793,7 +796,11 @@ show_summary() {
         log "  ✓ Time advanced past min commitment (operators can schedule exit)"
     fi
     if [[ "$OPERATOR_QA_REGISTRATION" == "true" ]]; then
-        log "  ✓ Extra operator registration QA blueprints (empty + required-schema)"
+        log "  ✓ Extra operator QA blueprints:"
+        log "    - Empty registration-schema blueprint"
+        log "    - Required registration-schema blueprint (bool + uint32)"
+        log "    - Required request-schema deploy blueprint (bool + uint32)"
+        log "    - Sample request args JSON: [true, 42]"
     fi
     if [[ "$OPERATOR_QA_SLASHING" == "true" ]]; then
         log "  ✓ Seeded operator slashing QA fixtures"
@@ -848,8 +855,9 @@ main() {
                 echo "  --with-rewards          Seed Tangle Payments rewards for frontend QA testing"
                 echo "                          Op1=native-only, Op2=ERC20-only, Op3=multi-token + claim history"
                 echo "  --with-operator-qa-registration"
-                echo "                          Add extra blueprints for operator registration QA"
-                echo "                          (empty-schema blueprint + required-schema blueprint)"
+                echo "                          Add extra operator QA blueprints"
+                echo "                          (empty registration-schema + required registration-schema +"
+                echo "                           required request-schema deploy blueprint)"
                 echo "  --with-operator-qa-slashing"
                 echo "                          Seed operator slashing QA fixtures"
                 echo "                          (single OpA pending slash with readable claim context)"

--- a/src/core/Services.sol
+++ b/src/core/Services.sol
@@ -354,12 +354,23 @@ abstract contract Services is Base {
         return req.minExposureBps == _defaultTntMinExposureBps;
     }
 
-    function _storeDefaultTntCommitment(uint64 requestId, address operator) private {
+    function _storeDefaultTntCommitment(uint64 requestId, address operator, uint16 tntExposureBps) private {
         Types.AssetSecurityCommitment[] storage existing = _requestSecurityCommitments[requestId][operator];
         if (existing.length > 0) return;
 
         Types.AssetSecurityRequirement storage req = _requestSecurityRequirements[requestId][0];
-        existing.push(Types.AssetSecurityCommitment({ asset: req.asset, exposureBps: req.minExposureBps }));
+        uint16 exposure = tntExposureBps == 0 ? req.minExposureBps : tntExposureBps;
+
+        if (tntExposureBps != 0) {
+            if (tntExposureBps < req.minExposureBps) {
+                revert Errors.CommitmentBelowMinimum(req.asset.token, tntExposureBps, req.minExposureBps);
+            }
+            if (tntExposureBps > req.maxExposureBps) {
+                revert Errors.CommitmentAboveMaximum(req.asset.token, tntExposureBps, req.maxExposureBps);
+            }
+        }
+
+        existing.push(Types.AssetSecurityCommitment({ asset: req.asset, exposureBps: exposure }));
     }
 
     function _loadBlueprintRequestData(uint64 blueprintId) private view returns (BlueprintRequestData memory data) {
@@ -431,6 +442,26 @@ abstract contract Services is Base {
 
     /// @notice Approve a service request
     function approveService(uint64 requestId, uint8 stakingPercent) external whenNotPaused nonReentrant {
+        _approveServiceInternal(requestId, stakingPercent, 0);
+    }
+
+    /// @notice Approve a service request with custom TNT exposure
+    /// @param requestId The service request ID
+    /// @param stakingPercent The staking percentage (0-100)
+    /// @param tntExposureBps Custom TNT exposure in basis points (0 = use default minimum)
+    function approveService(
+        uint64 requestId,
+        uint8 stakingPercent,
+        uint16 tntExposureBps
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        _approveServiceInternal(requestId, stakingPercent, tntExposureBps);
+    }
+
+    function _approveServiceInternal(uint64 requestId, uint8 stakingPercent, uint16 tntExposureBps) private {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -457,7 +488,7 @@ abstract contract Services is Base {
             if (!_isOnlyDefaultTntRequirement(requestId)) {
                 revert Errors.SecurityCommitmentsRequired(requestId);
             }
-            _storeDefaultTntCommitment(requestId, msg.sender);
+            _storeDefaultTntCommitment(requestId, msg.sender, tntExposureBps);
         }
 
         _requestApprovals[requestId][msg.sender] = true;

--- a/src/core/ServicesApprovals.sol
+++ b/src/core/ServicesApprovals.sol
@@ -27,6 +27,26 @@ abstract contract ServicesApprovals is Base {
 
     /// @notice Approve a service request
     function approveService(uint64 requestId, uint8 stakingPercent) external whenNotPaused nonReentrant {
+        _approveServiceInternal(requestId, stakingPercent, 0);
+    }
+
+    /// @notice Approve a service request with custom TNT exposure
+    /// @param requestId The service request ID
+    /// @param stakingPercent The staking percentage (0-100)
+    /// @param tntExposureBps Custom TNT exposure in basis points (0 = use default minimum)
+    function approveService(
+        uint64 requestId,
+        uint8 stakingPercent,
+        uint16 tntExposureBps
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        _approveServiceInternal(requestId, stakingPercent, tntExposureBps);
+    }
+
+    function _approveServiceInternal(uint64 requestId, uint8 stakingPercent, uint16 tntExposureBps) private {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -50,7 +70,7 @@ abstract contract ServicesApprovals is Base {
             if (!_isOnlyDefaultTntRequirement(requestId)) {
                 revert Errors.SecurityCommitmentsRequired(requestId);
             }
-            _storeDefaultTntCommitment(requestId, msg.sender);
+            _storeDefaultTntCommitment(requestId, msg.sender, tntExposureBps);
         }
 
         _requestApprovals[requestId][msg.sender] = true;
@@ -95,6 +115,35 @@ abstract contract ServicesApprovals is Base {
         whenNotPaused
         nonReentrant
     {
+        _approveServiceWithBlsInternal(requestId, stakingPercent, 0, blsPubkey);
+    }
+
+    /// @notice Approve a service request with BLS public key and custom TNT exposure
+    /// @param requestId The service request ID
+    /// @param stakingPercent The staking percentage (0-100)
+    /// @param tntExposureBps Custom TNT exposure in basis points (0 = use default minimum)
+    /// @param blsPubkey The operator's BLS G2 public key [x0, x1, y0, y1]
+    function approveServiceWithBls(
+        uint64 requestId,
+        uint8 stakingPercent,
+        uint16 tntExposureBps,
+        uint256[4] calldata blsPubkey
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        _approveServiceWithBlsInternal(requestId, stakingPercent, tntExposureBps, blsPubkey);
+    }
+
+    function _approveServiceWithBlsInternal(
+        uint64 requestId,
+        uint8 stakingPercent,
+        uint16 tntExposureBps,
+        uint256[4] calldata blsPubkey
+    )
+        private
+    {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
 
@@ -118,7 +167,7 @@ abstract contract ServicesApprovals is Base {
             if (!_isOnlyDefaultTntRequirement(requestId)) {
                 revert Errors.SecurityCommitmentsRequired(requestId);
             }
-            _storeDefaultTntCommitment(requestId, msg.sender);
+            _storeDefaultTntCommitment(requestId, msg.sender, tntExposureBps);
         }
 
         // Store BLS pubkey for this operator (to be transferred to service on activation)
@@ -320,12 +369,23 @@ abstract contract ServicesApprovals is Base {
         return req.minExposureBps == _defaultTntMinExposureBps;
     }
 
-    function _storeDefaultTntCommitment(uint64 requestId, address operator) private {
+    function _storeDefaultTntCommitment(uint64 requestId, address operator, uint16 tntExposureBps) private {
         Types.AssetSecurityCommitment[] storage existing = _requestSecurityCommitments[requestId][operator];
         if (existing.length > 0) return;
 
         Types.AssetSecurityRequirement storage req = _requestSecurityRequirements[requestId][0];
-        existing.push(Types.AssetSecurityCommitment({ asset: req.asset, exposureBps: req.minExposureBps }));
+        uint16 exposure = tntExposureBps == 0 ? req.minExposureBps : tntExposureBps;
+
+        if (tntExposureBps != 0) {
+            if (tntExposureBps < req.minExposureBps) {
+                revert Errors.CommitmentBelowMinimum(req.asset.token, tntExposureBps, req.minExposureBps);
+            }
+            if (tntExposureBps > req.maxExposureBps) {
+                revert Errors.CommitmentAboveMaximum(req.asset.token, tntExposureBps, req.maxExposureBps);
+            }
+        }
+
+        existing.push(Types.AssetSecurityCommitment({ asset: req.asset, exposureBps: exposure }));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/facets/tangle/TangleServicesFacet.sol
+++ b/src/facets/tangle/TangleServicesFacet.sol
@@ -16,14 +16,20 @@ contract TangleServicesFacet is ServicesApprovals, IFacetSelectors {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](6);
-        selectorList[0] = this.approveService.selector;
-        selectorList[1] = bytes4(keccak256("approveServiceWithCommitments(uint64,((uint8,address),uint16)[])"));
-        selectorList[2] = this.rejectService.selector;
-        selectorList[3] = this.approveServiceWithBls.selector;
-        selectorList[4] =
+        selectorList = new bytes4[](8);
+        // approveService(uint64,uint8)
+        selectorList[0] = bytes4(keccak256("approveService(uint64,uint8)"));
+        // approveService(uint64,uint8,uint16)
+        selectorList[1] = bytes4(keccak256("approveService(uint64,uint8,uint16)"));
+        selectorList[2] = bytes4(keccak256("approveServiceWithCommitments(uint64,((uint8,address),uint16)[])"));
+        selectorList[3] = this.rejectService.selector;
+        // approveServiceWithBls(uint64,uint8,uint256[4])
+        selectorList[4] = bytes4(keccak256("approveServiceWithBls(uint64,uint8,uint256[4])"));
+        // approveServiceWithBls(uint64,uint8,uint16,uint256[4])
+        selectorList[5] = bytes4(keccak256("approveServiceWithBls(uint64,uint8,uint16,uint256[4])"));
+        selectorList[6] =
             bytes4(keccak256("approveServiceWithCommitmentsAndBls(uint64,((uint8,address),uint16)[],uint256[4])"));
-        selectorList[5] = this.getOperatorBlsPubkey.selector;
+        selectorList[7] = this.getOperatorBlsPubkey.selector;
     }
 
     /// @notice Get operator's BLS public key for a service

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -95,6 +95,12 @@ interface ITangleServices {
     /// @notice Approve a service request (as operator) - simple version
     function approveService(uint64 requestId, uint8 stakingPercent) external;
 
+    /// @notice Approve a service request with custom TNT exposure
+    /// @param requestId The service request ID
+    /// @param stakingPercent The staking percentage (0-100)
+    /// @param tntExposureBps Custom TNT exposure in basis points (0 = use default minimum)
+    function approveService(uint64 requestId, uint8 stakingPercent, uint16 tntExposureBps) external;
+
     /// @notice Approve a service request with multi-asset security commitments
     /// @dev Commitments must match the security requirements specified in the request
     function approveServiceWithCommitments(
@@ -108,6 +114,19 @@ interface ITangleServices {
     /// @param stakingPercent The staking percentage (0-100)
     /// @param blsPubkey The operator's BLS G2 public key [x0, x1, y0, y1]
     function approveServiceWithBls(uint64 requestId, uint8 stakingPercent, uint256[4] calldata blsPubkey) external;
+
+    /// @notice Approve a service request with BLS public key and custom TNT exposure
+    /// @param requestId The service request ID
+    /// @param stakingPercent The staking percentage (0-100)
+    /// @param tntExposureBps Custom TNT exposure in basis points (0 = use default minimum)
+    /// @param blsPubkey The operator's BLS G2 public key [x0, x1, y0, y1]
+    function approveServiceWithBls(
+        uint64 requestId,
+        uint8 stakingPercent,
+        uint16 tntExposureBps,
+        uint256[4] calldata blsPubkey
+    )
+        external;
 
     /// @notice Approve a service request with both security commitments and BLS public key
     /// @param requestId The service request ID

--- a/test/tangle/TntExposureApproval.t.sol
+++ b/test/tangle/TntExposureApproval.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BaseTest } from "../BaseTest.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+import { MockERC20 } from "../mocks/MockERC20.sol";
+
+/// @title TntExposureApprovalTest
+/// @notice Tests for the approveService overload that accepts custom TNT exposure bps
+contract TntExposureApprovalTest is BaseTest {
+    uint64 blueprintId;
+    MockERC20 tnt;
+
+    function setUp() public override {
+        super.setUp();
+
+        tnt = new MockERC20();
+
+        vm.prank(admin);
+        tangle.setTntToken(address(tnt));
+
+        // Register operators in staking
+        _registerOperator(operator1);
+        _registerOperator(operator2);
+
+        // Create a blueprint
+        vm.prank(developer);
+        blueprintId = tangle.createBlueprint(_blueprintDefinition("ipfs://tnt-exposure-test", address(0)));
+
+        // Register operators for blueprint
+        _registerForBlueprint(operator1, blueprintId);
+        _registerForBlueprint(operator2, blueprintId);
+    }
+
+    function test_ApproveService_WithTntExposure() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Approve with 50% TNT exposure (5000 bps)
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0, 5000);
+
+        Types.AssetSecurityCommitment[] memory commits =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        assertEq(commits.length, 1, "Should have exactly one commitment");
+        assertEq(commits[0].asset.token, address(tnt), "Commitment should be for TNT token");
+        assertEq(commits[0].exposureBps, 5000, "Exposure should be 5000 bps (50%)");
+    }
+
+    function test_ApproveService_WithTntExposure_Zero_UsesDefault() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Approve with tntExposureBps=0 -> should use default min (1000 bps / 10%)
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0, 0);
+
+        Types.AssetSecurityCommitment[] memory commits =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        assertEq(commits.length, 1, "Should have exactly one commitment");
+        assertEq(commits[0].exposureBps, 1000, "Exposure should be default 1000 bps (10%)");
+    }
+
+    function test_ApproveService_WithTntExposure_RevertBelowMinimum() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Try to approve with 500 bps (5%) which is below min of 1000 bps (10%)
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CommitmentBelowMinimum.selector, address(tnt), 500, 1000));
+        tangle.approveService(requestId, 0, 500);
+    }
+
+    function test_ApproveService_WithTntExposure_RevertAboveMaximum() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Try to approve with 10001 bps which exceeds max of 10000 bps (100%)
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.CommitmentAboveMaximum.selector, address(tnt), 10001, 10000));
+        tangle.approveService(requestId, 0, 10001);
+    }
+
+    function test_ApproveService_WithTntExposure_MaxExposure() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Approve with 100% TNT exposure (10000 bps)
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0, 10000);
+
+        Types.AssetSecurityCommitment[] memory commits =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        assertEq(commits.length, 1, "Should have exactly one commitment");
+        assertEq(commits[0].exposureBps, 10000, "Exposure should be 10000 bps (100%)");
+    }
+
+    function test_ApproveService_WithTntExposure_DifferentOperatorExposures() public {
+        // Request a service with two operators
+        address[] memory operators = new address[](2);
+        operators[0] = operator1;
+        operators[1] = operator2;
+        address[] memory callers = new address[](0);
+
+        vm.prank(user1);
+        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+
+        // Operator1 approves at 20% TNT exposure
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0, 2000);
+
+        // Operator2 approves at 80% TNT exposure
+        vm.prank(operator2);
+        tangle.approveService(requestId, 0, 8000);
+
+        // Verify different commitments
+        Types.AssetSecurityCommitment[] memory commits1 =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        Types.AssetSecurityCommitment[] memory commits2 =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator2);
+
+        assertEq(commits1[0].exposureBps, 2000, "Operator1 should have 2000 bps (20%)");
+        assertEq(commits2[0].exposureBps, 8000, "Operator2 should have 8000 bps (80%)");
+    }
+
+    function test_ApproveService_OldSignature_StillUsesDefault() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Use the old 2-arg signature (backwards compatible)
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0);
+
+        Types.AssetSecurityCommitment[] memory commits =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        assertEq(commits.length, 1, "Should have exactly one commitment");
+        assertEq(commits[0].exposureBps, 1000, "Old signature should use default 1000 bps");
+    }
+
+    function test_ApproveService_WithTntExposure_MinExposureBoundary() public {
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+
+        // Approve with exactly the min exposure (1000 bps / 10%)
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0, 1000);
+
+        Types.AssetSecurityCommitment[] memory commits =
+            tangle.getServiceRequestSecurityCommitments(requestId, operator1);
+        assertEq(commits[0].exposureBps, 1000, "Should accept min exposure boundary");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `approveService(uint64, uint8, uint16)` and `approveServiceWithBls(uint64, uint8, uint16, uint256[4])` overloads so operators can specify a custom TNT exposure (in basis points) when approving service requests
- Existing 2-arg signatures remain backwards-compatible and default to the blueprint's minimum exposure
- Validates custom exposure falls within `[minExposureBps, maxExposureBps]`, reverting with `CommitmentBelowMinimum` / `CommitmentAboveMaximum` otherwise

## Changes
- **`Services.sol` / `ServicesApprovals.sol`**: New overloads + `_approveServiceInternal` / `_approveServiceWithBlsInternal` private helpers; updated `_storeDefaultTntCommitment` with bounds validation
- **`ITangleServices.sol`**: Interface additions for the new overloads
- **`TangleServicesFacet.sol`**: Updated selector list (6 → 8 selectors)
- **`TntExposureApproval.t.sol`**: 8 test cases covering custom exposure, default fallback, boundary values, revert cases, multi-operator divergent exposures, and backwards compatibility
- **`LocalTestnet.s.sol` / `start-local-dev.sh`**: Deploy QA blueprint fixture with required request schema; export indexer env vars

## Test plan
- [ ] `forge test --match-path test/tangle/TntExposureApproval.t.sol` — all 8 new tests pass
- [ ] `forge test` — full suite passes, no regressions
- [ ] Verify facet selector list matches ABI

🤖 Generated with [Claude Code](https://claude.com/claude-code)