### PR TITLE
[codex] Harden Base Sepolia launch flow

### DIFF
--- a/script/sh/deploy-testnet-base-sepolia.sh
+++ b/script/sh/deploy-testnet-base-sepolia.sh
@@ -1,53 +1,180 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deploy the TNT protocol stack to Base Sepolia using the config-driven FullDeploy flow.
+# Release-oriented deploy wrapper for the Base Sepolia FullDeploy flow.
 #
 # Required env:
 # - PRIVATE_KEY
 # - BASE_SEPOLIA_RPC
 #
 # Optional env:
-# - FULL_DEPLOY_CONFIG (defaults to deploy/config/base-sepolia.json)
-# - FOUNDRY_PROFILE (defaults to deploy_size to keep ServiceFeeDistributor under EIP-170)
+# - FULL_DEPLOY_CONFIG      defaults to deploy/config/base-sepolia.json
+# - FOUNDRY_PROFILE         defaults to deploy_size
+# - RELEASE_TAG             defaults to UTC timestamp (YYYYmmdd-HHMMSS)
+# - DRY_RUN                 true|false, defaults to false
+# - SKIP_VERIFY             true|false, defaults to false
+#
+# Behavior:
+# - Writes manifests into deployments/base-sepolia/releases/<tag>/
+# - Refreshes deployments/base-sepolia/latest.json only after a verified broadcast
+# - Leaves prior release snapshots intact for rollback/auditability
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-: "${PRIVATE_KEY:?Missing PRIVATE_KEY}"
-: "${BASE_SEPOLIA_RPC:?Missing BASE_SEPOLIA_RPC}"
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+}
+
+json_get() {
+  local file="$1"
+  local query="$2"
+  jq -er "$query" "$file"
+}
+
+bool_env() {
+  local value="${1:-false}"
+  [[ "$value" == "1" || "$value" == "true" || "$value" == "TRUE" || "$value" == "yes" || "$value" == "YES" ]]
+}
 
 FULL_DEPLOY_CONFIG="${FULL_DEPLOY_CONFIG:-deploy/config/base-sepolia.json}"
 FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-deploy_size}"
+RELEASE_TAG="${RELEASE_TAG:-$(date -u +%Y%m%d-%H%M%S)}"
+DRY_RUN="${DRY_RUN:-false}"
+SKIP_VERIFY="${SKIP_VERIFY:-false}"
+EXPECTED_CHAIN_ID=84532
 
-if [[ ! -f "$FULL_DEPLOY_CONFIG" ]]; then
-  echo "Config not found: $FULL_DEPLOY_CONFIG" >&2
-  exit 1
+: "${PRIVATE_KEY:?Missing PRIVATE_KEY}"
+: "${BASE_SEPOLIA_RPC:?Missing BASE_SEPOLIA_RPC}"
+
+require_cmd forge
+require_cmd jq
+require_cmd cast
+require_cmd cp
+require_cmd mktemp
+
+[[ -f "$FULL_DEPLOY_CONFIG" ]] || fail "Config not found: $FULL_DEPLOY_CONFIG"
+
+CONFIG_NETWORK="$(json_get "$FULL_DEPLOY_CONFIG" '.network')"
+[[ "$CONFIG_NETWORK" == "base-sepolia" ]] || fail "Expected .network=base-sepolia, found: $CONFIG_NETWORK"
+
+CONFIG_CHAIN_ID="$(json_get "$FULL_DEPLOY_CONFIG" '._chainId')"
+[[ "$CONFIG_CHAIN_ID" == "$EXPECTED_CHAIN_ID" ]] || fail "Expected ._chainId=$EXPECTED_CHAIN_ID, found: $CONFIG_CHAIN_ID"
+
+MANIFEST_PATH="$(json_get "$FULL_DEPLOY_CONFIG" '.manifest.path')"
+[[ -n "$MANIFEST_PATH" && "$MANIFEST_PATH" != "null" ]] || fail "Missing .manifest.path in $FULL_DEPLOY_CONFIG"
+
+MIGRATION_DEPLOY="$(jq -r '.migration.deploy // false' "$FULL_DEPLOY_CONFIG")"
+MIGRATION_ARTIFACTS_PATH="$(jq -r '.migration.artifactsPath // empty' "$FULL_DEPLOY_CONFIG")"
+
+MANIFEST_DIR="$(dirname "$MANIFEST_PATH")"
+RELEASE_DIR="$MANIFEST_DIR/releases/$RELEASE_TAG"
+RELEASE_MANIFEST_PATH="$RELEASE_DIR/manifest.json"
+LATEST_PATH="$MANIFEST_PATH"
+
+RELEASE_MIGRATION_PATH=""
+LATEST_MIGRATION_PATH=""
+if [[ "$MIGRATION_DEPLOY" == "true" && -n "$MIGRATION_ARTIFACTS_PATH" && "$MIGRATION_ARTIFACTS_PATH" != "null" ]]; then
+  LATEST_MIGRATION_PATH="$MIGRATION_ARTIFACTS_PATH"
+  RELEASE_MIGRATION_PATH="$RELEASE_DIR/migration.json"
 fi
 
-if ! command -v forge >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-  echo "forge and jq are required" >&2
-  exit 1
+mkdir -p "$RELEASE_DIR"
+
+TEMP_CONFIG="$(mktemp "$ROOT_DIR/.base-sepolia-deploy.XXXXXX.json")"
+cleanup() {
+  rm -f "$TEMP_CONFIG"
+}
+trap cleanup EXIT
+
+if [[ -n "$RELEASE_MIGRATION_PATH" ]]; then
+  jq \
+    --arg manifest_path "$RELEASE_MANIFEST_PATH" \
+    --arg migration_path "$RELEASE_MIGRATION_PATH" \
+    '.manifest.path = $manifest_path | .migration.artifactsPath = $migration_path' \
+    "$FULL_DEPLOY_CONFIG" >"$TEMP_CONFIG"
+else
+  jq \
+    --arg manifest_path "$RELEASE_MANIFEST_PATH" \
+    '.manifest.path = $manifest_path' \
+    "$FULL_DEPLOY_CONFIG" >"$TEMP_CONFIG"
 fi
 
-MANIFEST_PATH="$(jq -r '.manifest.path' "$FULL_DEPLOY_CONFIG")"
-if [[ -z "$MANIFEST_PATH" || "$MANIFEST_PATH" == "null" ]]; then
-  echo "Missing .manifest.path in $FULL_DEPLOY_CONFIG" >&2
-  exit 1
+RPC_CHAIN_ID="$(cast chain-id --rpc-url "$BASE_SEPOLIA_RPC")"
+[[ "$RPC_CHAIN_ID" == "$EXPECTED_CHAIN_ID" ]] || fail "RPC chain id mismatch: expected $EXPECTED_CHAIN_ID, got $RPC_CHAIN_ID"
+
+DEPLOYER_ADDRESS="$(cast wallet address --private-key "$PRIVATE_KEY")"
+CONFIG_ADMIN="$(json_get "$FULL_DEPLOY_CONFIG" '.roles.admin')"
+
+if [[ "${ALLOW_ADMIN_MISMATCH:-false}" != "true" && "$CONFIG_ADMIN" != "$DEPLOYER_ADDRESS" ]]; then
+  fail "Config admin ($CONFIG_ADMIN) does not match deployer key ($DEPLOYER_ADDRESS). FullDeploy performs privileged setup during deployment, so PRIVATE_KEY must currently control .roles.admin."
 fi
 
-echo "==> Deploying TNT protocol to Base Sepolia"
-echo "Config:    $FULL_DEPLOY_CONFIG"
-echo "Manifest:  $MANIFEST_PATH"
-echo "Profile:   $FOUNDRY_PROFILE"
+echo "==> Base Sepolia launch"
+echo "Config:            $FULL_DEPLOY_CONFIG"
+echo "Temp config:       $TEMP_CONFIG"
+echo "Release tag:       $RELEASE_TAG"
+echo "Release dir:       $RELEASE_DIR"
+echo "Release manifest:  $RELEASE_MANIFEST_PATH"
+echo "Stable manifest:   $LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" ]]; then
+  echo "Release migration: $RELEASE_MIGRATION_PATH"
+  echo "Stable migration:  $LATEST_MIGRATION_PATH"
+fi
+echo "Profile:           $FOUNDRY_PROFILE"
+echo "Deployer:          $DEPLOYER_ADDRESS"
 
-FULL_DEPLOY_CONFIG="$FULL_DEPLOY_CONFIG" \
-FOUNDRY_PROFILE="$FOUNDRY_PROFILE" \
-forge script script/FullDeploy.s.sol:FullDeploy \
-  --rpc-url "$BASE_SEPOLIA_RPC" \
-  --broadcast \
+FORGE_ARGS=(
+  script script/FullDeploy.s.sol:FullDeploy
+  --rpc-url "$BASE_SEPOLIA_RPC"
   --non-interactive
+)
 
-echo ""
-echo "Done."
-echo "Manifest: $MANIFEST_PATH"
+if bool_env "$DRY_RUN"; then
+  echo "Mode:              dry-run"
+else
+  echo "Mode:              broadcast"
+  FORGE_ARGS+=(--broadcast)
+fi
+
+FULL_DEPLOY_CONFIG="$TEMP_CONFIG" \
+FOUNDRY_PROFILE="$FOUNDRY_PROFILE" \
+forge "${FORGE_ARGS[@]}"
+
+[[ -f "$RELEASE_MANIFEST_PATH" ]] || fail "Expected manifest not written: $RELEASE_MANIFEST_PATH"
+
+if bool_env "$DRY_RUN"; then
+  echo
+  echo "Dry-run completed."
+  echo "Release manifest: $RELEASE_MANIFEST_PATH"
+  echo "Stable manifest unchanged: $LATEST_PATH"
+  exit 0
+fi
+
+if ! bool_env "$SKIP_VERIFY"; then
+  "$ROOT_DIR/script/sh/verify-full-deploy-manifest.sh" \
+    --manifest "$RELEASE_MANIFEST_PATH" \
+    --rpc-url "$BASE_SEPOLIA_RPC" \
+    --chain-id "$EXPECTED_CHAIN_ID"
+else
+  echo "Skipping manifest verification because SKIP_VERIFY=true"
+fi
+
+cp "$RELEASE_MANIFEST_PATH" "$LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" && -f "$RELEASE_MIGRATION_PATH" ]]; then
+  cp "$RELEASE_MIGRATION_PATH" "$LATEST_MIGRATION_PATH"
+fi
+
+echo
+echo "Deployment verified."
+echo "Release manifest: $RELEASE_MANIFEST_PATH"
+echo "Stable manifest:  $LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" && -f "$RELEASE_MIGRATION_PATH" ]]; then
+  echo "Stable migration: $LATEST_MIGRATION_PATH"
+fi

--- a/script/sh/verify-full-deploy-manifest.sh
+++ b/script/sh/verify-full-deploy-manifest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  script/sh/verify-full-deploy-manifest.sh --manifest <path> --rpc-url <url> [--chain-id <id>]
+
+Checks that a FullDeploy manifest exists, has the expected chain id, and that each deployed
+contract address in the manifest has non-empty bytecode on the target RPC.
+EOF
+}
+
+MANIFEST_PATH=""
+RPC_URL=""
+EXPECTED_CHAIN_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      MANIFEST_PATH="${2:-}"
+      shift 2
+      ;;
+    --rpc-url)
+      RPC_URL="${2:-}"
+      shift 2
+      ;;
+    --chain-id)
+      EXPECTED_CHAIN_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$MANIFEST_PATH" ]] || fail "Missing --manifest"
+[[ -n "$RPC_URL" ]] || fail "Missing --rpc-url"
+[[ -f "$MANIFEST_PATH" ]] || fail "Manifest not found: $MANIFEST_PATH"
+
+require_cmd jq
+require_cmd cast
+
+CHAIN_ID_IN_MANIFEST="$(jq -er '.chainId' "$MANIFEST_PATH")"
+if [[ -n "$EXPECTED_CHAIN_ID" && "$CHAIN_ID_IN_MANIFEST" != "$EXPECTED_CHAIN_ID" ]]; then
+  fail "Manifest chain id mismatch: expected $EXPECTED_CHAIN_ID, got $CHAIN_ID_IN_MANIFEST"
+fi
+
+RPC_CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL")"
+if [[ "$CHAIN_ID_IN_MANIFEST" != "$RPC_CHAIN_ID" ]]; then
+  fail "RPC chain id mismatch: manifest has $CHAIN_ID_IN_MANIFEST, RPC returned $RPC_CHAIN_ID"
+fi
+
+NETWORK="$(jq -er '.network' "$MANIFEST_PATH")"
+DEPLOYER="$(jq -er '.deployer' "$MANIFEST_PATH")"
+
+echo "==> Verifying FullDeploy manifest"
+echo "Manifest:  $MANIFEST_PATH"
+echo "Network:   $NETWORK"
+echo "Chain id:  $CHAIN_ID_IN_MANIFEST"
+echo "Deployer:  $DEPLOYER"
+
+check_code() {
+  local label="$1"
+  local address="$2"
+  if [[ -z "$address" || "$address" == "null" || "$address" == "0x0000000000000000000000000000000000000000" ]]; then
+    return 0
+  fi
+
+  local code
+  code="$(cast code "$address" --rpc-url "$RPC_URL" 2>/dev/null || true)"
+  if [[ ! "$code" =~ ^0x[0-9a-fA-F]{10,}$ ]]; then
+    fail "No deployed bytecode for $label at $address"
+  fi
+
+  echo "Verified $label: $address"
+}
+
+check_code "tangle" "$(jq -r '.tangle // empty' "$MANIFEST_PATH")"
+check_code "staking" "$(jq -r '.staking // .restaking // empty' "$MANIFEST_PATH")"
+check_code "statusRegistry" "$(jq -r '.statusRegistry // empty' "$MANIFEST_PATH")"
+check_code "tntToken" "$(jq -r '.tntToken // empty' "$MANIFEST_PATH")"
+check_code "metrics" "$(jq -r '.metrics // empty' "$MANIFEST_PATH")"
+check_code "rewardVaults" "$(jq -r '.rewardVaults // empty' "$MANIFEST_PATH")"
+check_code "inflationPool" "$(jq -r '.inflationPool // empty' "$MANIFEST_PATH")"
+check_code "credits" "$(jq -r '.credits // empty' "$MANIFEST_PATH")"
+check_code "tangleMigration" "$(jq -r '.migration.tangleMigration // empty' "$MANIFEST_PATH")"
+check_code "zkVerifier" "$(jq -r '.migration.zkVerifier // empty' "$MANIFEST_PATH")"
+
+echo "Manifest verification passed."


### PR DESCRIPTION
## What changed
- rewrote the Base Sepolia deploy wrapper to behave like a release launcher instead of a one-shot script
- write each run to `deployments/base-sepolia/releases/<tag>/` first
- only refresh `deployments/base-sepolia/latest.json` after a successful verified broadcast
- added preflight checks for toolchain, config network/chain id, RPC chain id, and deployer/admin mismatch
- added `script/sh/verify-full-deploy-manifest.sh` to validate the manifest against live on-chain bytecode after deployment

## Why
The previous wrapper overwrote the stable manifest directly and did not enforce enough launch-time validation. That made reruns and testnet go-live operations fragile.

A dry-run also exposed an underlying deploy constraint: `FullDeploy` currently performs privileged setup during deployment, so the deploy key must control `.roles.admin`. The wrapper now fails fast on that mismatch instead of letting the deployment revert mid-run.

## Operator impact
- operators get timestamped release snapshots for auditability and rollback
- `latest.json` remains the stable pointer for downstream tooling
- misconfigured deploy credentials fail before broadcast instead of halfway through deployment

## Validation
- `bash -n script/sh/deploy-testnet-base-sepolia.sh`
- `bash -n script/sh/verify-full-deploy-manifest.sh`
- Base Sepolia dry-run through the new launcher
- live manifest verification smoke test against known deployed Base Sepolia contracts
