### PR TITLE
feat: add execution confidentiality intent to service request and RFQ flows

### DIFF
--- a/script/CreateServiceForTLV2Test.s.sol
+++ b/script/CreateServiceForTLV2Test.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import { Script, console2 } from "forge-std/Script.sol";
 import { ITangleFull } from "../src/interfaces/ITangle.sol";
+import { Types } from "../src/libraries/Types.sol";
 
 /// @title CreateServiceForTLV2Test
 /// @notice Create a service for the TLV v2 test blueprint
@@ -31,15 +32,17 @@ contract CreateServiceForTLV2Test is Script {
         address[] memory operators = new address[](1);
         operators[0] = OPERATOR1;
         address[] memory permittedCallers = new address[](0); // Anyone can call
+        bytes memory requestConfig = "";
 
         uint64 serviceId = tangle.requestService(
             1, // blueprintId
             operators, // operators
-            "", // config
+            requestConfig, // config
             permittedCallers, // permittedCallers
             uint64(7 days), // ttl
             address(0), // paymentToken (native)
-            0 // paymentAmount
+            0, // paymentAmount
+            Types.ConfidentialityPolicy.Any
         );
         console2.log("Service requested with ID:", serviceId);
         vm.stopBroadcast();

--- a/script/DemoSimulation.s.sol
+++ b/script/DemoSimulation.s.sol
@@ -466,7 +466,8 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
                 permittedCallers,
                 0, // No TTL
                 address(0), // Native payment
-                0
+                0,
+                Types.ConfidentialityPolicy.Any
             );
 
             vm.stopBroadcast();

--- a/script/LocalTestnet.s.sol
+++ b/script/LocalTestnet.s.sol
@@ -879,6 +879,7 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
         operators[1] = operator2;
 
         address[] memory permittedCallers = new address[](0);
+        bytes memory requestConfig = "";
 
         for (uint256 i = 0; i < numServiceInstances; i++) {
             if (useBroadcastKeys) {
@@ -892,11 +893,12 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
             uint64 currentRequestId = tangle.requestService{ value: escrowAmount }(
                 blueprintId,
                 operators,
-                "", // Empty config
+                requestConfig, // Empty config
                 permittedCallers,
                 0, // No TTL
                 address(0), // Native ETH payment
-                escrowAmount
+                escrowAmount,
+                Types.ConfidentialityPolicy.Any
             );
             console2.log("Service requested, ID:", currentRequestId);
             if (useBroadcastKeys) {
@@ -1231,6 +1233,7 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
         address[] memory ops = new address[](1);
         ops[0] = operator;
         address[] memory permittedCallers = new address[](0);
+        bytes memory requestConfig = "";
         uint256 nativeValue = paymentToken == address(0) ? paymentAmount : 0;
 
         // Deployer requests the service (pays for it)
@@ -1238,7 +1241,7 @@ contract LocalTestnetSetup is Script, BlueprintDefinitionHelper {
         else vm.startPrank(deployer);
 
         uint64 reqId = tangle.requestService{ value: nativeValue }(
-            bpId, ops, "", permittedCallers, 0, paymentToken, paymentAmount
+            bpId, ops, requestConfig, permittedCallers, 0, paymentToken, paymentAmount, Types.ConfidentialityPolicy.Any
         );
 
         if (useBroadcastKeys) vm.stopBroadcast();

--- a/src/core/Base.sol
+++ b/src/core/Base.sol
@@ -50,7 +50,13 @@ abstract contract Base is
     /// @param serviceId The newly created service ID
     /// @param requestId The request ID that was activated
     /// @param blueprintId The blueprint this service is based on
-    event ServiceActivated(uint64 indexed serviceId, uint64 indexed requestId, uint64 indexed blueprintId);
+    /// @param confidentiality The effective execution confidentiality for the service
+    event ServiceActivated(
+        uint64 indexed serviceId,
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        Types.ConfidentialityPolicy confidentiality
+    );
 
     /// @notice Emitted when the MBSM registry is updated
     /// @param registry The new registry address

--- a/src/core/QuotesCreate.sol
+++ b/src/core/QuotesCreate.sol
@@ -17,6 +17,7 @@ abstract contract QuotesCreate is Base {
     struct QuoteActivation {
         uint64 serviceId;
         uint256 totalExposure;
+        Types.ConfidentialityPolicy confidentiality;
     }
 
     // ServiceActivated event inherited from Base.sol
@@ -150,6 +151,17 @@ abstract contract QuotesCreate is Base {
         returns (uint256 totalCost)
     {
         (totalCost,) = SignatureLib.verifyQuoteBatch(_usedQuotes, _domainSeparator, quotes, blueprintId, ttl);
+        _ensureQuoteConfidentialityConsistent(quotes);
+    }
+
+    function _ensureQuoteConfidentialityConsistent(Types.SignedQuote[] calldata quotes) private pure {
+        if (quotes.length == 0) return;
+        Types.ConfidentialityPolicy basePolicy = quotes[0].details.confidentiality;
+        for (uint256 i = 1; i < quotes.length; ++i) {
+            if (quotes[i].details.confidentiality != basePolicy) {
+                revert Errors.InvalidQuoteSignature(quotes[i].operator);
+            }
+        }
     }
 
     function _activateQuoteService(
@@ -165,6 +177,7 @@ abstract contract QuotesCreate is Base {
     {
         activation.serviceId = _serviceCount++;
         Types.BlueprintConfig storage bpConfig = _blueprintConfigs[blueprintId];
+        activation.confidentiality = quotes[0].details.confidentiality;
 
         _services[activation.serviceId] = Types.Service({
             blueprintId: blueprintId,
@@ -178,12 +191,13 @@ abstract contract QuotesCreate is Base {
             maxOperators: bpConfig.maxOperators,
             membership: bp.membership,
             pricing: bp.pricing,
+            confidentiality: activation.confidentiality,
             status: Types.ServiceStatus.Active
         });
 
         activation.totalExposure = _processOperatorQuotes(activation.serviceId, operators, exposures, quotes);
 
-        emit ServiceActivated(activation.serviceId, 0, blueprintId);
+        emit ServiceActivated(activation.serviceId, 0, blueprintId, activation.confidentiality);
         _recordServiceCreated(activation.serviceId, blueprintId, msg.sender, operators.length);
         _configureHeartbeat(activation.serviceId, bp.manager, msg.sender, operators);
     }

--- a/src/core/QuotesExtend.sol
+++ b/src/core/QuotesExtend.sol
@@ -67,6 +67,7 @@ abstract contract QuotesExtend is Base {
 
         // Verify quotes and get total cost
         uint256 totalCost = _verifyExtensionQuotes(quotes, svc.blueprintId, additionalTtl);
+        _ensureExtensionQuoteConfidentiality(quotes, svc.confidentiality);
 
         // Collect payment
         _collectQuotePayment(totalCost);
@@ -135,6 +136,27 @@ abstract contract QuotesExtend is Base {
         returns (uint256 totalCost)
     {
         (totalCost,) = SignatureLib.verifyQuoteBatch(_usedQuotes, _domainSeparator, quotes, blueprintId, ttl);
+    }
+
+    function _ensureExtensionQuoteConfidentiality(
+        Types.SignedQuote[] calldata quotes,
+        Types.ConfidentialityPolicy expectedPolicy
+    )
+        private
+        pure
+    {
+        if (quotes.length == 0) return;
+
+        Types.ConfidentialityPolicy basePolicy = quotes[0].details.confidentiality;
+        if (basePolicy != expectedPolicy) {
+            revert Errors.InvalidQuoteSignature(quotes[0].operator);
+        }
+
+        for (uint256 i = 1; i < quotes.length; ++i) {
+            if (quotes[i].details.confidentiality != basePolicy) {
+                revert Errors.InvalidQuoteSignature(quotes[i].operator);
+            }
+        }
     }
 
     function _collectQuotePayment(uint256 totalCost) private {

--- a/src/core/ServicesRequests.sol
+++ b/src/core/ServicesRequests.sol
@@ -32,8 +32,18 @@ abstract contract ServicesRequests is Base {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
-    event ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
+    event ServiceRequested(
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        address indexed requester,
+        Types.ConfidentialityPolicy confidentiality
+    );
+    event ServiceRequestedWithSecurity(
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        address indexed requester,
+        Types.ConfidentialityPolicy confidentiality
+    );
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SERVICE REQUESTS
@@ -47,7 +57,8 @@ abstract contract ServicesRequests is Base {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable
@@ -57,7 +68,7 @@ abstract contract ServicesRequests is Base {
     {
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceWithDefaultExposure(
-            blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount
+            blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount, confidentiality
         );
         _storeDefaultTntRequirement(requestId);
         _storeDefaultResourceRequirements(requestId, blueprintId);
@@ -73,7 +84,8 @@ abstract contract ServicesRequests is Base {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable
@@ -84,7 +96,15 @@ abstract contract ServicesRequests is Base {
         if (operators.length != exposures.length) revert Errors.LengthMismatch();
         _validateRequestConfig(blueprintId, config);
         requestId = _requestServiceInternal(
-            blueprintId, operators, exposures, config, permittedCallers, ttl, paymentToken, paymentAmount
+            blueprintId,
+            operators,
+            exposures,
+            config,
+            permittedCallers,
+            ttl,
+            paymentToken,
+            paymentAmount,
+            confidentiality
         );
         _storeDefaultTntRequirement(requestId);
         _storeDefaultResourceRequirements(requestId, blueprintId);
@@ -100,7 +120,8 @@ abstract contract ServicesRequests is Base {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable
@@ -111,12 +132,12 @@ abstract contract ServicesRequests is Base {
         _validateSecurityRequirements(securityRequirements);
 
         requestId = _requestServiceWithDefaultExposure(
-            blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount
+            blueprintId, operators, config, permittedCallers, ttl, paymentToken, paymentAmount, confidentiality
         );
 
         _storeSecurityRequirementsWithDefaultTnt(requestId, securityRequirements);
         _storeDefaultResourceRequirements(requestId, blueprintId);
-        emit ServiceRequestedWithSecurity(requestId, blueprintId, msg.sender);
+        emit ServiceRequestedWithSecurity(requestId, blueprintId, msg.sender, confidentiality);
     }
 
     function _requestServiceWithDefaultExposure(
@@ -126,7 +147,8 @@ abstract contract ServicesRequests is Base {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         private
         returns (uint64 requestId)
@@ -134,7 +156,15 @@ abstract contract ServicesRequests is Base {
         uint16[] memory exposures = _defaultExposures(operators.length);
         _validateRequestConfig(blueprintId, config);
         return _requestServiceInternal(
-            blueprintId, operators, exposures, config, permittedCallers, ttl, paymentToken, paymentAmount
+            blueprintId,
+            operators,
+            exposures,
+            config,
+            permittedCallers,
+            ttl,
+            paymentToken,
+            paymentAmount,
+            confidentiality
         );
     }
 
@@ -147,7 +177,8 @@ abstract contract ServicesRequests is Base {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         internal
         returns (uint64 requestId)
@@ -170,12 +201,14 @@ abstract contract ServicesRequests is Base {
 
         RequestBounds memory bounds = _computeRequestBounds(blueprintId, uint32(operators.length));
 
-        requestId = _createServiceRequest(blueprintId, ttl, paymentToken, paymentAmount, blueprintData, bounds);
+        requestId = _createServiceRequest(
+            blueprintId, ttl, paymentToken, paymentAmount, confidentiality, blueprintData, bounds
+        );
 
         _storeRequestOperators(requestId, operators, exposures);
         _storePermittedCallers(requestId, permittedCallers);
 
-        emit ServiceRequested(requestId, blueprintId, msg.sender);
+        emit ServiceRequested(requestId, blueprintId, msg.sender, confidentiality);
 
         _notifyManagerOnRequest(blueprintData.manager, requestId, operators, config);
     }
@@ -373,6 +406,7 @@ abstract contract ServicesRequests is Base {
         uint64 ttl,
         address paymentToken,
         uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality,
         BlueprintRequestData memory blueprintData,
         RequestBounds memory bounds
     )
@@ -392,6 +426,7 @@ abstract contract ServicesRequests is Base {
             membership: blueprintData.membership,
             minOperators: bounds.minOperators,
             maxOperators: bounds.maxOperators,
+            confidentiality: confidentiality,
             rejected: false
         });
     }

--- a/src/facets/tangle/TangleQuotesExtensionFacet.sol
+++ b/src/facets/tangle/TangleQuotesExtensionFacet.sol
@@ -12,7 +12,7 @@ contract TangleQuotesExtensionFacet is QuotesExtend, IFacetSelectors {
         selectorList = new bytes4[](1);
         selectorList[0] = bytes4(
             keccak256(
-                "extendServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],uint64)"
+                "extendServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,uint8,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],uint64)"
             )
         );
     }

--- a/src/facets/tangle/TangleQuotesFacet.sol
+++ b/src/facets/tangle/TangleQuotesFacet.sol
@@ -12,7 +12,7 @@ contract TangleQuotesFacet is QuotesCreate, IFacetSelectors {
         selectorList = new bytes4[](2);
         selectorList[0] = bytes4(
             keccak256(
-                "createServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],bytes,address[],uint64)"
+                "createServiceFromQuotes(uint64,((uint64,uint64,uint256,uint64,uint64,uint8,((uint8,address),uint16)[],(uint8,uint64)[]),bytes,address)[],bytes,address[],uint64)"
             )
         );
         selectorList[1] = bytes4(keccak256("getServiceResourceCommitmentHash(uint64,address)"));

--- a/src/facets/tangle/TangleServicesFacet.sol
+++ b/src/facets/tangle/TangleServicesFacet.sol
@@ -79,7 +79,9 @@ contract TangleServicesFacet is ServicesApprovals, IFacetSelectors {
             requestId
         );
 
-        _triggerManagerOnActivation(requestId, serviceId, req.blueprintId, req.requester, req.ttl, bp.manager);
+        _triggerManagerOnActivation(
+            requestId, serviceId, req.blueprintId, req.requester, req.ttl, bp.manager, req.confidentiality
+        );
     }
 
     function _persistServiceSecurity(uint64 serviceId, uint64 requestId) private {
@@ -121,6 +123,7 @@ contract TangleServicesFacet is ServicesApprovals, IFacetSelectors {
             maxOperators: req.maxOperators,
             membership: req.membership,
             pricing: bp.pricing,
+            confidentiality: req.confidentiality,
             status: Types.ServiceStatus.Active
         });
     }
@@ -204,11 +207,12 @@ contract TangleServicesFacet is ServicesApprovals, IFacetSelectors {
         uint64 blueprintId,
         address requester,
         uint64 ttl,
-        address manager
+        address manager,
+        Types.ConfidentialityPolicy confidentiality
     )
         private
     {
-        emit ServiceActivated(serviceId, requestId, blueprintId);
+        emit ServiceActivated(serviceId, requestId, blueprintId, confidentiality);
 
         address[] memory operators = _copyRequestOperators(requestId);
         _configureHeartbeat(serviceId, manager, requester, operators);

--- a/src/facets/tangle/TangleServicesRequestsFacet.sol
+++ b/src/facets/tangle/TangleServicesRequestsFacet.sol
@@ -13,13 +13,16 @@ contract TangleServicesRequestsFacet is ServicesRequests, IFacetSelectors {
 
     function selectors() external pure returns (bytes4[] memory selectorList) {
         selectorList = new bytes4[](4);
-        selectorList[0] = bytes4(keccak256("requestService(uint64,address[],bytes,address[],uint64,address,uint256)"));
+        selectorList[0] =
+            bytes4(keccak256("requestService(uint64,address[],bytes,address[],uint64,address,uint256,uint8)"));
         selectorList[1] = bytes4(
-            keccak256("requestServiceWithExposure(uint64,address[],uint16[],bytes,address[],uint64,address,uint256)")
+            keccak256(
+                "requestServiceWithExposure(uint64,address[],uint16[],bytes,address[],uint64,address,uint256,uint8)"
+            )
         );
         selectorList[2] = bytes4(
             keccak256(
-                "requestServiceWithSecurity(uint64,address[],((uint8,address),uint16,uint16)[],bytes,address[],uint64,address,uint256)"
+                "requestServiceWithSecurity(uint64,address[],((uint8,address),uint16,uint16)[],bytes,address[],uint64,address,uint256,uint8)"
             )
         );
         selectorList[3] = bytes4(keccak256("getServiceRequestResourceRequirements(uint64)"));

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -11,15 +11,30 @@ interface ITangleServices {
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    event ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
+    event ServiceRequested(
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        address indexed requester,
+        Types.ConfidentialityPolicy confidentiality
+    );
 
-    event ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester);
+    event ServiceRequestedWithSecurity(
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        address indexed requester,
+        Types.ConfidentialityPolicy confidentiality
+    );
 
     event ServiceApproved(uint64 indexed requestId, address indexed operator);
 
     event ServiceRejected(uint64 indexed requestId, address indexed operator);
 
-    event ServiceActivated(uint64 indexed serviceId, uint64 indexed requestId, uint64 indexed blueprintId);
+    event ServiceActivated(
+        uint64 indexed serviceId,
+        uint64 indexed requestId,
+        uint64 indexed blueprintId,
+        Types.ConfidentialityPolicy confidentiality
+    );
 
     event ServiceTerminated(uint64 indexed serviceId);
     event ServiceTerminatedForNonPayment(
@@ -49,7 +64,8 @@ interface ITangleServices {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable
@@ -64,7 +80,8 @@ interface ITangleServices {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable
@@ -80,7 +97,8 @@ interface ITangleServices {
         address[] calldata permittedCallers,
         uint64 ttl,
         address paymentToken,
-        uint256 paymentAmount
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
     )
         external
         payable

--- a/src/libraries/SignatureLib.sol
+++ b/src/libraries/SignatureLib.sol
@@ -29,7 +29,7 @@ library SignatureLib {
     /// @dev EIP-712 TypeHash for QuoteDetails
     /// @dev Replay protection is handled by marking digests as used
     bytes32 internal constant QUOTE_TYPEHASH = keccak256(
-        "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+        "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
     );
 
     /// @dev EIP-712 TypeHash for JobQuoteDetails (per-job RFQ)
@@ -85,6 +85,7 @@ library SignatureLib {
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -305,7 +305,7 @@ library Types {
     ///      Slot 1: createdAt (8) + ttl (8) + operatorCount (4) + approvalCount (4) = 24 bytes
     ///      Slot 2: paymentToken (20) + membership (1) + minOperators (4) = 25 bytes
     ///      Slot 3: paymentAmount (32)
-    ///      Slot 4: maxOperators (4) + rejected (1) = 5 bytes
+    ///      Slot 4: maxOperators (4) + rejected (1) + confidentiality (1) = 6 bytes
     struct ServiceRequest {
         uint64 blueprintId;
         address requester;
@@ -318,8 +318,8 @@ library Types {
         MembershipModel membership; // Fixed or Dynamic
         uint32 minOperators; // For dynamic: minimum required
         uint32 maxOperators; // For dynamic: maximum allowed (0 = unlimited)
-        ConfidentialityPolicy confidentiality; // Requested execution confidentiality
         bool rejected;
+        ConfidentialityPolicy confidentiality; // Requested execution confidentiality
     }
 
     /// @notice Service - an active instance of a blueprint
@@ -327,7 +327,7 @@ library Types {
     ///      Slot 0: blueprintId (8) + owner (20) = 28 bytes
     ///      Slot 1: createdAt (8) + ttl (8) + terminatedAt (8) = 24 bytes
     ///      Slot 2: lastPaymentAt (8) + operatorCount (4) + minOperators (4) + maxOperators (4) = 20 bytes
-    ///      Slot 3: membership (1) + pricing (1) + status (1) = 3 bytes
+    ///      Slot 3: membership (1) + pricing (1) + status (1) + confidentiality (1) = 4 bytes
     struct Service {
         uint64 blueprintId;
         address owner;
@@ -340,8 +340,8 @@ library Types {
         uint32 maxOperators; // Maximum allowed (0 = unlimited)
         MembershipModel membership;
         PricingModel pricing;
-        ConfidentialityPolicy confidentiality; // Effective execution confidentiality
         ServiceStatus status;
+        ConfidentialityPolicy confidentiality; // Effective execution confidentiality
     }
 
     /// @notice Operator's participation in a service

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -290,6 +290,15 @@ library Types {
         Terminated // Ended (by owner or expiry)
     }
 
+    /// @notice Confidentiality policy selected for service execution
+    /// @dev Any=0, TeeRequired=1, StandardRequired=2, TeePreferred=3
+    enum ConfidentialityPolicy {
+        Any,
+        TeeRequired,
+        StandardRequired,
+        TeePreferred
+    }
+
     /// @notice Service request - pending service awaiting approval
     /// @dev Struct layout for storage optimization:
     ///      Slot 0: blueprintId (8) + requester (20) = 28 bytes (could be tighter but crossing slot)
@@ -309,6 +318,7 @@ library Types {
         MembershipModel membership; // Fixed or Dynamic
         uint32 minOperators; // For dynamic: minimum required
         uint32 maxOperators; // For dynamic: maximum allowed (0 = unlimited)
+        ConfidentialityPolicy confidentiality; // Requested execution confidentiality
         bool rejected;
     }
 
@@ -330,6 +340,7 @@ library Types {
         uint32 maxOperators; // Maximum allowed (0 = unlimited)
         MembershipModel membership;
         PricingModel pricing;
+        ConfidentialityPolicy confidentiality; // Effective execution confidentiality
         ServiceStatus status;
     }
 
@@ -553,6 +564,7 @@ library Types {
         uint256 totalCost; // Total cost in payment token (wei)
         uint64 timestamp; // When quote was generated
         uint64 expiry; // Quote expiry timestamp
+        ConfidentialityPolicy confidentiality; // Requested execution confidentiality
         AssetSecurityCommitment[] securityCommitments; // Operator's security commitments
         ResourceCommitment[] resourceCommitments; // Operator's resource commitments
     }

--- a/test/BLSAggregation.t.sol
+++ b/test/BLSAggregation.t.sol
@@ -67,7 +67,9 @@ contract BLSAggregationTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -351,7 +353,9 @@ contract BLSAggregationTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 reqId = tangle.requestService(noBsmBlueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 reqId = tangle.requestService(
+            noBsmBlueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(reqId, 0);

--- a/test/BLSAggregationE2E.t.sol
+++ b/test/BLSAggregationE2E.t.sol
@@ -67,7 +67,9 @@ contract BLSAggregationE2ETest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Approve with BLS pubkeys - operators use sk=1,2,3 respectively
         vm.prank(operator1);
@@ -274,7 +276,9 @@ contract BLSAggregationE2ETest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 reqId = tangle.requestService(dynamicBpId, operators, "", callers, 0, address(0), 0);
+        uint64 reqId = tangle.requestService(
+            dynamicBpId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(reqId, 0);
@@ -343,7 +347,9 @@ contract BLSAggregationE2ETest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 reqId = tangle.requestService(dynamicBpId, operators, "", callers, 0, address(0), 0);
+        uint64 reqId = tangle.requestService(
+            dynamicBpId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(reqId, 0);

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -279,7 +279,8 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -334,7 +335,10 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address[] memory callers = new address[](0);
 
         vm.prank(requester);
-        return tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        return
+            tangle.requestService(
+                blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+            );
     }
 
     /// @notice Request a service with payment
@@ -352,7 +356,9 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
         address[] memory callers = new address[](0);
 
         vm.prank(requester);
-        return tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
+        return tangle.requestService{ value: payment }(
+            blueprintId, operators, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
     }
 
     /// @notice Approve a service request
@@ -383,7 +389,9 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
 
         address[] memory callers = new address[](0);
         vm.prank(user1);
-        uint64 requestId = tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, ops, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         for (uint256 i = 0; i < ops.length; i++) {
             vm.prank(ops[i]);
@@ -410,7 +418,9 @@ abstract contract BaseTest is Test, BlueprintDefinitionHelper {
 
         vm.startPrank(requester);
         IERC20(token).approve(address(tangle), payment);
-        requestId = tangle.requestService(blueprintId, operators, "", callers, 0, token, payment);
+        requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, token, payment, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
     }
 }

--- a/test/EndToEndSlashingTest.t.sol
+++ b/test/EndToEndSlashingTest.t.sol
@@ -136,7 +136,9 @@ contract EndToEndSlashingTest is BaseTest {
         ops[0] = operator1;
         ops[1] = operator2;
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
         vm.prank(operator2);
@@ -314,8 +316,9 @@ contract EndToEndSlashingTest is BaseTest {
         exposures[0] = 5000; // 50%
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 

--- a/test/EndToEndSubscriptionTest.t.sol
+++ b/test/EndToEndSubscriptionTest.t.sol
@@ -40,8 +40,9 @@ contract EndToEndSubscriptionTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, operators, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         // Step 5: Operator approves - payment is distributed
         vm.prank(operator1);
@@ -87,7 +88,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -158,7 +159,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: escrowAmount }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, exposures, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -253,7 +254,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -301,7 +302,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -352,7 +353,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -405,7 +406,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -448,7 +449,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -497,7 +498,7 @@ contract EndToEndSubscriptionTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: escrowAmount }(
-            blueprintId, operators, "", callers, 0, address(0), escrowAmount
+            blueprintId, operators, "", callers, 0, address(0), escrowAmount, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -62,8 +62,9 @@ contract IntegrationTest is BaseTest {
         uint256 developerBefore = developer.balance;
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, operators, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         // Step 6: All operators approve (service activates after last approval)
         vm.prank(operator1);
@@ -131,7 +132,7 @@ contract IntegrationTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), payment
+            blueprintId, operators, exposures, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
         );
 
         // Both approve
@@ -190,8 +191,9 @@ contract IntegrationTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -275,7 +277,7 @@ contract IntegrationTest is BaseTest {
         vm.deal(address(tangle), 10 ether);
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: 1 ether }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether
+            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -435,7 +437,9 @@ contract IntegrationTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -742,8 +746,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Request should be created
         Types.ServiceRequest memory req = tangle.getServiceRequest(requestId);
@@ -779,8 +784,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         assertEq(requestId, 0);
     }
@@ -802,7 +808,9 @@ contract MultiAssetSecurityTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(Errors.NoSecurityRequirements.selector);
-        tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
     }
 
     function test_RequestServiceWithSecurity_RevertInvalidMinMax() public {
@@ -829,7 +837,9 @@ contract MultiAssetSecurityTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidSecurityRequirement.selector);
-        tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
     }
 
     function test_ApproveWithCommitments_ValidCommitment() public {
@@ -855,8 +865,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Operator approves with valid commitment (7500 bps = 75%)
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
@@ -893,8 +904,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Try to commit only 30% when min is 50%
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
@@ -929,8 +941,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Try to commit 80% when max is 50%
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
@@ -971,8 +984,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Only commit for native asset, missing ERC20
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](1);
@@ -1007,8 +1021,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         Types.AssetSecurityCommitment[] memory commitments = new Types.AssetSecurityCommitment[](2);
         commitments[0] = Types.AssetSecurityCommitment({
@@ -1054,8 +1069,9 @@ contract MultiAssetSecurityTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Both operators commit with different amounts
         Types.AssetSecurityCommitment[] memory commitments1 = new Types.AssetSecurityCommitment[](1);
@@ -1097,7 +1113,7 @@ contract RFQTest is BaseTest {
 
     function _signQuote(Types.QuoteDetails memory details, uint256 privateKey) internal view returns (bytes memory) {
         bytes32 QUOTE_TYPEHASH = keccak256(
-            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
         );
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
         bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
@@ -1120,6 +1136,7 @@ contract RFQTest is BaseTest {
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )
@@ -1191,6 +1208,7 @@ contract RFQTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1238,6 +1256,7 @@ contract RFQTest is BaseTest {
             totalCost: 0.5 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1248,6 +1267,7 @@ contract RFQTest is BaseTest {
             totalCost: 0.7 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1292,6 +1312,7 @@ contract RFQTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1329,6 +1350,7 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1366,6 +1388,7 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1405,6 +1428,7 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1439,6 +1463,7 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1473,6 +1498,7 @@ contract RFQTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -1513,6 +1539,7 @@ contract RFQTest is BaseTest {
             totalCost: 2 ether, // Costs 2 ETH
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });

--- a/test/SchemaValidationTest.t.sol
+++ b/test/SchemaValidationTest.t.sol
@@ -53,12 +53,16 @@ contract SchemaValidationTest is BaseTest {
                 uint256(1)
             )
         );
-        tangle.requestService(blueprintId, operators, _encodeBool(true), permitted, 0, address(0), 0);
+        tangle.requestService(
+            blueprintId, operators, _encodeBool(true), permitted, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Valid payload succeeds
         bytes memory validConfig = bytes.concat(_encodeBool(false), _encodeUint32(42));
         vm.prank(user1);
-        tangle.requestService(blueprintId, operators, validConfig, permitted, 0, address(0), 0);
+        tangle.requestService(
+            blueprintId, operators, validConfig, permitted, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
     }
 
     function test_JobParamsAndResultSchemaMismatch() public {
@@ -71,7 +75,9 @@ contract SchemaValidationTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/StakeRequirementTests.t.sol
+++ b/test/StakeRequirementTests.t.sol
@@ -214,7 +214,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -259,7 +260,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -317,7 +319,8 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         assertLt(requestId, 100); // Valid request ID (starts from 0 or 1)
     }
@@ -349,7 +352,7 @@ contract StakeRequirementTests is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.InsufficientOperators.selector, 3, 1));
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_AboveMaxOperators_Reverts() public {
@@ -389,7 +392,7 @@ contract StakeRequirementTests is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.TooManyOperators.selector, 2, 3));
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_MaxOperatorsZero_NoLimit() public {
@@ -426,7 +429,7 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_MinOperatorsZero_DefaultsToOne() public {
@@ -455,7 +458,7 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -487,8 +490,9 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", callers, 365 days, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -535,8 +539,9 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", callers, 365 days, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -583,8 +588,9 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", callers, 365 days, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", callers, 365 days, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -631,7 +637,7 @@ contract StakeRequirementTests is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_StakeRequirement_ExactlyAtMinimum() public {

--- a/test/Tangle.t.sol
+++ b/test/Tangle.t.sol
@@ -244,7 +244,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         Types.ServiceRequest memory req = tangle.getServiceRequest(requestId);
         assertEq(req.operatorCount, 3);
@@ -258,7 +260,7 @@ contract TangleTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(Errors.NoOperators.selector);
-        tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_RevertOperatorNotRegistered() public {
@@ -272,7 +274,7 @@ contract TangleTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.OperatorNotRegistered.selector, blueprintId, operator1));
-        tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -306,7 +308,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // First approval - not activated yet
         _approveService(operator1, requestId);
@@ -615,8 +619,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Approve to activate service
         vm.prank(operator1);
@@ -685,8 +690,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -726,8 +732,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -788,8 +795,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -822,8 +830,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         assertEq(requestId, 0);
     }
@@ -841,7 +850,9 @@ contract TangleTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(Errors.InvalidState.selector);
-        tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
     }
 
     function test_GetServiceOperators() public {
@@ -857,7 +868,9 @@ contract TangleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -952,7 +965,7 @@ contract TangleTest is BaseTest {
         // Request with payment for subscription
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: 1 ether }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether
+            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -1007,7 +1020,7 @@ contract TangleTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: 1 ether }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether
+            blueprintId, operators, exposures, "", callers, 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);

--- a/test/blueprints/BSMHooksLifecycle.t.sol
+++ b/test/blueprints/BSMHooksLifecycle.t.sol
@@ -136,7 +136,7 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
 
         vm.prank(serviceOwner);
         tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "test-inputs", new address[](0), 0, address(0), 1 ether
+            blueprintId, ops, "test-inputs", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
 
         assertEq(bsm.getHookCalls().onRequest, 1);
@@ -163,11 +163,15 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
                 abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 1 ether, 0.5 ether)
             )
         );
-        tangle.requestService{ value: 0.5 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 0.5 ether);
+        tangle.requestService{ value: 0.5 ether }(
+            blueprintId, ops, "", new address[](0), 0, address(0), 0.5 ether, Types.ConfidentialityPolicy.Any
+        );
 
         // At minimum succeeds
         vm.prank(serviceOwner);
-        tangle.requestService{ value: 1 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 1 ether);
+        tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
         assertEq(bsm.getHookCalls().onRequest, 1);
     }
 
@@ -187,8 +191,9 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[1] = operator2;
 
         vm.prank(serviceOwner);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -221,8 +226,9 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[0] = operator1;
 
         vm.prank(serviceOwner);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(blueprintId, ops, "", new address[](0), 0, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            blueprintId, ops, "", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.rejectService(requestId);
@@ -551,7 +557,7 @@ contract BSMHooksLifecycleTest is BlueprintTestHarness {
         ops[0] = operator1;
         vm.prank(serviceOwner);
         uint64 requestId = tangle.requestService{ value: 1 ether }(
-            blueprintId, ops, "test", new address[](0), 0, address(0), 1 ether
+            blueprintId, ops, "test", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
         assertEq(bsm.getHookCalls().onRequest, 1);
 

--- a/test/blueprints/CrossVersionCompatibility.t.sol
+++ b/test/blueprints/CrossVersionCompatibility.t.sol
@@ -342,7 +342,9 @@ contract CrossVersionCompatibilityTest is BlueprintTestHarness {
                 abi.encodeWithSelector(MockBSM_V2.InsufficientPayment.selector, 5 ether, 1 ether)
             )
         );
-        tangle.requestService{ value: 1 ether }(blueprintV2, ops, "", new address[](0), 0, address(0), 1 ether);
+        tangle.requestService{ value: 1 ether }(
+            blueprintV2, ops, "", new address[](0), 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/blueprints/TestHarness.sol
+++ b/test/blueprints/TestHarness.sol
@@ -299,8 +299,9 @@ abstract contract BlueprintTestHarness is Test, BlueprintDefinitionHelper {
         address[] memory callers = new address[](0);
 
         vm.prank(serviceOwner);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, operators, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         // Approve with all operators
         for (uint256 i = 0; i < operators.length; i++) {

--- a/test/fuzz/InvariantFuzz.t.sol
+++ b/test/fuzz/InvariantFuzz.t.sol
@@ -145,7 +145,9 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         ops[0] = operator1;
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -170,8 +172,9 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         exposures[0] = exposure;
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator2);
         tangle.approveService(requestId, 0);
@@ -272,15 +275,21 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         if (requestOps < minOps) {
             vm.prank(user1);
             vm.expectRevert(abi.encodeWithSelector(Errors.InsufficientOperators.selector, minOps, requestOps));
-            tangle.requestService(newBpId, operators, "", new address[](0), 0, address(0), 0);
+            tangle.requestService(
+                newBpId, operators, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+            );
         } else if (requestOps > maxOps) {
             vm.prank(user1);
             vm.expectRevert(abi.encodeWithSelector(Errors.TooManyOperators.selector, maxOps, requestOps));
-            tangle.requestService(newBpId, operators, "", new address[](0), 0, address(0), 0);
+            tangle.requestService(
+                newBpId, operators, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+            );
         } else {
             // Should succeed
             vm.prank(user1);
-            tangle.requestService(newBpId, operators, "", new address[](0), 0, address(0), 0);
+            tangle.requestService(
+                newBpId, operators, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+            );
         }
     }
 
@@ -343,7 +352,9 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
             ops[0] = operator1;
 
             vm.prank(user1);
-            uint64 requestId = tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(0), 0);
+            uint64 requestId = tangle.requestService(
+                blueprintId, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+            );
 
             vm.prank(operator1);
             tangle.approveService(requestId, 0);
@@ -424,8 +435,9 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         ops[0] = operator1;
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: deposit }(subBp, ops, "", new address[](0), 365 days, address(0), deposit);
+        uint64 requestId = tangle.requestService{ value: deposit }(
+            subBp, ops, "", new address[](0), 365 days, address(0), deposit, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -480,8 +492,9 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         ops[0] = operator1;
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, ops, "", new address[](0), 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, ops, "", new address[](0), 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/fuzz/PaymentFuzz.t.sol
+++ b/test/fuzz/PaymentFuzz.t.sol
@@ -81,7 +81,14 @@ contract PaymentFuzzTest is BaseTest {
         uint64 requestId;
         vm.prank(user1);
         requestId = tangle.requestService{ value: payment }(
-            blueprintId, _singleOperator(operator1), "", new address[](0), 0, address(0), payment
+            blueprintId,
+            _singleOperator(operator1),
+            "",
+            new address[](0),
+            0,
+            address(0),
+            payment,
+            Types.ConfidentialityPolicy.Any
         );
 
         // Should not overflow during payment distribution
@@ -119,7 +126,7 @@ contract PaymentFuzzTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), payment
+            blueprintId, operators, exposures, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -176,7 +183,7 @@ contract PaymentFuzzTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: initialEscrow }(
-            subBp, operators, "", new address[](0), 365 days, address(0), initialEscrow
+            subBp, operators, "", new address[](0), 365 days, address(0), initialEscrow, Types.ConfidentialityPolicy.Any
         );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/fuzz/SlashingFuzz.t.sol
+++ b/test/fuzz/SlashingFuzz.t.sol
@@ -182,8 +182,9 @@ contract SlashingFuzzTest is BaseTest {
         exposures[0] = exposure;
 
         vm.prank(user1);
-        uint64 reqId =
-            tangle.requestServiceWithExposure(blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0);
+        uint64 reqId = tangle.requestServiceWithExposure(
+            blueprintId, ops, exposures, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator2);
         tangle.approveService(reqId, 0);
         uint64 svcId = tangle.serviceCount() - 1;

--- a/test/rewards/ServiceFeeDistributor.t.sol
+++ b/test/rewards/ServiceFeeDistributor.t.sol
@@ -95,7 +95,15 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         MockERC20(paymentToken).approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, paymentToken, paymentAmount
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            paymentToken,
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -171,8 +179,16 @@ contract ServiceFeeDistributorTest is BaseTest {
         uint256 paymentAmount = 110 ether;
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
-        uint64 requestId =
-            tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(payTokenA), paymentAmount);
+        uint64 requestId = tangle.requestService(
+            blueprintId,
+            ops,
+            "",
+            new address[](0),
+            0,
+            address(payTokenA),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
 
         vm.prank(operator1);
@@ -242,7 +258,15 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), paymentAmount
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payTokenA),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -292,7 +316,15 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), paymentAmount
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payTokenA),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -316,8 +348,9 @@ contract ServiceFeeDistributorTest is BaseTest {
         // Create service with operator2 (who has no delegators)
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), 100 ether);
-        uint64 requestId =
-            tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(payTokenA), 100 ether);
+        uint64 requestId = tangle.requestService(
+            blueprintId, ops, "", new address[](0), 0, address(payTokenA), 100 ether, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
 
         // Should not revert even though operator has no delegators
@@ -452,7 +485,15 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), 100 ether);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), 100 ether
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payTokenA),
+            100 ether,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -485,7 +526,7 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), 1000);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), 1000
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), 1000, Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -586,7 +627,15 @@ contract ServiceFeeDistributorTest is BaseTest {
         vm.startPrank(user1);
         payTokenA.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payTokenA), paymentAmount
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payTokenA),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 

--- a/test/rewards/ServiceFeeDistributorStreaming.t.sol
+++ b/test/rewards/ServiceFeeDistributorStreaming.t.sol
@@ -355,7 +355,15 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, _nativeSecurityReqs(), "", new address[](0), TTL, address(payToken), 0
+            blueprintId,
+            ops,
+            _nativeSecurityReqs(),
+            "",
+            new address[](0),
+            TTL,
+            address(payToken),
+            0,
+            Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -563,7 +571,15 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), payment);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, _nativeSecurityReqs(), "", new address[](0), TTL, address(payToken), payment
+            blueprintId,
+            ops,
+            _nativeSecurityReqs(),
+            "",
+            new address[](0),
+            TTL,
+            address(payToken),
+            payment,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -580,7 +596,15 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), payment);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, _nativeSecurityReqs(), "", new address[](0), 0, address(payToken), payment
+            blueprintId,
+            ops,
+            _nativeSecurityReqs(),
+            "",
+            new address[](0),
+            0,
+            address(payToken),
+            payment,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -598,7 +622,15 @@ contract ServiceFeeDistributorStreamingTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), payment);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, _nativeSecurityReqs(), "", new address[](0), TTL, address(payToken), payment
+            blueprintId,
+            ops,
+            _nativeSecurityReqs(),
+            "",
+            new address[](0),
+            TTL,
+            address(payToken),
+            payment,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 

--- a/test/tangle/JobPricingAndRFQ.t.sol
+++ b/test/tangle/JobPricingAndRFQ.t.sol
@@ -64,7 +64,8 @@ contract JobPricingAndRFQTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/tangle/OperatorLifecycle.t.sol
+++ b/test/tangle/OperatorLifecycle.t.sol
@@ -174,7 +174,9 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // First operator approves
         vm.prank(operator1);
@@ -218,7 +220,9 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -285,8 +289,9 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(blueprintId, operators, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            blueprintId, operators, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -367,8 +372,9 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithSecurity(blueprintId, operators, requirements, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId, operators, requirements, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.SecurityCommitmentsRequired.selector, requestId));
@@ -403,7 +409,8 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(dynamicBp, operators, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(dynamicBp, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 
@@ -459,7 +466,8 @@ contract OperatorLifecycleTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(dynamicBp, operators, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(dynamicBp, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
         vm.prank(operator2);
@@ -554,7 +562,9 @@ contract OperatorLifecycleTest is BaseTest {
         callers[1] = makeAddr("caller2");
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 
@@ -596,7 +606,9 @@ contract OperatorLifecycleTest is BaseTest {
         callers[0] = makeAddr("removable");
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 
@@ -649,7 +661,9 @@ contract OperatorLifecycleTest is BaseTest {
         uint64 validTtl = 1 hours;
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, validTtl, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, validTtl, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
 

--- a/test/tangle/PaymentEdgeCases.t.sol
+++ b/test/tangle/PaymentEdgeCases.t.sol
@@ -200,8 +200,9 @@ contract PaymentEdgeCasesTest is BaseTest {
         uint256 payment = 100;
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, ops, "", callers, 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, ops, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         _approveService(operator1, requestId);
         _approveService(operator2, requestId);
@@ -232,7 +233,9 @@ contract PaymentEdgeCasesTest is BaseTest {
         vm.startPrank(user1);
         revertToken.approve(address(tangle), 5 ether);
         vm.expectRevert(bytes("TransferFrom disabled"));
-        tangle.requestService(blueprintId, operators, "", callers, 0, address(revertToken), 5 ether);
+        tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(revertToken), 5 ether, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
     }
 
@@ -263,7 +266,7 @@ contract PaymentEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId, ops, exposures, "", callers, 0, address(0), payment
+            blueprintId, ops, exposures, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
         );
 
         _approveService(operator1, requestId);
@@ -288,7 +291,7 @@ contract PaymentEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId, ops, exposures, "", callers, 0, address(0), payment
+            blueprintId, ops, exposures, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
         );
 
         _approveService(operator1, requestId);
@@ -472,7 +475,7 @@ contract PaymentEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: initialDeposit }(
-            subBlueprintId, ops, "", callers, 365 days, address(0), initialDeposit
+            subBlueprintId, ops, "", callers, 365 days, address(0), initialDeposit, Types.ConfidentialityPolicy.Any
         );
 
         _approveService(operator1, requestId);

--- a/test/tangle/Payments.t.sol
+++ b/test/tangle/Payments.t.sol
@@ -261,8 +261,9 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: payment }(blueprintId, operators, "", callers, 0, address(0), payment);
+        uint64 requestId = tangle.requestService{ value: payment }(
+            blueprintId, operators, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -290,7 +291,7 @@ contract PaymentsTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestServiceWithExposure{ value: payment }(
-            blueprintId, operators, exposures, "", callers, 0, address(0), payment
+            blueprintId, operators, exposures, "", callers, 0, address(0), payment, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -339,8 +340,9 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: upfront }(eventBlueprintId, operators, "", callers, 0, address(0), upfront);
+        uint64 requestId = tangle.requestService{ value: upfront }(
+            eventBlueprintId, operators, "", callers, 0, address(0), upfront, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -372,7 +374,9 @@ contract PaymentsTest is BaseTest {
         vm.startPrank(user1);
         token.approve(address(tangle), 1 ether);
         vm.expectRevert(Errors.InvalidPaymentToken.selector);
-        tangle.requestService(eventBlueprintId, operators, "", callers, 0, address(token), 1 ether);
+        tangle.requestService(
+            eventBlueprintId, operators, "", callers, 0, address(token), 1 ether, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
     }
 
@@ -481,8 +485,9 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 1 ether }(subBlueprintId, operators, "", callers, 0, address(0), 1 ether);
+        uint64 requestId = tangle.requestService{ value: 1 ether }(
+            subBlueprintId, operators, "", callers, 0, address(0), 1 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -583,8 +588,9 @@ contract PaymentsTest is BaseTest {
         uint256 initialDeposit = 100 ether;
         vm.startPrank(user1);
         token.approve(address(tangle), initialDeposit);
-        uint64 requestId =
-            tangle.requestService(ercBlueprintId, operators, "", callers, 0, address(token), initialDeposit);
+        uint64 requestId = tangle.requestService(
+            ercBlueprintId, operators, "", callers, 0, address(token), initialDeposit, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
 
         vm.prank(operator1);
@@ -627,7 +633,9 @@ contract PaymentsTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(ercBlueprintId, operators, "", callers, 0, address(token), 0);
+        uint64 requestId = tangle.requestService(
+            ercBlueprintId, operators, "", callers, 0, address(token), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -663,8 +671,9 @@ contract PaymentsTest is BaseTest {
         });
 
         vm.prank(developer);
-        uint64 guardedBp =
-            tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://guarded-subscription", address(manager), config));
+        uint64 guardedBp = tangle.createBlueprint(
+            _blueprintDefinitionWithConfig("ipfs://guarded-subscription", address(manager), config)
+        );
         _registerForBlueprint(operator1, guardedBp);
 
         address[] memory operators = new address[](1);
@@ -673,7 +682,7 @@ contract PaymentsTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.TokenNotAllowed.selector, address(token)));
-        tangle.requestService(guardedBp, operators, "", callers, 0, address(token), 0);
+        tangle.requestService(guardedBp, operators, "", callers, 0, address(token), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestPaymentAsset_ContextDenyCannotBeOverriddenByLegacyGlobalAllow() public {
@@ -691,12 +700,14 @@ contract PaymentsTest is BaseTest {
 
         // Consume requestContextId=0 first so next request uses contextId=1.
         vm.prank(user1);
-        tangle.requestService(guardedBp, operators, "", callers, 0, address(0), 0);
+        tangle.requestService(guardedBp, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.startPrank(user1);
         token.approve(address(tangle), 1 ether);
         vm.expectRevert(abi.encodeWithSelector(Errors.TokenNotAllowed.selector, address(token)));
-        tangle.requestService(guardedBp, operators, "", callers, 0, address(token), 1 ether);
+        tangle.requestService(
+            guardedBp, operators, "", callers, 0, address(token), 1 ether, Types.ConfidentialityPolicy.Any
+        );
         vm.stopPrank();
     }
 
@@ -737,8 +748,9 @@ contract PaymentsTest is BaseTest {
 
         // Only deposit 0.5 ETH but rate is 1 ETH
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 0.5 ether }(bp, operators, "", callers, 0, address(0), 0.5 ether);
+        uint64 requestId = tangle.requestService{ value: 0.5 ether }(
+            bp, operators, "", callers, 0, address(0), 0.5 ether, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);
@@ -792,7 +804,7 @@ contract PaymentsTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: 1 ether }(
-            expBlueprintId, operators, "", callers, 1 days, address(0), 1 ether
+            expBlueprintId, operators, "", callers, 1 days, address(0), 1 ether, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);
@@ -979,7 +991,7 @@ contract PaymentsTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: initialDeposit }(
-            bp, operators, "", callers, ttl, address(0), initialDeposit
+            bp, operators, "", callers, ttl, address(0), initialDeposit, Types.ConfidentialityPolicy.Any
         );
 
         vm.prank(operator1);

--- a/test/tangle/PerAssetExposureIntegration.t.sol
+++ b/test/tangle/PerAssetExposureIntegration.t.sol
@@ -94,7 +94,15 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), paymentAmount);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payToken), paymentAmount
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payToken),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 
@@ -139,7 +147,7 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         vm.startPrank(user1);
         payToken.approve(address(tangle), 1 ether);
         uint64 requestId = tangle.requestServiceWithSecurity(
-            blueprintId, ops, reqs, "", new address[](0), 0, address(payToken), 1 ether
+            blueprintId, ops, reqs, "", new address[](0), 0, address(payToken), 1 ether, Types.ConfidentialityPolicy.Any
         );
         vm.stopPrank();
 

--- a/test/tangle/QuoteEdgeCases.t.sol
+++ b/test/tangle/QuoteEdgeCases.t.sol
@@ -101,6 +101,7 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -149,6 +150,7 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -283,6 +285,7 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -318,6 +321,7 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: commitments,
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -433,6 +437,7 @@ contract QuoteEdgeCasesTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -449,13 +454,14 @@ contract QuoteEdgeCasesTest is BaseTest {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
                 ),
                 details.blueprintId,
                 details.ttlBlocks,
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/test/tangle/QuoteExtension.t.sol
+++ b/test/tangle/QuoteExtension.t.sol
@@ -172,6 +172,7 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: 0.5 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp - 1), // Expired
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -308,6 +309,7 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -334,6 +336,7 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -360,6 +363,7 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 2 hours), // Different expiry
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -387,6 +391,7 @@ contract QuoteExtensionTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: expiry,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -403,13 +408,14 @@ contract QuoteExtensionTest is BaseTest {
         bytes32 structHash = keccak256(
             abi.encode(
                 keccak256(
-                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+                    "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
                 ),
                 details.blueprintId,
                 details.ttlBlocks,
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/test/tangle/QuoteExtension.t.sol
+++ b/test/tangle/QuoteExtension.t.sol
@@ -201,6 +201,35 @@ contract QuoteExtensionTest is BaseTest {
         tangle.extendServiceFromQuotes{ value: 1 ether }(serviceId, quotes, additionalTtl);
     }
 
+    function test_ExtendService_RevertsOnMixedConfidentialityQuotes() public {
+        uint64 additionalTtl = 15 days;
+
+        Types.SignedQuote[] memory quotes = new Types.SignedQuote[](2);
+        quotes[0] = _createExtensionQuoteWithPolicy(
+            operator1Key, operator1, 0.5 ether, additionalTtl, Types.ConfidentialityPolicy.Any
+        );
+        quotes[1] = _createExtensionQuoteWithPolicy(
+            operator2Key, operator2, 0.6 ether, additionalTtl, Types.ConfidentialityPolicy.TeeRequired
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidQuoteSignature.selector, operator2));
+        tangle.extendServiceFromQuotes{ value: 1.1 ether }(serviceId, quotes, additionalTtl);
+    }
+
+    function test_ExtendService_RevertsOnServiceConfidentialityMismatch() public {
+        uint64 additionalTtl = 15 days;
+
+        Types.SignedQuote[] memory quotes = new Types.SignedQuote[](1);
+        quotes[0] = _createExtensionQuoteWithPolicy(
+            operator1Key, operator1, 0.5 ether, additionalTtl, Types.ConfidentialityPolicy.TeeRequired
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidQuoteSignature.selector, operator1));
+        tangle.extendServiceFromQuotes{ value: 0.5 ether }(serviceId, quotes, additionalTtl);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // TTL CALCULATION
     // ═══════════════════════════════════════════════════════════════════════════
@@ -303,13 +332,29 @@ contract QuoteExtensionTest is BaseTest {
         view
         returns (Types.SignedQuote memory)
     {
+        return _createExtensionQuoteWithPolicy(
+            privateKey, operator, totalCost, additionalTtl, Types.ConfidentialityPolicy.Any
+        );
+    }
+
+    function _createExtensionQuoteWithPolicy(
+        uint256 privateKey,
+        address operator,
+        uint256 totalCost,
+        uint64 additionalTtl,
+        Types.ConfidentialityPolicy confidentiality
+    )
+        internal
+        view
+        returns (Types.SignedQuote memory)
+    {
         Types.QuoteDetails memory details = Types.QuoteDetails({
             blueprintId: blueprintId,
             ttlBlocks: additionalTtl,
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
-            confidentiality: Types.ConfidentialityPolicy.Any,
+            confidentiality: confidentiality,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });

--- a/test/tangle/QuotePaymentSplit.t.sol
+++ b/test/tangle/QuotePaymentSplit.t.sol
@@ -69,7 +69,7 @@ contract RevertingMetricsRecorder is IMetricsRecorder {
 contract QuotePaymentSplitTest is BaseTest {
     uint256 internal constant OPERATOR_PK = 0xA11CE;
     bytes32 private constant QUOTE_TYPEHASH = keccak256(
-        "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+        "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
     );
 
     RecordingMetrics internal metrics;
@@ -149,6 +149,7 @@ contract QuotePaymentSplitTest is BaseTest {
             totalCost: totalCost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -178,6 +179,7 @@ contract QuotePaymentSplitTest is BaseTest {
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/test/tangle/QuoteVerification.t.sol
+++ b/test/tangle/QuoteVerification.t.sol
@@ -141,6 +141,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -167,6 +168,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp - 1), // Already expired
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -188,6 +190,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -209,6 +212,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -440,6 +444,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: 1 ether,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -512,6 +517,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: cost,
             timestamp: baseTimestamp,
             expiry: baseTimestamp + 1 hours,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -540,6 +546,7 @@ contract QuoteVerificationTest is BaseTest {
             totalCost: cost,
             timestamp: baseTimestamp,
             expiry: baseTimestamp + 1 hours,
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](1),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -564,7 +571,7 @@ contract QuoteVerificationTest is BaseTest {
         returns (bytes memory)
     {
         bytes32 QUOTE_TYPEHASH = keccak256(
-            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
         );
         bytes32 commitmentsHash = _hashSecurityCommitments(details.securityCommitments);
         bytes32 resourcesHash = _hashResourceCommitments(details.resourceCommitments);
@@ -587,6 +594,7 @@ contract QuoteVerificationTest is BaseTest {
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/test/tangle/RFQPaymentDistribution.t.sol
+++ b/test/tangle/RFQPaymentDistribution.t.sol
@@ -72,7 +72,8 @@ contract RFQPaymentDistributionTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/tangle/ResourceCommitments.t.sol
+++ b/test/tangle/ResourceCommitments.t.sol
@@ -181,6 +181,7 @@ contract ResourceCommitmentsTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: resources
         });
@@ -207,6 +208,7 @@ contract ResourceCommitmentsTest is BaseTest {
             totalCost: cost,
             timestamp: uint64(block.timestamp),
             expiry: uint64(block.timestamp + 1 hours),
+            confidentiality: Types.ConfidentialityPolicy.Any,
             securityCommitments: new Types.AssetSecurityCommitment[](0),
             resourceCommitments: new Types.ResourceCommitment[](0)
         });
@@ -221,7 +223,7 @@ contract ResourceCommitmentsTest is BaseTest {
         bytes32 resourcesHash = SignatureLib.hashResourceCommitments(details.resourceCommitments);
 
         bytes32 QUOTE_TYPEHASH = keccak256(
-            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
+            "QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)AssetSecurityCommitment(Asset asset,uint16 exposureBps)Asset(uint8 kind,address token)ResourceCommitment(uint8 kind,uint64 count)"
         );
 
         bytes32 domainSeparator = keccak256(
@@ -242,6 +244,7 @@ contract ResourceCommitmentsTest is BaseTest {
                 details.totalCost,
                 details.timestamp,
                 details.expiry,
+                details.confidentiality,
                 commitmentsHash,
                 resourcesHash
             )

--- a/test/tangle/ResourceRequirementsApproval.t.sol
+++ b/test/tangle/ResourceRequirementsApproval.t.sol
@@ -169,7 +169,9 @@ contract ResourceRequirementsApprovalTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, operators, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, operators, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         // Both approve
         _approveService(operator1, requestId);

--- a/test/tangle/ServiceLifecycleEdgeCases.t.sol
+++ b/test/tangle/ServiceLifecycleEdgeCases.t.sol
@@ -254,8 +254,9 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestService{ value: 5 ether }(subBlueprintId, ops, "", callers, 365 days, address(0), 5 ether);
+        uint64 requestId = tangle.requestService{ value: 5 ether }(
+            subBlueprintId, ops, "", callers, 365 days, address(0), 5 ether, Types.ConfidentialityPolicy.Any
+        );
 
         _approveService(operator1, requestId);
 
@@ -407,7 +408,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(operator1, requestId);
 
@@ -427,7 +429,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.TTLAboveMaximum.selector, maxTTL, maximum));
-        tangle.requestService(blueprintId, ops, "", callers, maxTTL, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, maxTTL, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_ServiceWithValidMaxTTL() public {
@@ -439,7 +441,9 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         uint64 validMaxTTL = 365 days;
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, validMaxTTL, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            blueprintId, ops, "", callers, validMaxTTL, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         _approveService(operator1, requestId);
 
@@ -478,7 +482,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(limitedBpId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(limitedBpId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(operator1, requestId);
         _approveService(operator2, requestId);
@@ -518,7 +523,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(minOpBpId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(minOpBpId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(operator1, requestId);
         _approveService(operator2, requestId);
@@ -611,7 +617,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         callers[0] = user2; // Add user2 as permitted caller
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(operator1, requestId);
 
@@ -670,7 +677,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(); // BSM reverts
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_InactiveBlueprint_Reverts() public {
@@ -684,7 +691,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         vm.expectRevert(abi.encodeWithSelector(Errors.BlueprintNotActive.selector, blueprintId));
-        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
     }
 
     function test_RequestService_DuplicateOperators() public {
@@ -697,7 +704,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         vm.prank(user1);
         // Behavior depends on implementation - may allow or reject duplicates
         // This tests the actual behavior
-        try tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0) {
+        try tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any) {
         // If it succeeds, verify service state
         }
             catch {
@@ -711,7 +718,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(operator1, requestId);
 
@@ -728,7 +736,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         // operator1 rejects
         vm.prank(operator1);
@@ -750,7 +759,8 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(bpId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(bpId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         _approveService(op, requestId);
 
@@ -763,7 +773,9 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(dynamicBlueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestService(
+            dynamicBlueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         _approveService(op, requestId);
 
@@ -797,7 +809,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         vm.prank(user1);
         uint64 requestId = tangle.requestService{ value: initialDeposit }(
-            subBlueprintId, ops, "", callers, 365 days, address(0), initialDeposit
+            subBlueprintId, ops, "", callers, 365 days, address(0), initialDeposit, Types.ConfidentialityPolicy.Any
         );
 
         _approveService(operator1, requestId);

--- a/test/tangle/ServicesExitFlow.t.sol
+++ b/test/tangle/ServicesExitFlow.t.sol
@@ -149,7 +149,8 @@ contract ServicesExitFlowTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId = tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0);
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
 
         vm.prank(operator1);
         tangle.approveService(requestId, 0);

--- a/test/tangle/Slashing.t.sol
+++ b/test/tangle/Slashing.t.sol
@@ -490,7 +490,9 @@ contract SlashingTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 reqId = tangle.requestServiceWithExposure(bpId, ops, exposures, "", callers, 0, address(0), 0);
+        uint64 reqId = tangle.requestServiceWithExposure(
+            bpId, ops, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         vm.prank(operator1);
         tangle.approveService(reqId, 0);

--- a/test/tangle/SlashingEdgeCases.t.sol
+++ b/test/tangle/SlashingEdgeCases.t.sol
@@ -382,8 +382,9 @@ contract SlashingEdgeCasesTest is BaseTest {
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
-        uint64 requestId =
-            tangle.requestServiceWithExposure(exposureBpId, ops, exposures, "", callers, 0, address(0), 0);
+        uint64 requestId = tangle.requestServiceWithExposure(
+            exposureBpId, ops, exposures, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
 
         _approveService(operator1, requestId);
 


### PR DESCRIPTION
## Summary
- add first-class execution confidentiality intent on-chain via `Types.ConfidentialityPolicy`
- persist confidentiality on service requests, activated services, and signed quote details
- extend service request APIs/events to carry confidentiality end-to-end
- include confidentiality in quote EIP-712 hashing and signature verification
- enforce RFQ batch consistency by rejecting mixed-confidentiality quote sets
- update facet selector signatures for request/RFQ create/extend flows to match new tuple shapes
- update scripts/tests for new request signatures and quote hashing layout

## Key protocol changes
- `Types.ServiceRequest.confidentiality`
- `Types.Service.confidentiality`
- `Types.QuoteDetails.confidentiality`
- request functions now take trailing `Types.ConfidentialityPolicy confidentiality`
- `ServiceRequested`, `ServiceRequestedWithSecurity`, and `ServiceActivated` now emit confidentiality

## Verification
- `FOUNDRY_PROFILE=fast forge build --skip test --skip script`
- `FOUNDRY_PROFILE=fast forge test --skip script --match-path test/tangle/QuoteVerification.t.sol --match-test test_CreateFromQuote_SingleOperator -vv`
- `FOUNDRY_PROFILE=fast forge test --skip script --match-path test/tangle/QuoteExtension.t.sol --match-test test_ExtendService_ValidQuotes -vv`
- `FOUNDRY_PROFILE=fast forge test --skip script --match-path test/Tangle.t.sol --match-test test_RequestService -vv`
- additional suites validated under `--skip script`: `QuoteVerification`, `QuoteExtension`, `QuoteEdgeCases`, `QuotePaymentSplit`, `ResourceCommitments`, `SchemaValidationTest`, `PerAssetExposureIntegration`

## Notes
- local `forge` is `1.5.1`; CI uses `v0.3.0` per workflow. In this local environment, script-only builds may raise a Yul stack-depth error under `forge build --skip test` that did not affect contract/test-path verification under `--skip script`.
