### PR TITLE
fix(ci): unblock tnt-claim-prover-api Docker build

### DIFF
--- a/packages/migration-claim/sp1/prover-api/Dockerfile
+++ b/packages/migration-claim/sp1/prover-api/Dockerfile
@@ -1,11 +1,21 @@
-FROM rust:1.85-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /repo
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ curl git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY packages/migration-claim/sp1 ./packages/migration-claim/sp1
+
+# Install SP1 toolchain and build guest ELF before compiling the host API.
+ENV PATH="/root/.sp1/bin:${PATH}"
+RUN curl -L https://sp1up.succinct.xyz | bash \
+    && /root/.sp1/bin/sp1up
+
+WORKDIR /repo/packages/migration-claim/sp1/program
+RUN cargo prove build \
+    && mkdir -p elf \
+    && cp "$(find ../target/elf-compilation -type f -name sr25519-claim-program | head -n1)" elf/riscv32im-succinct-zkvm-elf
 
 WORKDIR /repo/packages/migration-claim/sp1
 RUN cargo build -p tnt-claim-prover-api --release


### PR DESCRIPTION
## Problem
`tnt-claim-prover-api` Docker CI started failing in `packages/migration-claim/sp1/prover-api/Dockerfile` with:
- `aws-types@1.3.11 requires rustc 1.88` (builder was pinned to `rust:1.85-slim`)
- after bumping Rust, compile still failed because `include_bytes!("../../program/elf/riscv32im-succinct-zkvm-elf")` had no ELF in a clean checkout.

## Fix
- bump builder image to `rust:1.88-slim`
- install missing build-time tools (`curl`, `git`)
- install SP1 toolchain in the builder stage via `sp1up`
- run `cargo prove build` in `sp1/program` to generate the guest ELF
- copy generated ELF from `target/elf-compilation/.../sr25519-claim-program` into `program/elf/riscv32im-succinct-zkvm-elf` so existing `include_bytes!` path resolves during `cargo build -p tnt-claim-prover-api --release`

## Validation
- locally reproduced failing Docker build
- verified fixed build succeeds:
  - `docker build -f packages/migration-claim/sp1/prover-api/Dockerfile -t tnt-claim-prover-api:ci-fix .`
