### PR TITLE
fix(deploy): enforce governance handoff invariants

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,7 +21,7 @@ optimizer = false
 sparse_mode = true
 gas_reports = []
 fuzz = { runs = 256 }
-invariant = { runs = 64, depth = 64, fail_on_revert = false }
+invariant = { runs = 64, depth = 64, fail_on_revert = true }
 
 [profile.local_build]
 # Local build-only profile that excludes tests and scripts from the compile graph.
@@ -61,7 +61,7 @@ wrap_comments = true
 
 
 [invariant]
-fail_on_revert = false
+fail_on_revert = true
 runs = 256
 depth = 120
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -189,6 +189,26 @@ contract DeployV2 is DeployScriptBase {
             address statusRegistry
         )
     {
+        return _deployCore(deployerPrivateKey, deployer, admin, treasury, admin, broadcast);
+    }
+
+    function _deployCore(
+        uint256 deployerPrivateKey,
+        address deployer,
+        address admin,
+        address treasury,
+        address statusRegistryOwner,
+        bool broadcast
+    )
+        internal
+        returns (
+            address stakingProxy,
+            address stakingImpl,
+            address tangleProxy,
+            address tangleImpl,
+            address statusRegistry
+        )
+    {
         if (broadcast) {
             vm.startBroadcast(deployerPrivateKey);
         } else if (deployer != address(0)) {
@@ -206,7 +226,8 @@ contract DeployV2 is DeployScriptBase {
         _registerStakingFacets(stakingProxy);
         _registerTangleFacets(tangleProxy);
 
-        statusRegistry = deployOperatorStatusRegistry(tangleProxy, admin);
+        address registryOwner = statusRegistryOwner == address(0) ? admin : statusRegistryOwner;
+        statusRegistry = deployOperatorStatusRegistry(tangleProxy, registryOwner);
         console2.log("OperatorStatusRegistry:", statusRegistry);
 
         // Verify proxy deployments

--- a/script/FullDeploy.s.sol
+++ b/script/FullDeploy.s.sol
@@ -17,6 +17,7 @@ import { Types } from "../src/libraries/Types.sol";
 import { ITangleAdmin } from "../src/interfaces/ITangle.sol";
 import { IMultiAssetDelegation } from "../src/interfaces/IMultiAssetDelegation.sol";
 import { MultiAssetDelegation } from "../src/staking/MultiAssetDelegation.sol";
+import { OperatorStatusRegistry } from "../src/staking/OperatorStatusRegistry.sol";
 import { RewardVaults } from "../src/rewards/RewardVaults.sol";
 import { TangleMetrics } from "../src/rewards/TangleMetrics.sol";
 import { InflationPool } from "../src/rewards/InflationPool.sol";
@@ -178,6 +179,8 @@ contract FullDeploy is DeployV2 {
         address metrics;
         address rewardVaults;
         address inflationPool;
+        address serviceFeeDistributor;
+        address streamingPaymentManager;
         address credits;
         StakeAssetConfig[] assets;
         RewardVaultConfig[] vaults;
@@ -221,7 +224,7 @@ contract FullDeploy is DeployV2 {
         _applyCoreOverrides(cfg.core);
 
         (address staking, address tangle, address statusRegistry) =
-            _resolveCore(cfg.core, deployerKey, deployer, admin, treasury);
+            _resolveCore(cfg.core, deployerKey, deployer, admin, treasury, timelock);
 
         vm.startBroadcast(deployerKey);
 
@@ -272,6 +275,29 @@ contract FullDeploy is DeployV2 {
         );
         vm.stopBroadcast();
 
+        _assertGovernanceConfiguration(
+            cfg.roles,
+            admin,
+            timelock,
+            multisig,
+            tangle,
+            staking,
+            statusRegistry,
+            tntToken,
+            metrics,
+            rewardVaults,
+            inflationPool,
+            serviceFeeDistributor,
+            streamingPaymentManager
+        );
+
+        address creditsOwner = cfg.credits.owner;
+        if (credits != address(0) && creditsOwner == address(0)) {
+            creditsOwner = timelock != address(0) ? timelock : admin;
+        }
+        _assertOwnableOwner(credits, creditsOwner, "Credits owner mismatch");
+        _assertOwnableOwner(migration.tangleMigration, migration.migrationOwner, "Migration owner mismatch");
+
         _runSmokeTests(staking, tangle, rewardVaults, cfg.stakeAssets, cfg.guards);
 
         DeploymentArtifacts memory artifacts = DeploymentArtifacts({
@@ -289,6 +315,8 @@ contract FullDeploy is DeployV2 {
             metrics: metrics,
             rewardVaults: rewardVaults,
             inflationPool: inflationPool,
+            serviceFeeDistributor: serviceFeeDistributor,
+            streamingPaymentManager: streamingPaymentManager,
             credits: credits,
             assets: cfg.stakeAssets,
             vaults: cfg.incentives.vaults,
@@ -620,7 +648,8 @@ contract FullDeploy is DeployV2 {
         uint256 deployerKey,
         address deployer,
         address admin,
-        address treasury
+        address treasury,
+        address timelock
     )
         internal
         returns (address staking, address tangle, address statusRegistry)
@@ -628,7 +657,9 @@ contract FullDeploy is DeployV2 {
         bool needsDeploy = core.deploy || core.staking == address(0) || core.tangle == address(0);
         if (needsDeploy) {
             console2.log("Deploying core stack...");
-            (staking,, tangle,, statusRegistry) = _deployCore(deployerKey, deployer, admin, treasury, true);
+            address statusRegistryOwner = timelock == address(0) ? admin : timelock;
+            (staking,, tangle,, statusRegistry) =
+                _deployCore(deployerKey, deployer, admin, treasury, statusRegistryOwner, true);
         } else {
             staking = core.staking;
             tangle = core.tangle;
@@ -1033,11 +1064,11 @@ contract FullDeploy is DeployV2 {
             _grantRole(tangleAddr, tangle.SLASH_ADMIN_ROLE(), multisig);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(tangleAddr, bytes32(0), bootstrapAdmin);
-                _revokeRole(tangleAddr, tangle.ADMIN_ROLE(), bootstrapAdmin);
-                _revokeRole(tangleAddr, tangle.UPGRADER_ROLE(), bootstrapAdmin);
                 _revokeRole(tangleAddr, tangle.PAUSER_ROLE(), bootstrapAdmin);
                 _revokeRole(tangleAddr, tangle.SLASH_ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(tangleAddr, tangle.ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(tangleAddr, tangle.UPGRADER_ROLE(), bootstrapAdmin);
+                _revokeRole(tangleAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1048,9 +1079,9 @@ contract FullDeploy is DeployV2 {
             _grantRole(stakingAddr, staking.ASSET_MANAGER_ROLE(), multisig);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(stakingAddr, bytes32(0), bootstrapAdmin);
-                _revokeRole(stakingAddr, staking.ADMIN_ROLE(), bootstrapAdmin);
                 _revokeRole(stakingAddr, staking.ASSET_MANAGER_ROLE(), bootstrapAdmin);
+                _revokeRole(stakingAddr, staking.ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(stakingAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1060,9 +1091,9 @@ contract FullDeploy is DeployV2 {
             _grantRole(tntToken, keccak256("UPGRADER_ROLE"), timelock);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(tntToken, bytes32(0), bootstrapAdmin);
                 _revokeRole(tntToken, keccak256("MINTER_ROLE"), bootstrapAdmin);
                 _revokeRole(tntToken, keccak256("UPGRADER_ROLE"), bootstrapAdmin);
+                _revokeRole(tntToken, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1071,8 +1102,8 @@ contract FullDeploy is DeployV2 {
             _grantRole(metricsAddr, keccak256("UPGRADER_ROLE"), timelock);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(metricsAddr, bytes32(0), bootstrapAdmin);
                 _revokeRole(metricsAddr, keccak256("UPGRADER_ROLE"), bootstrapAdmin);
+                _revokeRole(metricsAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1083,10 +1114,10 @@ contract FullDeploy is DeployV2 {
             _grantRole(rewardVaultsAddr, vaults.UPGRADER_ROLE(), timelock);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(rewardVaultsAddr, bytes32(0), bootstrapAdmin);
+                _revokeRole(rewardVaultsAddr, vaults.REWARDS_MANAGER_ROLE(), bootstrapAdmin);
                 _revokeRole(rewardVaultsAddr, vaults.ADMIN_ROLE(), bootstrapAdmin);
                 _revokeRole(rewardVaultsAddr, vaults.UPGRADER_ROLE(), bootstrapAdmin);
-                _revokeRole(rewardVaultsAddr, vaults.REWARDS_MANAGER_ROLE(), bootstrapAdmin);
+                _revokeRole(rewardVaultsAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1098,13 +1129,13 @@ contract FullDeploy is DeployV2 {
             _grantRole(inflationPoolAddr, pool.FUNDER_ROLE(), treasury);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(inflationPoolAddr, bytes32(0), bootstrapAdmin);
-                _revokeRole(inflationPoolAddr, pool.ADMIN_ROLE(), bootstrapAdmin);
-                _revokeRole(inflationPoolAddr, pool.UPGRADER_ROLE(), bootstrapAdmin);
                 if (bootstrapAdmin != treasury) {
                     _revokeRole(inflationPoolAddr, pool.FUNDER_ROLE(), bootstrapAdmin);
                 }
                 _revokeRole(inflationPoolAddr, pool.DISTRIBUTOR_ROLE(), bootstrapAdmin);
+                _revokeRole(inflationPoolAddr, pool.ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(inflationPoolAddr, pool.UPGRADER_ROLE(), bootstrapAdmin);
+                _revokeRole(inflationPoolAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1115,9 +1146,9 @@ contract FullDeploy is DeployV2 {
             _grantRole(serviceFeeDistributorAddr, distributor.UPGRADER_ROLE(), timelock);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(serviceFeeDistributorAddr, bytes32(0), bootstrapAdmin);
-                _revokeRole(serviceFeeDistributorAddr, distributor.ADMIN_ROLE(), bootstrapAdmin);
                 _revokeRole(serviceFeeDistributorAddr, distributor.UPGRADER_ROLE(), bootstrapAdmin);
+                _revokeRole(serviceFeeDistributorAddr, distributor.ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(serviceFeeDistributorAddr, bytes32(0), bootstrapAdmin);
             }
         }
 
@@ -1128,9 +1159,9 @@ contract FullDeploy is DeployV2 {
             _grantRole(streamingPaymentManagerAddr, streaming.UPGRADER_ROLE(), timelock);
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
-                _revokeRole(streamingPaymentManagerAddr, bytes32(0), bootstrapAdmin);
-                _revokeRole(streamingPaymentManagerAddr, streaming.ADMIN_ROLE(), bootstrapAdmin);
                 _revokeRole(streamingPaymentManagerAddr, streaming.UPGRADER_ROLE(), bootstrapAdmin);
+                _revokeRole(streamingPaymentManagerAddr, streaming.ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(streamingPaymentManagerAddr, bytes32(0), bootstrapAdmin);
             }
         }
     }
@@ -1158,6 +1189,181 @@ contract FullDeploy is DeployV2 {
         if (IAccessControl(target).hasRole(role, account)) {
             IAccessControl(target).revokeRole(role, account);
         }
+    }
+
+    function _assertGovernanceConfiguration(
+        RolesConfig memory roles,
+        address bootstrapAdmin,
+        address timelock,
+        address multisig,
+        address tangleAddr,
+        address stakingAddr,
+        address statusRegistryAddr,
+        address tntToken,
+        address metricsAddr,
+        address rewardVaultsAddr,
+        address inflationPoolAddr,
+        address serviceFeeDistributorAddr,
+        address streamingPaymentManagerAddr
+    )
+        internal
+        view
+    {
+        bool requested = roles.timelock != address(0) || roles.multisig != address(0) || roles.revokeBootstrap;
+        if (!requested) return;
+
+        _assertOwnableOwner(statusRegistryAddr, timelock, "OperatorStatusRegistry owner mismatch");
+
+        if (tangleAddr != address(0)) {
+            Tangle tangle = Tangle(payable(tangleAddr));
+            _assertHasRole(tangleAddr, bytes32(0), timelock, "Tangle missing DEFAULT_ADMIN_ROLE");
+            _assertHasRole(tangleAddr, tangle.ADMIN_ROLE(), timelock, "Tangle missing ADMIN_ROLE");
+            _assertHasRole(tangleAddr, tangle.UPGRADER_ROLE(), timelock, "Tangle missing UPGRADER_ROLE");
+            _assertHasRole(tangleAddr, tangle.PAUSER_ROLE(), multisig, "Tangle missing PAUSER_ROLE");
+            _assertHasRole(tangleAddr, tangle.SLASH_ADMIN_ROLE(), multisig, "Tangle missing SLASH_ADMIN_ROLE");
+
+            if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
+                _assertMissingRole(tangleAddr, bytes32(0), bootstrapAdmin, "Bootstrap still has Tangle admin");
+                _assertMissingRole(tangleAddr, tangle.ADMIN_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle ADMIN_ROLE");
+                _assertMissingRole(
+                    tangleAddr, tangle.UPGRADER_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle UPGRADER_ROLE"
+                );
+                _assertMissingRole(
+                    tangleAddr, tangle.PAUSER_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle PAUSER_ROLE"
+                );
+                _assertMissingRole(
+                    tangleAddr,
+                    tangle.SLASH_ADMIN_ROLE(),
+                    bootstrapAdmin,
+                    "Bootstrap still has Tangle SLASH_ADMIN_ROLE"
+                );
+            }
+        }
+
+        if (stakingAddr != address(0)) {
+            MultiAssetDelegation staking = MultiAssetDelegation(payable(stakingAddr));
+            _assertHasRole(stakingAddr, bytes32(0), timelock, "Staking missing DEFAULT_ADMIN_ROLE");
+            _assertHasRole(stakingAddr, staking.ADMIN_ROLE(), timelock, "Staking missing ADMIN_ROLE");
+            _assertHasRole(stakingAddr, staking.ASSET_MANAGER_ROLE(), multisig, "Staking missing ASSET_MANAGER_ROLE");
+
+            if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
+                _assertMissingRole(stakingAddr, bytes32(0), bootstrapAdmin, "Bootstrap still has Staking admin");
+                _assertMissingRole(
+                    stakingAddr, staking.ADMIN_ROLE(), bootstrapAdmin, "Bootstrap still has Staking ADMIN_ROLE"
+                );
+                _assertMissingRole(
+                    stakingAddr,
+                    staking.ASSET_MANAGER_ROLE(),
+                    bootstrapAdmin,
+                    "Bootstrap still has Staking ASSET_MANAGER_ROLE"
+                );
+            }
+        }
+
+        if (tntToken != address(0)) {
+            _assertHasRole(tntToken, bytes32(0), timelock, "TNT token missing DEFAULT_ADMIN_ROLE");
+            _assertHasRole(tntToken, keccak256("MINTER_ROLE"), timelock, "TNT token missing MINTER_ROLE");
+            _assertHasRole(tntToken, keccak256("UPGRADER_ROLE"), timelock, "TNT token missing UPGRADER_ROLE");
+            if (roles.revokeBootstrap && bootstrapAdmin != address(0) && bootstrapAdmin != timelock) {
+                _assertMissingRole(tntToken, bytes32(0), bootstrapAdmin, "Bootstrap still has TNT DEFAULT_ADMIN_ROLE");
+                _assertMissingRole(
+                    tntToken, keccak256("MINTER_ROLE"), bootstrapAdmin, "Bootstrap still has TNT MINTER_ROLE"
+                );
+                _assertMissingRole(
+                    tntToken, keccak256("UPGRADER_ROLE"), bootstrapAdmin, "Bootstrap still has TNT UPGRADER_ROLE"
+                );
+            }
+        }
+
+        if (metricsAddr != address(0)) {
+            _assertHasRole(metricsAddr, bytes32(0), timelock, "Metrics missing DEFAULT_ADMIN_ROLE");
+            _assertHasRole(metricsAddr, keccak256("UPGRADER_ROLE"), timelock, "Metrics missing UPGRADER_ROLE");
+            if (roles.revokeBootstrap && bootstrapAdmin != address(0) && bootstrapAdmin != timelock) {
+                _assertMissingRole(
+                    metricsAddr, bytes32(0), bootstrapAdmin, "Bootstrap still has Metrics DEFAULT_ADMIN_ROLE"
+                );
+                _assertMissingRole(
+                    metricsAddr, keccak256("UPGRADER_ROLE"), bootstrapAdmin, "Bootstrap still has Metrics UPGRADER_ROLE"
+                );
+            }
+        }
+
+        _assertManagedContractRoles(
+            rewardVaultsAddr,
+            timelock,
+            bootstrapAdmin,
+            roles.revokeBootstrap,
+            "ADMIN_ROLE",
+            "UPGRADER_ROLE"
+        );
+        _assertManagedContractRoles(
+            inflationPoolAddr,
+            timelock,
+            bootstrapAdmin,
+            roles.revokeBootstrap,
+            "ADMIN_ROLE",
+            "UPGRADER_ROLE"
+        );
+        _assertManagedContractRoles(
+            serviceFeeDistributorAddr,
+            timelock,
+            bootstrapAdmin,
+            roles.revokeBootstrap,
+            "ADMIN_ROLE",
+            "UPGRADER_ROLE"
+        );
+        _assertManagedContractRoles(
+            streamingPaymentManagerAddr,
+            timelock,
+            bootstrapAdmin,
+            roles.revokeBootstrap,
+            "ADMIN_ROLE",
+            "UPGRADER_ROLE"
+        );
+    }
+
+    function _assertManagedContractRoles(
+        address target,
+        address timelock,
+        address bootstrapAdmin,
+        bool revokeBootstrap,
+        string memory adminRoleName,
+        string memory upgraderRoleName
+    )
+        internal
+        view
+    {
+        if (target == address(0)) return;
+        _assertHasRole(target, bytes32(0), timelock, "Managed contract missing DEFAULT_ADMIN_ROLE");
+        _assertHasRole(target, keccak256(bytes(adminRoleName)), timelock, "Managed contract missing ADMIN_ROLE");
+        _assertHasRole(
+            target, keccak256(bytes(upgraderRoleName)), timelock, "Managed contract missing UPGRADER_ROLE"
+        );
+
+        if (revokeBootstrap && bootstrapAdmin != address(0) && bootstrapAdmin != timelock) {
+            _assertMissingRole(target, bytes32(0), bootstrapAdmin, "Bootstrap still has DEFAULT_ADMIN_ROLE");
+            _assertMissingRole(
+                target, keccak256(bytes(adminRoleName)), bootstrapAdmin, "Bootstrap still has ADMIN_ROLE"
+            );
+            _assertMissingRole(
+                target, keccak256(bytes(upgraderRoleName)), bootstrapAdmin, "Bootstrap still has UPGRADER_ROLE"
+            );
+        }
+    }
+
+    function _assertHasRole(address target, bytes32 role, address account, string memory reason) internal view {
+        if (target == address(0) || account == address(0)) return;
+        require(IAccessControl(target).hasRole(role, account), reason);
+    }
+
+    function _assertMissingRole(address target, bytes32 role, address account, string memory reason) internal view {
+        if (target == address(0) || account == address(0)) return;
+        require(!IAccessControl(target).hasRole(role, account), reason);
+    }
+
+    function _assertOwnableOwner(address target, address expectedOwner, string memory reason) internal view {
+        if (target == address(0) || expectedOwner == address(0)) return;
+        require(OperatorStatusRegistry(target).owner() == expectedOwner, reason);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1354,7 +1560,7 @@ contract FullDeploy is DeployV2 {
 
         _ensureParentDir(manifest.path);
 
-        string memory json = string(
+        string memory header = string(
             abi.encodePacked(
                 "{",
                 "\"network\":\"",
@@ -1377,7 +1583,14 @@ contract FullDeploy is DeployV2 {
                 "\",",
                 "\"multisig\":\"",
                 _addrToString(artifacts.multisig),
-                "\",",
+                "\""
+            )
+        );
+
+        string memory coreAddresses = string(
+            abi.encodePacked(
+                header,
+                ",",
                 "\"tangle\":\"",
                 _addrToString(artifacts.tangle),
                 "\",",
@@ -1402,9 +1615,22 @@ contract FullDeploy is DeployV2 {
                 "\"inflationPool\":\"",
                 _addrToString(artifacts.inflationPool),
                 "\",",
+                "\"serviceFeeDistributor\":\"",
+                _addrToString(artifacts.serviceFeeDistributor),
+                "\",",
+                "\"streamingPaymentManager\":\"",
+                _addrToString(artifacts.streamingPaymentManager),
+                "\",",
                 "\"credits\":\"",
                 _addrToString(artifacts.credits),
-                "\",",
+                "\""
+            )
+        );
+
+        string memory json = string(
+            abi.encodePacked(
+                coreAddresses,
+                ",",
                 "\"epochLength\":",
                 artifacts.epochLength.toString(),
                 ",",
@@ -1580,7 +1806,7 @@ contract FullDeploy is DeployV2 {
     }
 
     function _migrationToJson(MigrationConfig memory migration) internal pure returns (string memory) {
-        return string(
+        string memory filePaths = string(
             abi.encodePacked(
                 "{",
                 '"deploy":',
@@ -1609,7 +1835,14 @@ contract FullDeploy is DeployV2 {
                 '",',
                 '"notes":"',
                 migration.notes,
-                '",',
+                '"'
+            )
+        );
+
+        string memory allocationFields = string(
+            abi.encodePacked(
+                filePaths,
+                ",",
                 '"migrationOwner":"',
                 _addrToString(migration.migrationOwner),
                 '",',
@@ -1639,7 +1872,14 @@ contract FullDeploy is DeployV2 {
                 '",',
                 '"foundationAmount":"',
                 migration.foundationAmount.toString(),
-                '",',
+                '"'
+            )
+        );
+
+        return string(
+            abi.encodePacked(
+                allocationFields,
+                ",",
                 '"claimDeadline":"',
                 migration.claimDeadline.toString(),
                 '",',

--- a/script/sh/deploy-testnet-base-sepolia.sh
+++ b/script/sh/deploy-testnet-base-sepolia.sh
@@ -60,6 +60,7 @@ require_cmd cp
 require_cmd mktemp
 
 [[ -f "$FULL_DEPLOY_CONFIG" ]] || fail "Config not found: $FULL_DEPLOY_CONFIG"
+[[ "$RELEASE_TAG" =~ ^[A-Za-z0-9._-]+$ ]] || fail "RELEASE_TAG contains unsafe characters: $RELEASE_TAG"
 
 CONFIG_NETWORK="$(json_get "$FULL_DEPLOY_CONFIG" '.network')"
 [[ "$CONFIG_NETWORK" == "base-sepolia" ]] || fail "Expected .network=base-sepolia, found: $CONFIG_NETWORK"
@@ -90,6 +91,9 @@ mkdir -p "$RELEASE_DIR"
 TEMP_CONFIG="$(mktemp "$ROOT_DIR/.base-sepolia-deploy.XXXXXX.json")"
 cleanup() {
   rm -f "$TEMP_CONFIG"
+  if bool_env "$DRY_RUN"; then
+    rm -rf "$RELEASE_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -160,6 +164,7 @@ fi
 if ! bool_env "$SKIP_VERIFY"; then
   "$ROOT_DIR/script/sh/verify-full-deploy-manifest.sh" \
     --manifest "$RELEASE_MANIFEST_PATH" \
+    --config "$TEMP_CONFIG" \
     --rpc-url "$BASE_SEPOLIA_RPC" \
     --chain-id "$EXPECTED_CHAIN_ID"
 else

--- a/script/sh/deploy-testnet-base-sepolia.sh
+++ b/script/sh/deploy-testnet-base-sepolia.sh
@@ -1,53 +1,180 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deploy the TNT protocol stack to Base Sepolia using the config-driven FullDeploy flow.
+# Release-oriented deploy wrapper for the Base Sepolia FullDeploy flow.
 #
 # Required env:
 # - PRIVATE_KEY
 # - BASE_SEPOLIA_RPC
 #
 # Optional env:
-# - FULL_DEPLOY_CONFIG (defaults to deploy/config/base-sepolia.json)
-# - FOUNDRY_PROFILE (defaults to deploy_size to keep ServiceFeeDistributor under EIP-170)
+# - FULL_DEPLOY_CONFIG      defaults to deploy/config/base-sepolia.json
+# - FOUNDRY_PROFILE         defaults to deploy_size
+# - RELEASE_TAG             defaults to UTC timestamp (YYYYmmdd-HHMMSS)
+# - DRY_RUN                 true|false, defaults to false
+# - SKIP_VERIFY             true|false, defaults to false
+#
+# Behavior:
+# - Writes manifests into deployments/base-sepolia/releases/<tag>/
+# - Refreshes deployments/base-sepolia/latest.json only after a verified broadcast
+# - Leaves prior release snapshots intact for rollback/auditability
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-: "${PRIVATE_KEY:?Missing PRIVATE_KEY}"
-: "${BASE_SEPOLIA_RPC:?Missing BASE_SEPOLIA_RPC}"
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+}
+
+json_get() {
+  local file="$1"
+  local query="$2"
+  jq -er "$query" "$file"
+}
+
+bool_env() {
+  local value="${1:-false}"
+  [[ "$value" == "1" || "$value" == "true" || "$value" == "TRUE" || "$value" == "yes" || "$value" == "YES" ]]
+}
 
 FULL_DEPLOY_CONFIG="${FULL_DEPLOY_CONFIG:-deploy/config/base-sepolia.json}"
 FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-deploy_size}"
+RELEASE_TAG="${RELEASE_TAG:-$(date -u +%Y%m%d-%H%M%S)}"
+DRY_RUN="${DRY_RUN:-false}"
+SKIP_VERIFY="${SKIP_VERIFY:-false}"
+EXPECTED_CHAIN_ID=84532
 
-if [[ ! -f "$FULL_DEPLOY_CONFIG" ]]; then
-  echo "Config not found: $FULL_DEPLOY_CONFIG" >&2
-  exit 1
+: "${PRIVATE_KEY:?Missing PRIVATE_KEY}"
+: "${BASE_SEPOLIA_RPC:?Missing BASE_SEPOLIA_RPC}"
+
+require_cmd forge
+require_cmd jq
+require_cmd cast
+require_cmd cp
+require_cmd mktemp
+
+[[ -f "$FULL_DEPLOY_CONFIG" ]] || fail "Config not found: $FULL_DEPLOY_CONFIG"
+
+CONFIG_NETWORK="$(json_get "$FULL_DEPLOY_CONFIG" '.network')"
+[[ "$CONFIG_NETWORK" == "base-sepolia" ]] || fail "Expected .network=base-sepolia, found: $CONFIG_NETWORK"
+
+CONFIG_CHAIN_ID="$(json_get "$FULL_DEPLOY_CONFIG" '._chainId')"
+[[ "$CONFIG_CHAIN_ID" == "$EXPECTED_CHAIN_ID" ]] || fail "Expected ._chainId=$EXPECTED_CHAIN_ID, found: $CONFIG_CHAIN_ID"
+
+MANIFEST_PATH="$(json_get "$FULL_DEPLOY_CONFIG" '.manifest.path')"
+[[ -n "$MANIFEST_PATH" && "$MANIFEST_PATH" != "null" ]] || fail "Missing .manifest.path in $FULL_DEPLOY_CONFIG"
+
+MIGRATION_DEPLOY="$(jq -r '.migration.deploy // false' "$FULL_DEPLOY_CONFIG")"
+MIGRATION_ARTIFACTS_PATH="$(jq -r '.migration.artifactsPath // empty' "$FULL_DEPLOY_CONFIG")"
+
+MANIFEST_DIR="$(dirname "$MANIFEST_PATH")"
+RELEASE_DIR="$MANIFEST_DIR/releases/$RELEASE_TAG"
+RELEASE_MANIFEST_PATH="$RELEASE_DIR/manifest.json"
+LATEST_PATH="$MANIFEST_PATH"
+
+RELEASE_MIGRATION_PATH=""
+LATEST_MIGRATION_PATH=""
+if [[ "$MIGRATION_DEPLOY" == "true" && -n "$MIGRATION_ARTIFACTS_PATH" && "$MIGRATION_ARTIFACTS_PATH" != "null" ]]; then
+  LATEST_MIGRATION_PATH="$MIGRATION_ARTIFACTS_PATH"
+  RELEASE_MIGRATION_PATH="$RELEASE_DIR/migration.json"
 fi
 
-if ! command -v forge >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-  echo "forge and jq are required" >&2
-  exit 1
+mkdir -p "$RELEASE_DIR"
+
+TEMP_CONFIG="$(mktemp "$ROOT_DIR/.base-sepolia-deploy.XXXXXX.json")"
+cleanup() {
+  rm -f "$TEMP_CONFIG"
+}
+trap cleanup EXIT
+
+if [[ -n "$RELEASE_MIGRATION_PATH" ]]; then
+  jq \
+    --arg manifest_path "$RELEASE_MANIFEST_PATH" \
+    --arg migration_path "$RELEASE_MIGRATION_PATH" \
+    '.manifest.path = $manifest_path | .migration.artifactsPath = $migration_path' \
+    "$FULL_DEPLOY_CONFIG" >"$TEMP_CONFIG"
+else
+  jq \
+    --arg manifest_path "$RELEASE_MANIFEST_PATH" \
+    '.manifest.path = $manifest_path' \
+    "$FULL_DEPLOY_CONFIG" >"$TEMP_CONFIG"
 fi
 
-MANIFEST_PATH="$(jq -r '.manifest.path' "$FULL_DEPLOY_CONFIG")"
-if [[ -z "$MANIFEST_PATH" || "$MANIFEST_PATH" == "null" ]]; then
-  echo "Missing .manifest.path in $FULL_DEPLOY_CONFIG" >&2
-  exit 1
+RPC_CHAIN_ID="$(cast chain-id --rpc-url "$BASE_SEPOLIA_RPC")"
+[[ "$RPC_CHAIN_ID" == "$EXPECTED_CHAIN_ID" ]] || fail "RPC chain id mismatch: expected $EXPECTED_CHAIN_ID, got $RPC_CHAIN_ID"
+
+DEPLOYER_ADDRESS="$(cast wallet address --private-key "$PRIVATE_KEY")"
+CONFIG_ADMIN="$(json_get "$FULL_DEPLOY_CONFIG" '.roles.admin')"
+
+if [[ "${ALLOW_ADMIN_MISMATCH:-false}" != "true" && "$CONFIG_ADMIN" != "$DEPLOYER_ADDRESS" ]]; then
+  fail "Config admin ($CONFIG_ADMIN) does not match deployer key ($DEPLOYER_ADDRESS). FullDeploy performs privileged setup during deployment, so PRIVATE_KEY must currently control .roles.admin."
 fi
 
-echo "==> Deploying TNT protocol to Base Sepolia"
-echo "Config:    $FULL_DEPLOY_CONFIG"
-echo "Manifest:  $MANIFEST_PATH"
-echo "Profile:   $FOUNDRY_PROFILE"
+echo "==> Base Sepolia launch"
+echo "Config:            $FULL_DEPLOY_CONFIG"
+echo "Temp config:       $TEMP_CONFIG"
+echo "Release tag:       $RELEASE_TAG"
+echo "Release dir:       $RELEASE_DIR"
+echo "Release manifest:  $RELEASE_MANIFEST_PATH"
+echo "Stable manifest:   $LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" ]]; then
+  echo "Release migration: $RELEASE_MIGRATION_PATH"
+  echo "Stable migration:  $LATEST_MIGRATION_PATH"
+fi
+echo "Profile:           $FOUNDRY_PROFILE"
+echo "Deployer:          $DEPLOYER_ADDRESS"
 
-FULL_DEPLOY_CONFIG="$FULL_DEPLOY_CONFIG" \
-FOUNDRY_PROFILE="$FOUNDRY_PROFILE" \
-forge script script/FullDeploy.s.sol:FullDeploy \
-  --rpc-url "$BASE_SEPOLIA_RPC" \
-  --broadcast \
+FORGE_ARGS=(
+  script script/FullDeploy.s.sol:FullDeploy
+  --rpc-url "$BASE_SEPOLIA_RPC"
   --non-interactive
+)
 
-echo ""
-echo "Done."
-echo "Manifest: $MANIFEST_PATH"
+if bool_env "$DRY_RUN"; then
+  echo "Mode:              dry-run"
+else
+  echo "Mode:              broadcast"
+  FORGE_ARGS+=(--broadcast)
+fi
+
+FULL_DEPLOY_CONFIG="$TEMP_CONFIG" \
+FOUNDRY_PROFILE="$FOUNDRY_PROFILE" \
+forge "${FORGE_ARGS[@]}"
+
+[[ -f "$RELEASE_MANIFEST_PATH" ]] || fail "Expected manifest not written: $RELEASE_MANIFEST_PATH"
+
+if bool_env "$DRY_RUN"; then
+  echo
+  echo "Dry-run completed."
+  echo "Release manifest: $RELEASE_MANIFEST_PATH"
+  echo "Stable manifest unchanged: $LATEST_PATH"
+  exit 0
+fi
+
+if ! bool_env "$SKIP_VERIFY"; then
+  "$ROOT_DIR/script/sh/verify-full-deploy-manifest.sh" \
+    --manifest "$RELEASE_MANIFEST_PATH" \
+    --rpc-url "$BASE_SEPOLIA_RPC" \
+    --chain-id "$EXPECTED_CHAIN_ID"
+else
+  echo "Skipping manifest verification because SKIP_VERIFY=true"
+fi
+
+cp "$RELEASE_MANIFEST_PATH" "$LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" && -f "$RELEASE_MIGRATION_PATH" ]]; then
+  cp "$RELEASE_MIGRATION_PATH" "$LATEST_MIGRATION_PATH"
+fi
+
+echo
+echo "Deployment verified."
+echo "Release manifest: $RELEASE_MANIFEST_PATH"
+echo "Stable manifest:  $LATEST_PATH"
+if [[ -n "$RELEASE_MIGRATION_PATH" && -f "$RELEASE_MIGRATION_PATH" ]]; then
+  echo "Stable migration: $LATEST_MIGRATION_PATH"
+fi

--- a/script/sh/verify-full-deploy-manifest.sh
+++ b/script/sh/verify-full-deploy-manifest.sh
@@ -91,6 +91,12 @@ read_manifest_address() {
   jq -r "$query // empty" "$MANIFEST_PATH"
 }
 
+read_config_value() {
+  local query="$1"
+  [[ -n "$CONFIG_PATH" ]] || return 1
+  jq -r "$query // empty" "$CONFIG_PATH"
+}
+
 check_code() {
   local label="$1"
   local address="$2"
@@ -117,6 +123,53 @@ require_from_config() {
   [[ "$value" == "true" ]]
 }
 
+normalize_bool_result() {
+  local value
+  value="$(echo "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '\n\r[:space:]')"
+  [[ "$value" == "true" || "$value" == "0x0000000000000000000000000000000000000000000000000000000000000001" ]]
+}
+
+check_has_role() {
+  local label="$1"
+  local address="$2"
+  local role="$3"
+  local account="$4"
+  [[ -n "$address" && "$address" != "0x0000000000000000000000000000000000000000" ]] || return 0
+  [[ -n "$account" && "$account" != "0x0000000000000000000000000000000000000000" ]] || return 0
+
+  local result
+  result="$(cast call "$address" "hasRole(bytes32,address)(bool)" "$role" "$account" --rpc-url "$RPC_URL")"
+  normalize_bool_result "$result" || fail "$label missing role $role for $account"
+  echo "Verified $label role $role for $account"
+}
+
+check_missing_role() {
+  local label="$1"
+  local address="$2"
+  local role="$3"
+  local account="$4"
+  [[ -n "$address" && "$address" != "0x0000000000000000000000000000000000000000" ]] || return 0
+  [[ -n "$account" && "$account" != "0x0000000000000000000000000000000000000000" ]] || return 0
+
+  local result
+  result="$(cast call "$address" "hasRole(bytes32,address)(bool)" "$role" "$account" --rpc-url "$RPC_URL")"
+  normalize_bool_result "$result" && fail "$label unexpectedly retains role $role for $account"
+  echo "Verified $label does not grant role $role to $account"
+}
+
+check_owner() {
+  local label="$1"
+  local address="$2"
+  local expected_owner="$3"
+  [[ -n "$address" && "$address" != "0x0000000000000000000000000000000000000000" ]] || return 0
+  [[ -n "$expected_owner" && "$expected_owner" != "0x0000000000000000000000000000000000000000" ]] || return 0
+
+  local owner
+  owner="$(cast call "$address" "owner()(address)" --rpc-url "$RPC_URL" | tr -d '\n\r[:space:]')"
+  [[ "${owner,,}" == "${expected_owner,,}" ]] || fail "$label owner mismatch: expected $expected_owner, got $owner"
+  echo "Verified $label owner: $owner"
+}
+
 CORE_REQUIRED=false
 METRICS_REQUIRED=false
 REWARD_VAULTS_REQUIRED=false
@@ -140,5 +193,95 @@ check_code "inflationPool" "$(read_manifest_address '.inflationPool')" "$INFLATI
 check_code "credits" "$(read_manifest_address '.credits')" "$CREDITS_REQUIRED"
 check_code "tangleMigration" "$(read_manifest_address '.migration.tangleMigration')" "$MIGRATION_REQUIRED"
 check_code "zkVerifier" "$(read_manifest_address '.migration.zkVerifier')" "$MIGRATION_REQUIRED"
+
+if [[ -n "$CONFIG_PATH" ]]; then
+  DEFAULT_ADMIN_ROLE="0x0000000000000000000000000000000000000000000000000000000000000000"
+  ADMIN_ROLE="$(cast keccak "ADMIN_ROLE")"
+  PAUSER_ROLE="$(cast keccak "PAUSER_ROLE")"
+  UPGRADER_ROLE="$(cast keccak "UPGRADER_ROLE")"
+  SLASH_ADMIN_ROLE="$(cast keccak "SLASH_ADMIN_ROLE")"
+  ASSET_MANAGER_ROLE="$(cast keccak "ASSET_MANAGER_ROLE")"
+  MINTER_ROLE="$(cast keccak "MINTER_ROLE")"
+
+  CONFIG_ADMIN="$(read_config_value '.roles.admin')"
+  [[ -n "$CONFIG_ADMIN" ]] || CONFIG_ADMIN="$(read_manifest_address '.admin')"
+  CONFIG_TIMELOCK="$(read_config_value '.roles.timelock')"
+  CONFIG_MULTISIG="$(read_config_value '.roles.multisig')"
+  CONFIG_REVOKE_BOOTSTRAP="$(jq -r '.roles.revokeBootstrap // false' "$CONFIG_PATH")"
+
+  [[ -n "$CONFIG_TIMELOCK" && "$CONFIG_TIMELOCK" != "0x0000000000000000000000000000000000000000" ]] || CONFIG_TIMELOCK="$CONFIG_ADMIN"
+  [[ -n "$CONFIG_MULTISIG" && "$CONFIG_MULTISIG" != "0x0000000000000000000000000000000000000000" ]] || CONFIG_MULTISIG="$CONFIG_ADMIN"
+
+  TANGLE_ADDR="$(read_manifest_address '.tangle')"
+  STAKING_ADDR="$(read_manifest_address '.staking // .restaking')"
+  STATUS_REGISTRY_ADDR="$(read_manifest_address '.statusRegistry')"
+  TNT_TOKEN_ADDR="$(read_manifest_address '.tntToken')"
+  METRICS_ADDR="$(read_manifest_address '.metrics')"
+  REWARD_VAULTS_ADDR="$(read_manifest_address '.rewardVaults')"
+  INFLATION_POOL_ADDR="$(read_manifest_address '.inflationPool')"
+  SERVICE_FEE_DISTRIBUTOR_ADDR="$(read_manifest_address '.serviceFeeDistributor')"
+  STREAMING_PAYMENT_MANAGER_ADDR="$(read_manifest_address '.streamingPaymentManager')"
+  CREDITS_ADDR="$(read_manifest_address '.credits')"
+  MIGRATION_ADDR="$(read_manifest_address '.migration.tangleMigration')"
+
+  check_has_role "tangle" "$TANGLE_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "tangle" "$TANGLE_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "tangle" "$TANGLE_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "tangle" "$TANGLE_ADDR" "$PAUSER_ROLE" "$CONFIG_MULTISIG"
+  check_has_role "tangle" "$TANGLE_ADDR" "$SLASH_ADMIN_ROLE" "$CONFIG_MULTISIG"
+
+  check_has_role "staking" "$STAKING_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "staking" "$STAKING_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "staking" "$STAKING_ADDR" "$ASSET_MANAGER_ROLE" "$CONFIG_MULTISIG"
+
+  check_has_role "tntToken" "$TNT_TOKEN_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "tntToken" "$TNT_TOKEN_ADDR" "$MINTER_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "tntToken" "$TNT_TOKEN_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_has_role "metrics" "$METRICS_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "metrics" "$METRICS_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_has_role "rewardVaults" "$REWARD_VAULTS_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "rewardVaults" "$REWARD_VAULTS_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "rewardVaults" "$REWARD_VAULTS_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_has_role "inflationPool" "$INFLATION_POOL_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "inflationPool" "$INFLATION_POOL_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "inflationPool" "$INFLATION_POOL_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_has_role "serviceFeeDistributor" "$SERVICE_FEE_DISTRIBUTOR_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "serviceFeeDistributor" "$SERVICE_FEE_DISTRIBUTOR_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "serviceFeeDistributor" "$SERVICE_FEE_DISTRIBUTOR_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_has_role "streamingPaymentManager" "$STREAMING_PAYMENT_MANAGER_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "streamingPaymentManager" "$STREAMING_PAYMENT_MANAGER_ADDR" "$ADMIN_ROLE" "$CONFIG_TIMELOCK"
+  check_has_role "streamingPaymentManager" "$STREAMING_PAYMENT_MANAGER_ADDR" "$UPGRADER_ROLE" "$CONFIG_TIMELOCK"
+
+  check_owner "statusRegistry" "$STATUS_REGISTRY_ADDR" "$CONFIG_TIMELOCK"
+
+  CREDITS_OWNER="$(read_config_value '.credits.owner')"
+  [[ -n "$CREDITS_OWNER" && "$CREDITS_OWNER" != "0x0000000000000000000000000000000000000000" ]] || CREDITS_OWNER="$CONFIG_TIMELOCK"
+  check_owner "credits" "$CREDITS_ADDR" "$CREDITS_OWNER"
+
+  MIGRATION_OWNER="$(read_config_value '.migration.migrationOwner')"
+  [[ -n "$MIGRATION_OWNER" && "$MIGRATION_OWNER" != "0x0000000000000000000000000000000000000000" ]] || MIGRATION_OWNER="$CONFIG_TIMELOCK"
+  check_owner "tangleMigration" "$MIGRATION_ADDR" "$MIGRATION_OWNER"
+
+  if [[ "$CONFIG_REVOKE_BOOTSTRAP" == "true" && "${CONFIG_ADMIN,,}" != "${CONFIG_TIMELOCK,,}" && "${CONFIG_ADMIN,,}" != "${CONFIG_MULTISIG,,}" ]]; then
+    check_missing_role "tangle" "$TANGLE_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tangle" "$TANGLE_ADDR" "$ADMIN_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tangle" "$TANGLE_ADDR" "$UPGRADER_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tangle" "$TANGLE_ADDR" "$PAUSER_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tangle" "$TANGLE_ADDR" "$SLASH_ADMIN_ROLE" "$CONFIG_ADMIN"
+
+    check_missing_role "staking" "$STAKING_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "staking" "$STAKING_ADDR" "$ADMIN_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "staking" "$STAKING_ADDR" "$ASSET_MANAGER_ROLE" "$CONFIG_ADMIN"
+
+    check_missing_role "tntToken" "$TNT_TOKEN_ADDR" "$DEFAULT_ADMIN_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tntToken" "$TNT_TOKEN_ADDR" "$MINTER_ROLE" "$CONFIG_ADMIN"
+    check_missing_role "tntToken" "$TNT_TOKEN_ADDR" "$UPGRADER_ROLE" "$CONFIG_ADMIN"
+  fi
+fi
 
 echo "Manifest verification passed."

--- a/script/sh/verify-full-deploy-manifest.sh
+++ b/script/sh/verify-full-deploy-manifest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  script/sh/verify-full-deploy-manifest.sh --manifest <path> --rpc-url <url> [--chain-id <id>]
+
+Checks that a FullDeploy manifest exists, has the expected chain id, and that each deployed
+contract address in the manifest has non-empty bytecode on the target RPC.
+EOF
+}
+
+MANIFEST_PATH=""
+RPC_URL=""
+EXPECTED_CHAIN_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest)
+      MANIFEST_PATH="${2:-}"
+      shift 2
+      ;;
+    --rpc-url)
+      RPC_URL="${2:-}"
+      shift 2
+      ;;
+    --chain-id)
+      EXPECTED_CHAIN_ID="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$MANIFEST_PATH" ]] || fail "Missing --manifest"
+[[ -n "$RPC_URL" ]] || fail "Missing --rpc-url"
+[[ -f "$MANIFEST_PATH" ]] || fail "Manifest not found: $MANIFEST_PATH"
+
+require_cmd jq
+require_cmd cast
+
+CHAIN_ID_IN_MANIFEST="$(jq -er '.chainId' "$MANIFEST_PATH")"
+if [[ -n "$EXPECTED_CHAIN_ID" && "$CHAIN_ID_IN_MANIFEST" != "$EXPECTED_CHAIN_ID" ]]; then
+  fail "Manifest chain id mismatch: expected $EXPECTED_CHAIN_ID, got $CHAIN_ID_IN_MANIFEST"
+fi
+
+RPC_CHAIN_ID="$(cast chain-id --rpc-url "$RPC_URL")"
+if [[ "$CHAIN_ID_IN_MANIFEST" != "$RPC_CHAIN_ID" ]]; then
+  fail "RPC chain id mismatch: manifest has $CHAIN_ID_IN_MANIFEST, RPC returned $RPC_CHAIN_ID"
+fi
+
+NETWORK="$(jq -er '.network' "$MANIFEST_PATH")"
+DEPLOYER="$(jq -er '.deployer' "$MANIFEST_PATH")"
+
+echo "==> Verifying FullDeploy manifest"
+echo "Manifest:  $MANIFEST_PATH"
+echo "Network:   $NETWORK"
+echo "Chain id:  $CHAIN_ID_IN_MANIFEST"
+echo "Deployer:  $DEPLOYER"
+
+check_code() {
+  local label="$1"
+  local address="$2"
+  if [[ -z "$address" || "$address" == "null" || "$address" == "0x0000000000000000000000000000000000000000" ]]; then
+    return 0
+  fi
+
+  local code
+  code="$(cast code "$address" --rpc-url "$RPC_URL" 2>/dev/null || true)"
+  if [[ ! "$code" =~ ^0x[0-9a-fA-F]{10,}$ ]]; then
+    fail "No deployed bytecode for $label at $address"
+  fi
+
+  echo "Verified $label: $address"
+}
+
+check_code "tangle" "$(jq -r '.tangle // empty' "$MANIFEST_PATH")"
+check_code "staking" "$(jq -r '.staking // .restaking // empty' "$MANIFEST_PATH")"
+check_code "statusRegistry" "$(jq -r '.statusRegistry // empty' "$MANIFEST_PATH")"
+check_code "tntToken" "$(jq -r '.tntToken // empty' "$MANIFEST_PATH")"
+check_code "metrics" "$(jq -r '.metrics // empty' "$MANIFEST_PATH")"
+check_code "rewardVaults" "$(jq -r '.rewardVaults // empty' "$MANIFEST_PATH")"
+check_code "inflationPool" "$(jq -r '.inflationPool // empty' "$MANIFEST_PATH")"
+check_code "credits" "$(jq -r '.credits // empty' "$MANIFEST_PATH")"
+check_code "tangleMigration" "$(jq -r '.migration.tangleMigration // empty' "$MANIFEST_PATH")"
+check_code "zkVerifier" "$(jq -r '.migration.zkVerifier // empty' "$MANIFEST_PATH")"
+
+echo "Manifest verification passed."

--- a/script/sh/verify-full-deploy-manifest.sh
+++ b/script/sh/verify-full-deploy-manifest.sh
@@ -17,7 +17,7 @@ require_cmd() {
 usage() {
   cat <<'EOF'
 Usage:
-  script/sh/verify-full-deploy-manifest.sh --manifest <path> --rpc-url <url> [--chain-id <id>]
+  script/sh/verify-full-deploy-manifest.sh --manifest <path> --rpc-url <url> [--config <path>] [--chain-id <id>]
 
 Checks that a FullDeploy manifest exists, has the expected chain id, and that each deployed
 contract address in the manifest has non-empty bytecode on the target RPC.
@@ -27,6 +27,7 @@ EOF
 MANIFEST_PATH=""
 RPC_URL=""
 EXPECTED_CHAIN_ID=""
+CONFIG_PATH=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,6 +37,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --rpc-url)
       RPC_URL="${2:-}"
+      shift 2
+      ;;
+    --config)
+      CONFIG_PATH="${2:-}"
       shift 2
       ;;
     --chain-id)
@@ -55,6 +60,9 @@ done
 [[ -n "$MANIFEST_PATH" ]] || fail "Missing --manifest"
 [[ -n "$RPC_URL" ]] || fail "Missing --rpc-url"
 [[ -f "$MANIFEST_PATH" ]] || fail "Manifest not found: $MANIFEST_PATH"
+if [[ -n "$CONFIG_PATH" ]]; then
+  [[ -f "$CONFIG_PATH" ]] || fail "Config not found: $CONFIG_PATH"
+fi
 
 require_cmd jq
 require_cmd cast
@@ -78,10 +86,17 @@ echo "Network:   $NETWORK"
 echo "Chain id:  $CHAIN_ID_IN_MANIFEST"
 echo "Deployer:  $DEPLOYER"
 
+read_manifest_address() {
+  local query="$1"
+  jq -r "$query // empty" "$MANIFEST_PATH"
+}
+
 check_code() {
   local label="$1"
   local address="$2"
+  local required="${3:-false}"
   if [[ -z "$address" || "$address" == "null" || "$address" == "0x0000000000000000000000000000000000000000" ]]; then
+    [[ "$required" == "true" ]] && fail "Missing required address for $label in manifest"
     return 0
   fi
 
@@ -94,15 +109,36 @@ check_code() {
   echo "Verified $label: $address"
 }
 
-check_code "tangle" "$(jq -r '.tangle // empty' "$MANIFEST_PATH")"
-check_code "staking" "$(jq -r '.staking // .restaking // empty' "$MANIFEST_PATH")"
-check_code "statusRegistry" "$(jq -r '.statusRegistry // empty' "$MANIFEST_PATH")"
-check_code "tntToken" "$(jq -r '.tntToken // empty' "$MANIFEST_PATH")"
-check_code "metrics" "$(jq -r '.metrics // empty' "$MANIFEST_PATH")"
-check_code "rewardVaults" "$(jq -r '.rewardVaults // empty' "$MANIFEST_PATH")"
-check_code "inflationPool" "$(jq -r '.inflationPool // empty' "$MANIFEST_PATH")"
-check_code "credits" "$(jq -r '.credits // empty' "$MANIFEST_PATH")"
-check_code "tangleMigration" "$(jq -r '.migration.tangleMigration // empty' "$MANIFEST_PATH")"
-check_code "zkVerifier" "$(jq -r '.migration.zkVerifier // empty' "$MANIFEST_PATH")"
+require_from_config() {
+  local query="$1"
+  [[ -n "$CONFIG_PATH" ]] || return 1
+  local value
+  value="$(jq -r "$query // false" "$CONFIG_PATH")"
+  [[ "$value" == "true" ]]
+}
+
+CORE_REQUIRED=false
+METRICS_REQUIRED=false
+REWARD_VAULTS_REQUIRED=false
+INFLATION_POOL_REQUIRED=false
+MIGRATION_REQUIRED=false
+CREDITS_REQUIRED=false
+if require_from_config '.core.deploy'; then CORE_REQUIRED=true; fi
+if require_from_config '.incentives.deployMetrics'; then METRICS_REQUIRED=true; fi
+if require_from_config '.incentives.deployRewardVaults'; then REWARD_VAULTS_REQUIRED=true; fi
+if require_from_config '.incentives.deployInflationPool'; then INFLATION_POOL_REQUIRED=true; fi
+if require_from_config '.migration.deploy'; then MIGRATION_REQUIRED=true; fi
+if require_from_config '.credits.deploy'; then CREDITS_REQUIRED=true; fi
+
+check_code "tangle" "$(read_manifest_address '.tangle')" "$CORE_REQUIRED"
+check_code "staking" "$(read_manifest_address '.staking // .restaking')" "$CORE_REQUIRED"
+check_code "statusRegistry" "$(read_manifest_address '.statusRegistry')" "$CORE_REQUIRED"
+check_code "tntToken" "$(read_manifest_address '.tntToken')" "$CORE_REQUIRED"
+check_code "metrics" "$(read_manifest_address '.metrics')" "$METRICS_REQUIRED"
+check_code "rewardVaults" "$(read_manifest_address '.rewardVaults')" "$REWARD_VAULTS_REQUIRED"
+check_code "inflationPool" "$(read_manifest_address '.inflationPool')" "$INFLATION_POOL_REQUIRED"
+check_code "credits" "$(read_manifest_address '.credits')" "$CREDITS_REQUIRED"
+check_code "tangleMigration" "$(read_manifest_address '.migration.tangleMigration')" "$MIGRATION_REQUIRED"
+check_code "zkVerifier" "$(read_manifest_address '.migration.zkVerifier')" "$MIGRATION_REQUIRED"
 
 echo "Manifest verification passed."

--- a/src/beacon/L2SlashingConnector.sol
+++ b/src/beacon/L2SlashingConnector.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.26;
 import { ValidatorPodManager } from "./ValidatorPodManager.sol";
 import { ICrossChainMessenger } from "./interfaces/ICrossChainMessenger.sol";
 
+interface IBeaconSlashPod {
+    function beaconChainSlashingFactor() external view returns (uint64);
+}
+
 /// @title L2SlashingConnector
 /// @notice Connects beacon chain slashing events to Tangle L2 slashing mechanism
 /// @dev This contract bridges between beacon chain native staking and Tangle's L2 slashing
@@ -34,6 +38,7 @@ contract L2SlashingConnector {
     error UnsupportedDestinationChain();
     error MessengerNotConfigured();
     error UnknownPod(address pod);
+    error SlashingFactorMismatch(address pod, uint64 expected, uint64 provided);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EVENTS
@@ -241,6 +246,11 @@ contract L2SlashingConnector {
         address operator = _getOperatorForPod(pod);
         if (operator == address(0)) {
             return; // Pod not registered, skip
+        }
+
+        uint64 actualFactor = IBeaconSlashPod(pod).beaconChainSlashingFactor();
+        if (newSlashingFactor != actualFactor) {
+            revert SlashingFactorMismatch(pod, actualFactor, newSlashingFactor);
         }
 
         // Calculate L2 slash amount based on operator's total delegated stake

--- a/src/beacon/bridges/ArbitrumCrossChainMessenger.sol
+++ b/src/beacon/bridges/ArbitrumCrossChainMessenger.sol
@@ -214,6 +214,7 @@ contract ArbitrumL2Receiver {
     /// @notice The actual receiver contract
     // forge-lint: disable-next-line(screaming-snake-case-immutable)
     ICrossChainReceiver public immutable receiver;
+    uint256 public immutable sourceChainId;
 
     /// @notice M-12 FIX: Track processed message IDs to prevent replay attacks
     mapping(bytes32 => bool) public processedMessages;
@@ -227,9 +228,10 @@ contract ArbitrumL2Receiver {
     /// @notice M-12 FIX: Error for replayed messages
     error MessageAlreadyProcessed(bytes32 messageId);
 
-    constructor(address _l1Sender, address _receiver) {
+    constructor(address _l1Sender, address _receiver, uint256 _sourceChainId) {
         l1Sender = _l1Sender;
         receiver = ICrossChainReceiver(_receiver);
+        sourceChainId = _sourceChainId;
     }
 
     /// @notice Compute L1 aliased address
@@ -245,8 +247,8 @@ contract ArbitrumL2Receiver {
         // Verify msg.sender is the aliased L1 sender
         require(msg.sender == applyL1ToL2Alias(l1Sender), "Invalid sender");
 
-        // M-12 FIX: Generate unique message ID from payload and context
-        bytes32 messageId = keccak256(abi.encode(block.chainid, l1Sender, payload, messageNonce));
+        // Deduplicate identical bridged payload deliveries from the same L1 sender.
+        bytes32 messageId = keccak256(abi.encode(block.chainid, l1Sender, payload));
 
         // M-12 FIX: Check for replay attack
         if (processedMessages[messageId]) {
@@ -259,8 +261,7 @@ contract ArbitrumL2Receiver {
 
         emit MessageProcessed(messageId, l1Sender, currentNonce);
 
-        // Forward to receiver (chainId 1 = Ethereum mainnet)
-        receiver.receiveMessage(1, l1Sender, payload);
+        receiver.receiveMessage(sourceChainId, l1Sender, payload);
     }
 
     /// @notice M-12 FIX: Check if a message ID has been processed

--- a/src/beacon/bridges/BaseCrossChainMessenger.sol
+++ b/src/beacon/bridges/BaseCrossChainMessenger.sol
@@ -140,6 +140,7 @@ contract BaseL2Receiver {
     address public immutable l1Sender;
     // forge-lint: disable-next-line(screaming-snake-case-immutable)
     ICrossChainReceiver public immutable receiver;
+    uint256 public immutable sourceChainId;
 
     /// @notice M-12 FIX: Track processed message IDs to prevent replay attacks
     mapping(bytes32 => bool) public processedMessages;
@@ -153,10 +154,11 @@ contract BaseL2Receiver {
     /// @notice M-12 FIX: Error for replayed messages
     error MessageAlreadyProcessed(bytes32 messageId);
 
-    constructor(address _l2Messenger, address _l1Sender, address _receiver) {
+    constructor(address _l2Messenger, address _l1Sender, address _receiver, uint256 _sourceChainId) {
         l2Messenger = IBaseCrossDomainMessenger(_l2Messenger);
         l1Sender = _l1Sender;
         receiver = ICrossChainReceiver(_receiver);
+        sourceChainId = _sourceChainId;
     }
 
     /// @notice Relay message from L1
@@ -165,8 +167,8 @@ contract BaseL2Receiver {
         require(msg.sender == address(l2Messenger), "Only messenger");
         require(l2Messenger.xDomainMessageSender() == l1Sender, "Invalid sender");
 
-        // M-12 FIX: Generate unique message ID from payload and context
-        bytes32 messageId = keccak256(abi.encode(block.chainid, l1Sender, payload, messageNonce));
+        // Deduplicate identical bridged payload deliveries from the same L1 sender.
+        bytes32 messageId = keccak256(abi.encode(block.chainid, l1Sender, payload));
 
         // M-12 FIX: Check for replay attack
         if (processedMessages[messageId]) {
@@ -179,7 +181,7 @@ contract BaseL2Receiver {
 
         emit MessageProcessed(messageId, l1Sender, currentNonce);
 
-        receiver.receiveMessage(1, l1Sender, payload); // chainId 1 = Ethereum mainnet
+        receiver.receiveMessage(sourceChainId, l1Sender, payload);
     }
 
     /// @notice M-12 FIX: Check if a message ID has been processed

--- a/src/core/JobsAggregation.sol
+++ b/src/core/JobsAggregation.sol
@@ -52,6 +52,8 @@ abstract contract JobsAggregation is Base {
         Types.JobCall storage job = _getJobCall(serviceId, callId);
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
 
+        _validateServiceForAggregatedResult(svc, serviceId);
+
         if (job.completed) {
             revert Errors.JobAlreadyCompleted(serviceId, callId);
         }
@@ -166,12 +168,12 @@ abstract contract JobsAggregation is Base {
         if (thresholdType == 0) {
             // CountBased: achieved = signerCount, required = threshold% of operatorCount
             achieved = stats.signerCount;
-            required = (uint256(stats.operatorCount) * thresholdBps) / BPS_DENOMINATOR;
+            required = _ceilDiv(uint256(stats.operatorCount) * thresholdBps, BPS_DENOMINATOR);
             if (required == 0 && stats.operatorCount > 0) required = 1; // At least 1 signer required
         } else {
             // StakeWeighted: achieved = signerWeight, required = threshold% of totalWeight
             achieved = stats.signerWeight;
-            required = (stats.totalWeight * thresholdBps) / BPS_DENOMINATOR;
+            required = _ceilDiv(stats.totalWeight * thresholdBps, BPS_DENOMINATOR);
             if (required == 0 && stats.totalWeight > 0) required = 1;
         }
     }
@@ -281,6 +283,20 @@ abstract contract JobsAggregation is Base {
 
         // If no signers were found (empty bitmap with all inactive operators),
         // the aggregatedPubkey will be all zeros (point at infinity)
+    }
+
+    function _validateServiceForAggregatedResult(Types.Service storage svc, uint64 serviceId) private view {
+        if (svc.status != Types.ServiceStatus.Active) {
+            revert Errors.ServiceNotActive(serviceId);
+        }
+        if (svc.ttl > 0 && block.timestamp > svc.createdAt + svc.ttl) {
+            revert Errors.ServiceExpired(serviceId);
+        }
+    }
+
+    function _ceilDiv(uint256 numerator, uint256 denominator) private pure returns (uint256) {
+        if (numerator == 0) return 0;
+        return ((numerator - 1) / denominator) + 1;
     }
 
     function _jobSchema(

--- a/src/core/JobsRFQ.sol
+++ b/src/core/JobsRFQ.sol
@@ -147,6 +147,9 @@ abstract contract JobsRFQ is Base {
             if (quote.details.jobIndex != jobIndex) {
                 revert Errors.JobQuoteJobIndexMismatch(jobIndex, quote.details.jobIndex);
             }
+            if (quote.details.confidentiality != uint8(_services[serviceId].confidentiality)) {
+                revert Errors.InvalidQuoteSignature(quote.operator);
+            }
 
             // Check for duplicate operators
             for (uint256 j = 0; j < i; j++) {

--- a/src/core/JobsSubmission.sol
+++ b/src/core/JobsSubmission.sol
@@ -93,6 +93,7 @@ abstract contract JobsSubmission is Base {
     )
         private
     {
+        _validateServiceForResultSubmission(svc, serviceId);
         _ensureAggregationBypass(bp.manager, serviceId, job.jobIndex);
         _validateResultSubmissionState(serviceId, callId, job);
 
@@ -129,6 +130,15 @@ abstract contract JobsSubmission is Base {
     }
 
     function _validateServiceForSubmission(Types.Service storage svc, uint64 serviceId) private view {
+        if (svc.status != Types.ServiceStatus.Active) {
+            revert Errors.ServiceNotActive(serviceId);
+        }
+        if (svc.ttl > 0 && block.timestamp > svc.createdAt + svc.ttl) {
+            revert Errors.ServiceExpired(serviceId);
+        }
+    }
+
+    function _validateServiceForResultSubmission(Types.Service storage svc, uint64 serviceId) private view {
         if (svc.status != Types.ServiceStatus.Active) {
             revert Errors.ServiceNotActive(serviceId);
         }

--- a/src/core/PaymentsEffectiveExposure.sol
+++ b/src/core/PaymentsEffectiveExposure.sol
@@ -86,15 +86,12 @@ abstract contract PaymentsEffectiveExposure {
                     uint256 exposedAmount = (delegation * commitment.exposureBps) / _BPS_DENOM;
 
                     if (useOracle && exposedAmount > 0) {
-                        // Convert to USD for cross-asset comparison
+                        // When USD normalization is enabled, fail closed on oracle errors.
+                        // Mixing raw token amounts into a USD-weighted pool silently corrupts
+                        // payout weights across heterogeneous assets.
                         address token =
                             commitment.asset.kind == Types.AssetKind.Native ? address(0) : commitment.asset.token;
-                        try oracle.toUSD(token, exposedAmount) returns (uint256 usdValue) {
-                            operatorEffectiveExposure += usdValue;
-                        } catch {
-                            // Fallback: use raw amount if oracle fails
-                            operatorEffectiveExposure += exposedAmount;
-                        }
+                        operatorEffectiveExposure += oracle.toUSD(token, exposedAmount);
                     } else {
                         // No oracle: use raw amount
                         operatorEffectiveExposure += exposedAmount;

--- a/test/BLSAggregation.t.sol
+++ b/test/BLSAggregation.t.sol
@@ -188,8 +188,8 @@ contract BLSAggregationTest is BaseTest {
         vm.expectRevert(); // BLS verification will fail
         tangle.submitAggregatedResult(serviceId, callId0, "result", oneSigner, sig, pubkey);
 
-        // Job 1: 1 signer should fail threshold (67% of 3 = 2.01 -> 2)
-        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId1, 1, 2));
+        // Job 1: 1 signer should fail threshold (67% of 3 rounds up to 3)
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId1, 1, 3));
         tangle.submitAggregatedResult(serviceId, callId1, "result", oneSigner, sig, pubkey);
 
         // Job 2: 2 signers should fail threshold (100% of 3 = 3)
@@ -248,7 +248,7 @@ contract BLSAggregationTest is BaseTest {
 
     function test_ThresholdValidation_CountBased() public {
         // Enable aggregation with 67% threshold (count-based)
-        // 3 operators, 67% = 2 required
+        // 3 operators, 67% rounds up to 3 required.
         mockBsm.setAggregationConfig(0, true, 6700, 0);
 
         vm.prank(user1);
@@ -259,14 +259,14 @@ contract BLSAggregationTest is BaseTest {
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
-        // Should fail - threshold not met (1 < 2)
+        // Should fail - threshold not met (1 < 3)
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.AggregationThresholdNotMet.selector,
                 serviceId,
                 callId,
                 1, // achieved
-                2 // required
+                3 // required
             )
         );
         tangle.submitAggregatedResult(serviceId, callId, "result", oneSigner, sig, pubkey);
@@ -298,7 +298,7 @@ contract BLSAggregationTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_SignerBitmapValidation() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% = 1 signer needed
+        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% rounds up to 2 required
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -415,14 +415,14 @@ contract BLSAggregationTest is BaseTest {
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
-        // Should fail threshold - only 1 valid signer counted, need 2
+        // Should fail threshold - only 1 valid signer counted, need 3
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.AggregationThresholdNotMet.selector,
                 serviceId,
                 callId,
                 1, // achieved (only bit 0 counted)
-                2 // required
+                3 // required
             )
         );
         tangle.submitAggregatedResult(serviceId, callId, "result", invalidBitmap, sig, pubkey);
@@ -430,7 +430,7 @@ contract BLSAggregationTest is BaseTest {
 
     /// @notice Test that extremely high bitmap bits are ignored
     function test_InvalidBitmapBits_ExtremelyHighBits() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% = 1 required
+        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% rounds up to 2 required
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -441,14 +441,14 @@ contract BLSAggregationTest is BaseTest {
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
-        // Should fail - 0 valid signers, need 1
+        // Should fail - 0 valid signers, need 2
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.AggregationThresholdNotMet.selector,
                 serviceId,
                 callId,
                 0, // achieved
-                1 // required
+                2 // required
             )
         );
         tangle.submitAggregatedResult(serviceId, callId, "result", highBitsBitmap, sig, pubkey);
@@ -456,7 +456,7 @@ contract BLSAggregationTest is BaseTest {
 
     /// @notice Test that zero bitmap fails threshold
     function test_InvalidBitmapBits_ZeroBitmap() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% = 1 required
+        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% rounds up to 2 required
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -466,7 +466,7 @@ contract BLSAggregationTest is BaseTest {
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
         // Should fail - 0 signers
-        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId, 0, 1));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AggregationThresholdNotMet.selector, serviceId, callId, 0, 2));
         tangle.submitAggregatedResult(serviceId, callId, "result", zeroBitmap, sig, pubkey);
     }
 
@@ -670,7 +670,7 @@ contract BLSAggregationTest is BaseTest {
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
 
-        // All 3 signers - but 150% of 3 = 4.5 required
+        // All 3 signers - but 150% of 3 rounds up to 5 required
         uint256 allSigners = 0x7;
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
@@ -682,7 +682,7 @@ contract BLSAggregationTest is BaseTest {
                 serviceId,
                 callId,
                 3, // achieved (all operators)
-                4 // required (150% of 3)
+                5 // required (150% of 3, rounded up)
             )
         );
         tangle.submitAggregatedResult(serviceId, callId, "result", allSigners, sig, pubkey);
@@ -691,7 +691,7 @@ contract BLSAggregationTest is BaseTest {
     /// @notice Test threshold exactly at boundary (66.67% of 3 = 2)
     function test_Threshold_BoundaryCase() public {
         // 6666 bps = 66.66%, 6667 bps = 66.67%
-        // 66.66% of 3 = 1.9998 -> should round to 1 or 2?
+        // Threshold math must round up, not down, or quorum can be under-enforced.
         mockBsm.setAggregationConfig(0, true, 6666, 0);
 
         vm.prank(user1);
@@ -701,9 +701,16 @@ contract BLSAggregationTest is BaseTest {
         uint256[2] memory sig = [uint256(1), uint256(2)];
         uint256[4] memory pubkey = [uint256(1), uint256(2), uint256(3), uint256(4)];
 
-        // 6666 * 3 / 10000 = 1.9998 = 1 (integer division)
-        // So 1 signer should pass threshold but fail BLS
-        vm.expectRevert(); // BLS verification fails (not threshold)
+        // 6666 bps of 3 operators must require 2 signers, not 1.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AggregationThresholdNotMet.selector,
+                serviceId,
+                callId,
+                1,
+                2
+            )
+        );
         tangle.submitAggregatedResult(serviceId, callId, "result", oneSigner, sig, pubkey);
     }
 
@@ -732,8 +739,9 @@ contract BLSAggregationTest is BaseTest {
         if ((signerBitmap >> 1) & 1 == 1) validSigners++;
         if ((signerBitmap >> 2) & 1 == 1) validSigners++;
 
-        // Calculate required threshold (matching contract logic)
-        uint256 required = (uint256(3) * thresholdBps) / 10_000;
+        // Calculate required threshold (matching contract logic: round up)
+        uint256 required = uint256(3) * thresholdBps;
+        required = required == 0 ? 0 : ((required - 1) / 10_000) + 1;
         if (required == 0 && 3 > 0) required = 1;
 
         if (validSigners < required) {

--- a/test/BLSAggregationE2E.t.sol
+++ b/test/BLSAggregationE2E.t.sol
@@ -89,8 +89,8 @@ contract BLSAggregationE2ETest is BaseTest {
     /// @notice Test with valid BLS signature from single signer (sk=1)
     /// @dev This is the simplest valid BLS test case
     function test_ValidBLS_SingleSigner() public {
-        // Enable aggregation with 34% threshold (1 of 3 = 33.33%)
-        mockBsm.setAggregationConfig(0, true, 3400, 0);
+        // 3333 bps is the highest threshold that still permits 1 of 3 signers with round-up math.
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         // Submit a job
         vm.prank(user1);
@@ -201,15 +201,13 @@ contract BLSAggregationE2ETest is BaseTest {
     }
 
     /// @notice Test that count-based and stake-weighted produce different results
-    /// @dev With 3 operators (5/3/2 ETH stakes), count-based 50% = 2/3 needed,
-    ///      but 50% of 3 with integer math = 1, so single signer passes count-based!
-    ///      This test demonstrates the threshold calculation behavior.
+    /// @dev Count-based and stake-weighted thresholds should diverge under the same signer set.
     function test_CountVsStakeWeighted_Difference() public {
         // Setup: 3 operators with 5/3/2 ETH stakes
         // Total stake = 10 ETH
 
-        // Job 0: Count-based 50% = floor(3 * 0.5) = 1 operator needed
-        mockBsm.setAggregationConfig(0, true, 5000, 0);
+        // Job 0: Count-based 33.33% = 1 operator needed with round-up math.
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         // Job 1: Stake-weighted 50% = need operators with >= 5 ETH total
         // Operator 0 alone (5 ETH) satisfies stake-weighted 50%
@@ -228,8 +226,7 @@ contract BLSAggregationE2ETest is BaseTest {
         Types.BN254G1Point memory sig =
             BLSTestHelper.sign(BLSTestHelper.buildJobResultMessage(serviceId, callId0, output), 1);
 
-        // Count-based with 50% threshold: floor(3 * 0.5) = 1 required
-        // Single signer satisfies this, so it succeeds
+        // Count-based with 33.33% threshold requires exactly 1 signer.
         tangle.submitAggregatedResult(
             serviceId,
             callId0,
@@ -241,7 +238,7 @@ contract BLSAggregationE2ETest is BaseTest {
 
         // Verify job completed
         Types.JobCall memory job = tangle.getJobCall(serviceId, callId0);
-        assertTrue(job.completed, "Count-based job should complete with 1 signer at 50% threshold");
+        assertTrue(job.completed, "Count-based job should complete with 1 signer at 33.33% threshold");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -360,7 +357,7 @@ contract BLSAggregationE2ETest is BaseTest {
 
         uint64 dynamicSvcId = 1;
 
-        mockBsm.setAggregationConfig(0, true, 3400, 0); // 34% threshold
+        mockBsm.setAggregationConfig(0, true, 3333, 0); // 1 of 3 threshold with round-up math
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(dynamicSvcId, 0, "leave mid-agg");
@@ -391,10 +388,9 @@ contract BLSAggregationE2ETest is BaseTest {
     }
 
     /// @notice Test service termination during pending job
-    /// @dev GAP FOUND: Terminated services can still receive aggregated results!
-    ///      This might be intentional (allow pending jobs to complete) but should be documented.
+    /// @dev Termination is a hard stop: pending aggregated jobs cannot finalize afterward.
     function test_ServiceTermination_PendingJob() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0);
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         // Submit a job
         vm.prank(user1);
@@ -411,20 +407,17 @@ contract BLSAggregationE2ETest is BaseTest {
         Types.JobCall memory jobAfter = tangle.getJobCall(serviceId, callId);
         assertFalse(jobAfter.completed, "Job still not completed");
 
-        // GAP: Can still submit aggregated result to terminated service!
         bytes memory output = "late result";
         (Types.BN254G1Point memory sig, Types.BN254G2Point memory pubkey) =
             BLSTestHelper.createSingleSignerData(serviceId, callId, output);
 
-        // This SHOULD revert with ServiceNotActive, but it doesn't!
-        // Documenting current behavior: terminated services accept BLS submissions
+        vm.expectRevert(abi.encodeWithSelector(Errors.ServiceNotActive.selector, serviceId));
         tangle.submitAggregatedResult(
             serviceId, callId, output, 0x1, BLSTestHelper.g1ToArray(sig), BLSTestHelper.g2ToArray(pubkey)
         );
 
-        // Job completes even though service is terminated
         Types.JobCall memory jobFinal = tangle.getJobCall(serviceId, callId);
-        assertTrue(jobFinal.completed, "GAP: Job completed on terminated service");
+        assertFalse(jobFinal.completed, "terminated service must not accept aggregated completion");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -433,7 +426,7 @@ contract BLSAggregationE2ETest is BaseTest {
 
     /// @notice Test submitting correct signature with wrong output
     function test_ValidSignature_WrongOutput() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0);
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");
@@ -459,7 +452,7 @@ contract BLSAggregationE2ETest is BaseTest {
 
     /// @notice Test signature for wrong callId
     function test_ValidSignature_WrongCallId() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0);
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         vm.prank(user1);
         uint64 callId1 = tangle.submitJob(serviceId, 0, "job 1");
@@ -486,7 +479,7 @@ contract BLSAggregationE2ETest is BaseTest {
 
     /// @notice Test double submission (replay protection)
     function test_ValidSignature_ReplayPrevention() public {
-        mockBsm.setAggregationConfig(0, true, 3400, 0);
+        mockBsm.setAggregationConfig(0, true, 3333, 0);
 
         vm.prank(user1);
         uint64 callId = tangle.submitJob(serviceId, 0, "test");

--- a/test/Tangle.t.sol
+++ b/test/Tangle.t.sol
@@ -518,6 +518,26 @@ contract TangleTest is BaseTest {
         tangle.submitResult(serviceId, callId, "result2");
     }
 
+    function test_SubmitResult_RevertServiceTerminatedAfterJobSubmission() public {
+        _registerOperator(operator1);
+        uint64 blueprintId = _createBlueprint(developer);
+        _registerForBlueprint(operator1, blueprintId);
+        uint64 requestId = _requestService(user1, blueprintId, operator1);
+        _approveService(operator1, requestId);
+
+        uint64 serviceId = 0;
+
+        vm.prank(user1);
+        uint64 callId = tangle.submitJob(serviceId, 0, "input");
+
+        vm.prank(user1);
+        tangle.terminateService(serviceId);
+
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.ServiceNotActive.selector, serviceId));
+        tangle.submitResult(serviceId, callId, "late result");
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // ADMIN TESTS
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/beacon/CrossChainSlashingTest.t.sol
+++ b/test/beacon/CrossChainSlashingTest.t.sol
@@ -233,6 +233,18 @@ contract MockStaking is IStaking {
     }
 }
 
+contract MockSlashPod {
+    uint64 public beaconChainSlashingFactor;
+
+    constructor(uint64 factor) {
+        beaconChainSlashingFactor = factor;
+    }
+
+    function setBeaconChainSlashingFactor(uint64 factor) external {
+        beaconChainSlashingFactor = factor;
+    }
+}
+
 /// @title CrossChainSlashingTest
 /// @notice Tests for cross-chain slashing infrastructure
 contract CrossChainSlashingTest is Test {
@@ -249,17 +261,22 @@ contract CrossChainSlashingTest is Test {
     address public admin = makeAddr("admin");
     address public oracle = makeAddr("oracle");
     address public operator1 = makeAddr("operator1");
-    address public pod1 = makeAddr("pod1");
+    address public pod1;
 
     // Constants
     uint256 public constant TANGLE_CHAIN_ID = 5000;
     uint256 public constant ETH_CHAIN_ID = 1;
     uint256 public constant INITIAL_STAKE = 100 ether;
 
+    function _setPodFactor(address pod, uint64 factor) internal {
+        MockSlashPod(pod).setBeaconChainSlashingFactor(factor);
+    }
+
     function setUp() public {
         vm.deal(admin, 1000 ether);
         vm.deal(oracle, 100 ether);
         vm.deal(operator1, 100 ether);
+        pod1 = address(new MockSlashPod(1e18));
 
         // Deploy beacon oracle
         beaconOracle = new MockBeaconOracle();
@@ -318,6 +335,7 @@ contract CrossChainSlashingTest is Test {
     function test_propagateBeaconSlashing_Success() public {
         // First slash: 100% (implicit) -> 90%
         uint64 newFactor = 0.9e18; // 90% (10% slashed from initial 100%)
+        _setPodFactor(pod1, newFactor);
 
         vm.prank(oracle);
         connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, newFactor);
@@ -339,6 +357,7 @@ contract CrossChainSlashingTest is Test {
     function test_propagateBeaconSlashingToSpecificChain() public {
         uint256 altChainId = 8453;
         address altReceiver = makeAddr("altReceiver");
+        _setPodFactor(pod1, 0.95e18);
 
         vm.prank(admin);
         connector.setChainConfig(altChainId, altReceiver, 150_000, true);
@@ -354,8 +373,9 @@ contract CrossChainSlashingTest is Test {
     function test_batchPropagateBeaconSlashing_MultiplePods() public {
         messenger.setMockFee(0); // simplify fee accounting for batch calls
 
-        address pod2 = makeAddr("pod2");
+        address pod2 = address(new MockSlashPod(0.85e18));
         address operator2 = makeAddr("operator2");
+        _setPodFactor(pod1, 0.9e18);
 
         vm.prank(admin);
         connector.registerPodOperator(pod2, operator2);
@@ -394,6 +414,7 @@ contract CrossChainSlashingTest is Test {
             abi.encodeWithSelector(podManager.operatorDelegatedStake.selector, operator1),
             abi.encode(40 ether)
         );
+        _setPodFactor(pod1, 0.9e18);
 
         vm.prank(oracle);
         connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
@@ -416,6 +437,7 @@ contract CrossChainSlashingTest is Test {
             abi.encodeWithSelector(podManager.operatorDelegatedStake.selector, operator1),
             abi.encode(10 ether)
         );
+        _setPodFactor(pod1, 0.95e18);
 
         uint256 fee = connector.estimatePropagationFee(pod1, 0.95e18, TANGLE_CHAIN_ID);
         assertEq(fee, quotedFee);
@@ -431,13 +453,34 @@ contract CrossChainSlashingTest is Test {
 
     function test_propagateBeaconSlashing_RevertInvalidFactor() public {
         // First set up initial factor: 100% -> 90%
+        MockSlashPod slashPod = new MockSlashPod(0.9e18);
+
+        vm.prank(admin);
+        connector.registerPodOperator(address(slashPod), operator1);
+
         vm.prank(oracle);
-        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(address(slashPod), 0.9e18);
 
         // Try to propagate a higher/equal factor (should revert)
+        slashPod.setBeaconChainSlashingFactor(0.95e18);
         vm.prank(oracle);
         vm.expectRevert(L2SlashingConnector.InvalidSlashingFactor.selector);
-        connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.95e18);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(address(slashPod), 0.95e18);
+    }
+
+    function test_propagateBeaconSlashing_RevertMismatchedPodFactor() public {
+        MockSlashPod slashPod = new MockSlashPod(0.95e18);
+
+        vm.prank(admin);
+        connector.registerPodOperator(address(slashPod), operator1);
+
+        vm.prank(oracle);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                L2SlashingConnector.SlashingFactorMismatch.selector, address(slashPod), uint64(0.95e18), uint64(0.9e18)
+            )
+        );
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(address(slashPod), 0.9e18);
     }
 
     function test_propagateBeaconSlashing_RevertUnsupportedChain() public {
@@ -462,6 +505,7 @@ contract CrossChainSlashingTest is Test {
 
     function test_propagateBeaconSlashing_RevertInsufficientFee() public {
         messenger.setMockFee(0.1 ether);
+        _setPodFactor(pod1, 0.9e18);
 
         vm.startPrank(oracle);
         vm.expectRevert(L2SlashingConnector.InsufficientFee.selector);
@@ -484,8 +528,9 @@ contract CrossChainSlashingTest is Test {
     }
 
     function test_batchPropagateBeaconSlashing() public {
-        address pod2 = makeAddr("pod2");
+        address pod2 = address(new MockSlashPod(0.9e18));
         address operator2 = makeAddr("operator2");
+        _setPodFactor(pod1, 0.95e18);
 
         vm.prank(admin);
         connector.registerPodOperator(pod2, operator2);
@@ -511,10 +556,12 @@ contract CrossChainSlashingTest is Test {
 
     function test_estimatePropagationFee() public {
         // First propagate to set up state
+        _setPodFactor(pod1, 0.95e18);
         vm.prank(oracle);
         connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.95e18);
 
         // Now estimate fee for next slash
+        _setPodFactor(pod1, 0.9e18);
         uint256 fee = connector.estimatePropagationFee(pod1, 0.9e18, TANGLE_CHAIN_ID);
         assertEq(fee, messenger.mockFee());
     }
@@ -687,6 +734,7 @@ contract CrossChainSlashingTest is Test {
 
         // 1. Oracle detects beacon chain slashing and calls connector
         uint64 slashedFactor = 0.8e18; // 80% (20% slashed)
+        _setPodFactor(pod1, slashedFactor);
 
         // 2. Propagate slashing
         vm.prank(oracle);
@@ -716,6 +764,7 @@ contract CrossChainSlashingTest is Test {
         );
 
         // First slash: 100% (implicit) -> 90%
+        _setPodFactor(pod1, 0.9e18);
         vm.prank(oracle);
         connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.9e18);
 
@@ -727,6 +776,7 @@ contract CrossChainSlashingTest is Test {
         assertTrue(firstSlashAmount > 0);
 
         // Second slash: 90% -> 80%
+        _setPodFactor(pod1, 0.8e18);
         vm.prank(oracle);
         connector.propagateBeaconSlashing{ value: 0.01 ether }(pod1, 0.8e18);
 

--- a/test/beacon/bridges/CrossChainMessengersTest.t.sol
+++ b/test/beacon/bridges/CrossChainMessengersTest.t.sol
@@ -39,6 +39,8 @@ contract MockCrossChainReceiver is ICrossChainReceiver {
     }
 }
 
+uint256 constant SOURCE_CHAIN_ID = 11155111;
+
 contract MockArbitrumInbox is IArbitrumInbox {
     struct TicketParams {
         address to;
@@ -323,7 +325,7 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
         function test_arbitrumL2Receiver_RelaysFromAliasedSender() public {
             MockCrossChainReceiver receiver = new MockCrossChainReceiver();
             address l1Sender = makeAddr("l1Sender");
-            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
+            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver), SOURCE_CHAIN_ID);
 
             bytes memory data = abi.encode("hello");
             address aliased = l2Receiver.applyL1ToL2Alias(l1Sender);
@@ -331,7 +333,7 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
             vm.prank(aliased);
             l2Receiver.relayMessage(data);
 
-            assertEq(receiver.lastSourceChainId(), 1);
+            assertEq(receiver.lastSourceChainId(), SOURCE_CHAIN_ID);
             assertEq(receiver.lastSender(), l1Sender);
             assertEq(receiver.lastPayload(), data);
         }
@@ -339,10 +341,29 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
         function test_arbitrumL2Receiver_RevertWhenSenderIsNotAliased() public {
             MockCrossChainReceiver receiver = new MockCrossChainReceiver();
             address l1Sender = makeAddr("l1Sender");
-            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver));
+            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver), SOURCE_CHAIN_ID);
 
             vm.expectRevert("Invalid sender");
             l2Receiver.relayMessage("bad");
+        }
+
+        function test_arbitrumL2Receiver_RevertOnDuplicatePayload() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            address l1Sender = makeAddr("l1Sender");
+            ArbitrumL2Receiver l2Receiver = new ArbitrumL2Receiver(l1Sender, address(receiver), SOURCE_CHAIN_ID);
+
+            bytes memory data = abi.encode("hello");
+            address aliased = l2Receiver.applyL1ToL2Alias(l1Sender);
+
+            vm.prank(aliased);
+            l2Receiver.relayMessage(data);
+
+            bytes32 messageId = keccak256(abi.encode(block.chainid, l1Sender, data));
+            assertTrue(l2Receiver.isMessageProcessed(messageId));
+
+            vm.prank(aliased);
+            vm.expectRevert(abi.encodeWithSelector(ArbitrumL2Receiver.MessageAlreadyProcessed.selector, messageId));
+            l2Receiver.relayMessage(data);
         }
     }
 
@@ -380,21 +401,23 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
 
         function test_relayMessage_ValidatesMessengerAndSender() public {
             MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            BaseL2Receiver l2Receiver =
+                new BaseL2Receiver(address(baseMessenger), address(this), address(receiver), SOURCE_CHAIN_ID);
             bytes memory message = abi.encode("data");
 
             baseMessenger.setXDomainMessageSender(address(this));
             vm.prank(address(baseMessenger));
             l2Receiver.relayMessage(message);
 
-            assertEq(receiver.lastSourceChainId(), 1);
+            assertEq(receiver.lastSourceChainId(), SOURCE_CHAIN_ID);
             assertEq(receiver.lastSender(), address(this));
             assertEq(receiver.lastPayload(), message);
         }
 
         function test_relayMessage_RevertWhenMessengerMismatch() public {
             MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            BaseL2Receiver l2Receiver =
+                new BaseL2Receiver(address(baseMessenger), address(this), address(receiver), SOURCE_CHAIN_ID);
             bytes memory message = abi.encode("data");
 
             vm.expectRevert("Only messenger");
@@ -403,12 +426,31 @@ contract MockBaseMessenger is IBaseCrossDomainMessenger {
 
         function test_relayMessage_RevertWhenSenderMismatch() public {
             MockCrossChainReceiver receiver = new MockCrossChainReceiver();
-            BaseL2Receiver l2Receiver = new BaseL2Receiver(address(baseMessenger), address(this), address(receiver));
+            BaseL2Receiver l2Receiver =
+                new BaseL2Receiver(address(baseMessenger), address(this), address(receiver), SOURCE_CHAIN_ID);
             bytes memory message = abi.encode("data");
 
             baseMessenger.setXDomainMessageSender(makeAddr("other"));
             vm.prank(address(baseMessenger));
             vm.expectRevert("Invalid sender");
+            l2Receiver.relayMessage(message);
+        }
+
+        function test_relayMessage_RevertOnDuplicatePayload() public {
+            MockCrossChainReceiver receiver = new MockCrossChainReceiver();
+            BaseL2Receiver l2Receiver =
+                new BaseL2Receiver(address(baseMessenger), address(this), address(receiver), SOURCE_CHAIN_ID);
+            bytes memory message = abi.encode("data");
+
+            baseMessenger.setXDomainMessageSender(address(this));
+            vm.prank(address(baseMessenger));
+            l2Receiver.relayMessage(message);
+
+            bytes32 messageId = keccak256(abi.encode(block.chainid, address(this), message));
+            assertTrue(l2Receiver.isMessageProcessed(messageId));
+
+            vm.prank(address(baseMessenger));
+            vm.expectRevert(abi.encodeWithSelector(BaseL2Receiver.MessageAlreadyProcessed.selector, messageId));
             l2Receiver.relayMessage(message);
         }
     }

--- a/test/rewards/ServiceFeeDistributorInvariant.t.sol
+++ b/test/rewards/ServiceFeeDistributorInvariant.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { BaseTest } from "../BaseTest.sol";
+import { ServiceFeeDistributor } from "../../src/rewards/ServiceFeeDistributor.sol";
+
+contract ServiceFeeDistributorInvariantHandler is Test {
+    uint256 internal constant MIN_DELEGATION = 0.1 ether;
+    uint64 internal constant SERVICE_ID = 0;
+    uint64 internal constant BLUEPRINT_ID = 0;
+
+    ServiceFeeDistributor internal distributor;
+    IMultiAssetDelegationLike internal staking;
+    address internal operator;
+    address internal delegator1;
+    address internal delegator2;
+
+    uint256 public totalDistributedNative;
+    uint256 public totalClaimedNative;
+    uint256 public distributionCount;
+
+    constructor(
+        ServiceFeeDistributor distributor_,
+        address staking_,
+        address operator_,
+        address delegator1_,
+        address delegator2_
+    ) {
+        distributor = distributor_;
+        staking = IMultiAssetDelegationLike(staking_);
+        operator = operator_;
+        delegator1 = delegator1_;
+        delegator2 = delegator2_;
+    }
+
+    function delegate1(uint256 amount) external {
+        _delegate(delegator1, amount);
+    }
+
+    function delegate2(uint256 amount) external {
+        _delegate(delegator2, amount);
+    }
+
+    function undelegate1(uint256 amount) external {
+        _undelegate(delegator1, amount);
+    }
+
+    function undelegate2(uint256 amount) external {
+        _undelegate(delegator2, amount);
+    }
+
+    function distributeNative(uint256 amount) external {
+        if (staking.getOperatorDelegatedStake(operator) == 0) return;
+
+        amount = bound(amount, 1 wei, 5 ether);
+        vm.deal(address(this), address(this).balance + amount);
+
+        distributor.distributeInflationReward{ value: amount }(SERVICE_ID, BLUEPRINT_ID, operator, address(0), amount);
+
+        totalDistributedNative += amount;
+        distributionCount++;
+    }
+
+    function claim1() external {
+        _claim(delegator1);
+    }
+
+    function claim2() external {
+        _claim(delegator2);
+    }
+
+    function trackedPendingNative() external view returns (uint256) {
+        return distributor.pendingRewards(delegator1, address(0)) + distributor.pendingRewards(delegator2, address(0));
+    }
+
+    function _delegate(address delegator, uint256 amount) internal {
+        amount = bound(amount, MIN_DELEGATION, 5 ether);
+        vm.deal(delegator, delegator.balance + amount);
+        vm.prank(delegator);
+        try staking.depositAndDelegate{ value: amount }(operator) { } catch { }
+    }
+
+    function _undelegate(address delegator, uint256 amount) internal {
+        uint256 current = staking.getDelegation(delegator, operator);
+        if (current < MIN_DELEGATION) return;
+
+        amount = bound(amount, MIN_DELEGATION, current);
+        vm.prank(delegator);
+        try staking.scheduleDelegatorUnstake(operator, address(0), amount) { } catch { }
+    }
+
+    function _claim(address delegator) internal {
+        vm.prank(delegator);
+        uint256 claimed = distributor.claimAll(address(0));
+        totalClaimedNative += claimed;
+    }
+
+    receive() external payable { }
+}
+
+interface IMultiAssetDelegationLike {
+    function depositAndDelegate(address operator) external payable;
+    function scheduleDelegatorUnstake(address operator, address token, uint256 amount) external;
+    function getDelegation(address delegator, address operator) external view returns (uint256);
+    function getOperatorDelegatedStake(address operator) external view returns (uint256);
+}
+
+contract ServiceFeeDistributorInvariantTest is StdInvariant, BaseTest {
+    ServiceFeeDistributor internal distributor;
+    ServiceFeeDistributorInvariantHandler internal handler;
+
+    function setUp() public override {
+        super.setUp();
+
+        ServiceFeeDistributor impl = new ServiceFeeDistributor();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(ServiceFeeDistributor.initialize, (admin, address(staking), address(tangle), address(0)))
+        );
+        distributor = ServiceFeeDistributor(payable(address(proxy)));
+
+        vm.startPrank(admin);
+        tangle.setServiceFeeDistributor(address(distributor));
+        staking.setServiceFeeDistributor(address(distributor));
+        distributor.setInflationPool(address(this));
+        vm.stopPrank();
+
+        _registerOperator(operator1, 5 ether);
+
+        handler =
+            new ServiceFeeDistributorInvariantHandler(distributor, address(staking), operator1, delegator1, delegator2);
+
+        vm.prank(admin);
+        distributor.setInflationPool(address(handler));
+
+        targetContract(address(handler));
+    }
+
+    function invariant_nativeClaimsNeverExceedDistributed() external view {
+        uint256 pending = distributor.pendingRewards(delegator1, address(0)) + distributor.pendingRewards(delegator2, address(0));
+        uint256 claimed = handler.totalClaimedNative();
+        uint256 distributed = handler.totalDistributedNative();
+
+        assertLe(claimed, distributed, "claimed exceeds distributed");
+        assertLe(claimed + pending, distributed, "claimed plus pending exceeds distributed");
+        assertLe(pending, address(distributor).balance, "pending exceeds distributor balance");
+    }
+}

--- a/test/scripts/DeploymentScriptsTest.t.sol
+++ b/test/scripts/DeploymentScriptsTest.t.sol
@@ -14,7 +14,10 @@ import { LayerZeroReceiver } from "../../src/beacon/bridges/LayerZeroCrossChainM
 import { IStaking } from "../../src/interfaces/IStaking.sol";
 import { Types } from "../../src/libraries/Types.sol";
 import { MultiAssetDelegation } from "../../src/staking/MultiAssetDelegation.sol";
+import { OperatorStatusRegistry } from "../../src/staking/OperatorStatusRegistry.sol";
 import { Tangle } from "../../src/Tangle.sol";
+import { TangleToken } from "../../src/governance/TangleToken.sol";
+import { FullDeploy } from "../../script/FullDeploy.s.sol";
 
 /// @notice Minimal staking stub so L2 slashing scripts can deploy their contracts
 contract MockStaking is IStaking {
@@ -130,6 +133,57 @@ contract DeployV2Harness is DeployV2 {
     {
         (stakingProxy,, tangleProxy,, statusRegistry) = _deployCore(0, admin, admin, treasury, false);
     }
+
+    function deployCoreWithStatusRegistryOwnerNoPrank(
+        address admin,
+        address treasury,
+        address statusRegistryOwner
+    )
+        external
+        returns (address stakingProxy, address tangleProxy, address statusRegistry)
+    {
+        (stakingProxy,, tangleProxy,, statusRegistry) =
+            _deployCore(0, admin, admin, treasury, statusRegistryOwner, false);
+    }
+}
+
+contract FullDeployHarness is FullDeploy {
+    function assertGovernanceConfigurationNoPrank(
+        address bootstrapAdmin,
+        address timelock,
+        address multisig,
+        address tangleAddr,
+        address stakingAddr,
+        address tntToken,
+        address statusRegistryAddr
+    )
+        external
+        view
+    {
+        RolesConfig memory roles = RolesConfig({
+            admin: bootstrapAdmin,
+            treasury: bootstrapAdmin,
+            timelock: timelock,
+            multisig: multisig,
+            revokeBootstrap: true
+        });
+
+        _assertGovernanceConfiguration(
+            roles,
+            bootstrapAdmin,
+            timelock,
+            multisig,
+            tangleAddr,
+            stakingAddr,
+            statusRegistryAddr,
+            tntToken,
+            address(0),
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
+    }
 }
 
 contract DeployBeaconSlashingHarness is DeployBeaconSlashingL1 {
@@ -201,6 +255,81 @@ contract DeploymentScriptsTest is Test {
         assertTrue(staking.hasRole(slasherRole, tangleProxy), "tangle should be slasher");
         assertEq(Tangle(payable(tangleProxy)).operatorStatusRegistry(), statusRegistry, "registry wired");
         assertTrue(Tangle(payable(tangleProxy)).tntToken() != address(0), "tnt token configured");
+    }
+
+    function testDeployCoreCanSetStatusRegistryOwnerToTimelock() public {
+        address admin = makeAddr("admin");
+        address treasury = makeAddr("treasury");
+        address timelock = makeAddr("timelock");
+
+        DeployV2Harness script = new DeployV2Harness();
+        (, address tangleProxy, address statusRegistry) =
+            script.deployCoreWithStatusRegistryOwnerNoPrank(admin, treasury, timelock);
+
+        assertEq(OperatorStatusRegistry(statusRegistry).owner(), timelock, "status registry should start on timelock");
+        assertEq(Tangle(payable(tangleProxy)).operatorStatusRegistry(), statusRegistry, "registry wired");
+    }
+
+    function testFullDeployRoleHandoffRevokesBootstrapAndPinsGovernance() public {
+        address admin = makeAddr("admin");
+        address treasury = makeAddr("treasury");
+        address timelock = makeAddr("timelock");
+        address multisig = makeAddr("multisig");
+
+        DeployV2Harness deployHarness = new DeployV2Harness();
+        (address stakingProxy, address tangleProxy, address statusRegistry) =
+            deployHarness.deployCoreWithStatusRegistryOwnerNoPrank(admin, treasury, timelock);
+
+        FullDeployHarness fullDeploy = new FullDeployHarness();
+        Tangle tangle = Tangle(payable(tangleProxy));
+        MultiAssetDelegation staking = MultiAssetDelegation(payable(stakingProxy));
+        TangleToken token = TangleToken(tangle.tntToken());
+
+        vm.startPrank(admin);
+        tangle.grantRole(tangle.DEFAULT_ADMIN_ROLE(), timelock);
+        tangle.grantRole(tangle.ADMIN_ROLE(), timelock);
+        tangle.grantRole(tangle.UPGRADER_ROLE(), timelock);
+        tangle.grantRole(tangle.PAUSER_ROLE(), multisig);
+        tangle.grantRole(tangle.SLASH_ADMIN_ROLE(), multisig);
+        tangle.revokeRole(tangle.PAUSER_ROLE(), admin);
+        tangle.revokeRole(tangle.SLASH_ADMIN_ROLE(), admin);
+        tangle.revokeRole(tangle.ADMIN_ROLE(), admin);
+        tangle.revokeRole(tangle.UPGRADER_ROLE(), admin);
+        tangle.revokeRole(tangle.DEFAULT_ADMIN_ROLE(), admin);
+
+        staking.grantRole(staking.DEFAULT_ADMIN_ROLE(), timelock);
+        staking.grantRole(staking.ADMIN_ROLE(), timelock);
+        staking.grantRole(staking.ASSET_MANAGER_ROLE(), multisig);
+        staking.revokeRole(staking.ASSET_MANAGER_ROLE(), admin);
+        staking.revokeRole(staking.ADMIN_ROLE(), admin);
+        staking.revokeRole(staking.DEFAULT_ADMIN_ROLE(), admin);
+
+        token.grantRole(token.DEFAULT_ADMIN_ROLE(), timelock);
+        token.grantRole(token.MINTER_ROLE(), timelock);
+        token.grantRole(token.UPGRADER_ROLE(), timelock);
+        token.revokeRole(token.MINTER_ROLE(), admin);
+        token.revokeRole(token.UPGRADER_ROLE(), admin);
+        token.revokeRole(token.DEFAULT_ADMIN_ROLE(), admin);
+        vm.stopPrank();
+
+        fullDeploy.assertGovernanceConfigurationNoPrank(
+            admin, timelock, multisig, tangleProxy, stakingProxy, address(token), statusRegistry
+        );
+
+        assertTrue(tangle.hasRole(tangle.DEFAULT_ADMIN_ROLE(), timelock), "timelock should own tangle admin");
+        assertTrue(tangle.hasRole(tangle.PAUSER_ROLE(), multisig), "multisig should own pauser");
+        assertFalse(tangle.hasRole(tangle.DEFAULT_ADMIN_ROLE(), admin), "bootstrap tangle admin should be revoked");
+        assertFalse(tangle.hasRole(tangle.PAUSER_ROLE(), admin), "bootstrap pauser should be revoked");
+
+        assertTrue(staking.hasRole(staking.DEFAULT_ADMIN_ROLE(), timelock), "timelock should own staking admin");
+        assertTrue(
+            staking.hasRole(staking.ASSET_MANAGER_ROLE(), multisig), "multisig should own staking asset manager"
+        );
+        assertFalse(
+            staking.hasRole(staking.DEFAULT_ADMIN_ROLE(), admin), "bootstrap staking admin should be revoked"
+        );
+
+        assertEq(OperatorStatusRegistry(statusRegistry).owner(), timelock, "status registry owner should stay timelock");
     }
 
     function testDeployBeaconSlashingScriptRunsHyperlane() public {

--- a/test/staking/SlashAccountingInvariant.t.sol
+++ b/test/staking/SlashAccountingInvariant.t.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { IMultiAssetDelegation } from "../../src/interfaces/IMultiAssetDelegation.sol";
+import { IFacetSelectors } from "../../src/interfaces/IFacetSelectors.sol";
+import { MultiAssetDelegation } from "../../src/staking/MultiAssetDelegation.sol";
+import { StakingFacetBase } from "../../src/staking/StakingFacetBase.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { StakingOperatorsFacet } from "../../src/facets/staking/StakingOperatorsFacet.sol";
+import { StakingDepositsFacet } from "../../src/facets/staking/StakingDepositsFacet.sol";
+import { StakingDelegationsFacet } from "../../src/facets/staking/StakingDelegationsFacet.sol";
+import { StakingSlashingFacet } from "../../src/facets/staking/StakingSlashingFacet.sol";
+import { StakingAssetsFacet } from "../../src/facets/staking/StakingAssetsFacet.sol";
+import { StakingViewsFacet } from "../../src/facets/staking/StakingViewsFacet.sol";
+import { StakingAdminFacet } from "../../src/facets/staking/StakingAdminFacet.sol";
+
+contract MultiAssetDelegationInvariantExposed is StakingFacetBase, IFacetSelectors {
+    function selectors() external pure returns (bytes4[] memory selectorList) {
+        selectorList = new bytes4[](3);
+        selectorList[0] = this.rewardPoolTotals.selector;
+        selectorList[1] = this.blueprintPoolTotals.selector;
+        selectorList[2] = this.operatorStake.selector;
+    }
+
+    function rewardPoolTotals(address operator) external view returns (uint256) {
+        bytes32 assetHash = keccak256(abi.encode(Types.AssetKind.Native, address(0)));
+        return _rewardPools[operator][assetHash].totalAssets;
+    }
+
+    function blueprintPoolTotals(address operator, uint64 blueprintId) external view returns (uint256) {
+        bytes32 assetHash = keccak256(abi.encode(Types.AssetKind.Native, address(0)));
+        return _blueprintPools[operator][blueprintId][assetHash].totalAssets;
+    }
+
+    function operatorStake(address operator) external view returns (uint256) {
+        return _operatorMetadata[operator].stake;
+    }
+}
+
+contract SlashAccountingHandler is Test {
+    IMultiAssetDelegation internal delegation;
+    MultiAssetDelegationInvariantExposed internal exposed;
+
+    address internal admin;
+    address internal slasher;
+    address internal operator;
+    uint64 internal blueprintId;
+
+    address[] internal allDelegators;
+    address[] internal fixedDelegators;
+
+    uint256 internal modeledTotal;
+    uint256 internal cumulativeSlashed;
+    uint256 internal cumulativeDelegated;
+
+    constructor(
+        IMultiAssetDelegation delegation_,
+        MultiAssetDelegationInvariantExposed exposed_,
+        address admin_,
+        address slasher_,
+        address operator_,
+        uint64 blueprintId_
+    ) {
+        delegation = delegation_;
+        exposed = exposed_;
+        admin = admin_;
+        slasher = slasher_;
+        operator = operator_;
+        blueprintId = blueprintId_;
+
+        for (uint256 i = 0; i < 5; i++) {
+            allDelegators.push(makeAddr(string(abi.encodePacked("allDelegator", vm.toString(i)))));
+            fixedDelegators.push(makeAddr(string(abi.encodePacked("fixedDelegator", vm.toString(i)))));
+        }
+
+        modeledTotal = 90 ether;
+    }
+
+    function delegateAll(uint256 actorSeed, uint256 amountSeed) external {
+        if (!delegation.isOperatorActive(operator)) return;
+
+        address delegator = allDelegators[bound(actorSeed, 0, allDelegators.length - 1)];
+        uint256 amount = bound(amountSeed, 0.1 ether, 25 ether);
+
+        vm.deal(delegator, amount);
+        vm.prank(delegator);
+        delegation.depositAndDelegate{ value: amount }(operator);
+
+        cumulativeDelegated += amount;
+        modeledTotal += amount;
+    }
+
+    function delegateFixed(uint256 actorSeed, uint256 amountSeed) external {
+        if (!delegation.isOperatorActive(operator)) return;
+
+        address delegator = fixedDelegators[bound(actorSeed, 0, fixedDelegators.length - 1)];
+        uint256 amount = bound(amountSeed, 0.1 ether, 25 ether);
+
+        uint64[] memory blueprints = new uint64[](1);
+        blueprints[0] = blueprintId;
+
+        vm.deal(delegator, amount);
+        vm.prank(delegator);
+        delegation.depositAndDelegateWithOptions{ value: amount }(
+            operator, address(0), amount, Types.BlueprintSelectionMode.Fixed, blueprints
+        );
+
+        cumulativeDelegated += amount;
+        modeledTotal += amount;
+    }
+
+    function slash(uint256 rawBps) external {
+        uint16 slashBps = uint16(bound(rawBps, 1, 10_000));
+
+        vm.prank(slasher);
+        uint256 actualSlashed =
+            delegation.slashForBlueprint(operator, blueprintId, 99, slashBps, keccak256("invariant-evidence"));
+
+        cumulativeSlashed += actualSlashed;
+        modeledTotal -= actualSlashed;
+    }
+
+    function expectedTotal() external view returns (uint256) {
+        return modeledTotal;
+    }
+
+    function totalSlashed() external view returns (uint256) {
+        return cumulativeSlashed;
+    }
+
+    function totalDelegated() external view returns (uint256) {
+        return cumulativeDelegated;
+    }
+}
+
+contract SlashAccountingInvariantTest is StdInvariant, Test {
+    IMultiAssetDelegation internal delegation;
+    MultiAssetDelegationInvariantExposed internal exposed;
+    SlashAccountingHandler internal handler;
+
+    address internal admin = address(0xA11CE);
+    address internal slasher = address(0xBEEF);
+    address internal operator = address(0xDEAD);
+    uint64 internal constant BLUEPRINT_ID = 42;
+
+    function setUp() public {
+        MultiAssetDelegation impl = new MultiAssetDelegation();
+        bytes memory initData = abi.encodeCall(MultiAssetDelegation.initialize, (admin, 1 ether, 0.1 ether, 1000));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        delegation = IMultiAssetDelegation(payable(address(proxy)));
+        exposed = MultiAssetDelegationInvariantExposed(payable(address(proxy)));
+
+        vm.startPrank(admin);
+        _registerFacets(address(proxy));
+        delegation.addSlasher(slasher);
+        vm.stopPrank();
+
+        vm.deal(operator, 100 ether);
+        vm.prank(operator);
+        delegation.registerOperator{ value: 20 ether }();
+        vm.prank(operator);
+        delegation.setDelegationMode(Types.DelegationMode.Open);
+
+        address seedAllDelegator = address(0xAAA1);
+        address seedFixedDelegator = address(0xBBB2);
+
+        vm.deal(seedAllDelegator, 100 ether);
+        vm.prank(seedAllDelegator);
+        delegation.depositAndDelegate{ value: 30 ether }(operator);
+
+        vm.deal(seedFixedDelegator, 100 ether);
+        uint64[] memory blueprints = new uint64[](1);
+        blueprints[0] = BLUEPRINT_ID;
+        vm.prank(seedFixedDelegator);
+        delegation.depositAndDelegateWithOptions{ value: 40 ether }(
+            operator, address(0), 40 ether, Types.BlueprintSelectionMode.Fixed, blueprints
+        );
+
+        handler = new SlashAccountingHandler(delegation, exposed, admin, slasher, operator, BLUEPRINT_ID);
+        targetContract(address(handler));
+    }
+
+    function invariant_slashAccountingConservesSlashableMass() public view {
+        uint256 actualTotal =
+            exposed.operatorStake(operator) + exposed.rewardPoolTotals(operator) + exposed.blueprintPoolTotals(operator, BLUEPRINT_ID);
+
+        assertEq(actualTotal, handler.expectedTotal(), "slashable accounting drifted from modeled total");
+    }
+
+    function invariant_cumulativeSlashedNeverExceedsInitialPlusDeposits() public view {
+        uint256 actualTotal =
+            exposed.operatorStake(operator) + exposed.rewardPoolTotals(operator) + exposed.blueprintPoolTotals(operator, BLUEPRINT_ID);
+
+        uint256 grossModeled = 90 ether + handler.totalDelegated();
+        assertEq(actualTotal + handler.totalSlashed(), grossModeled, "slash conservation violated");
+        assertLe(handler.totalSlashed(), grossModeled, "slashed amount exceeded modeled slashable mass");
+    }
+
+    function _registerFacets(address proxy) internal {
+        MultiAssetDelegation router = MultiAssetDelegation(payable(proxy));
+        router.registerFacet(address(new StakingOperatorsFacet()));
+        router.registerFacet(address(new StakingDepositsFacet()));
+        router.registerFacet(address(new StakingDelegationsFacet()));
+        router.registerFacet(address(new StakingSlashingFacet()));
+        router.registerFacet(address(new StakingAssetsFacet()));
+        router.registerFacet(address(new StakingViewsFacet()));
+        router.registerFacet(address(new StakingAdminFacet()));
+        router.registerFacet(address(new MultiAssetDelegationInvariantExposed()));
+    }
+}

--- a/test/tangle/JobPricingAndRFQ.t.sol
+++ b/test/tangle/JobPricingAndRFQ.t.sol
@@ -579,6 +579,32 @@ contract JobPricingAndRFQTest is BaseTest {
         tangle.submitJobFromQuote{ value: 1 ether }(serviceId, 0, "", quotes);
     }
 
+    function test_SubmitJobFromQuote_ConfidentialityMismatch_Reverts() public {
+        vm.startPrank(user1);
+        tangle.terminateService(serviceId);
+
+        address[] memory ops = new address[](2);
+        ops[0] = operator1;
+        ops[1] = operator2;
+        uint64 requestId =
+            tangle.requestService(blueprintId, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.TeeRequired);
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        tangle.approveService(requestId, 0);
+        vm.prank(operator2);
+        tangle.approveService(requestId, 0);
+
+        uint64 confidentialServiceId = tangle.serviceCount() - 1;
+
+        Types.SignedJobQuote[] memory quotes = new Types.SignedJobQuote[](1);
+        quotes[0] = _createJobQuote(operator1, OPERATOR1_PK, confidentialServiceId, 0, 1 ether);
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidQuoteSignature.selector, operator1));
+        tangle.submitJobFromQuote{ value: 1 ether }(confidentialServiceId, 0, "", quotes);
+    }
+
     function test_RFQJob_PerJobRateDoesNotAffectRFQPrice() public {
         // Set per-job rate to 5 ether, but RFQ quote says 1 ether — RFQ uses quote price
         uint8[] memory indexes = new uint8[](1);

--- a/test/tangle/PerAssetExposureIntegration.t.sol
+++ b/test/tangle/PerAssetExposureIntegration.t.sol
@@ -9,6 +9,7 @@ import { MockERC20 } from "../mocks/MockERC20.sol";
 import { MockPriceOracle } from "../exposure/MockPriceOracle.sol";
 import { ServiceFeeDistributor } from "../../src/rewards/ServiceFeeDistributor.sol";
 import { SlashingLib } from "../../src/libraries/SlashingLib.sol";
+import { IPriceOracle } from "../../src/oracles/interfaces/IPriceOracle.sol";
 
 contract PerAssetExposureIntegrationTest is BaseTest {
     MockERC20 internal stakeToken;
@@ -169,5 +170,50 @@ contract PerAssetExposureIntegrationTest is BaseTest {
         SlashingLib.SlashProposal memory p = tangle.getSlashProposal(slashId);
         assertEq(p.slashBps, slashBps);
         assertEq(p.effectiveSlashBps, (uint256(slashBps) * 5500) / 10_000);
+    }
+
+    function test_ServiceFee_Distribution_RevertsWhenOraclePriceUnavailable() public {
+        Types.AssetSecurityRequirement[] memory reqs = new Types.AssetSecurityRequirement[](2);
+        reqs[0] = Types.AssetSecurityRequirement({
+            asset: Types.Asset({ kind: Types.AssetKind.Native, token: address(0) }),
+            minExposureBps: 1000,
+            maxExposureBps: 10_000
+        });
+        reqs[1] = Types.AssetSecurityRequirement({
+            asset: Types.Asset({ kind: Types.AssetKind.ERC20, token: address(stakeToken) }),
+            minExposureBps: 1000,
+            maxExposureBps: 10_000
+        });
+
+        address[] memory ops = new address[](1);
+        ops[0] = operator1;
+
+        uint256 paymentAmount = 110 ether;
+        vm.startPrank(user1);
+        payToken.approve(address(tangle), paymentAmount);
+        uint64 requestId = tangle.requestServiceWithSecurity(
+            blueprintId,
+            ops,
+            reqs,
+            "",
+            new address[](0),
+            0,
+            address(payToken),
+            paymentAmount,
+            Types.ConfidentialityPolicy.Any
+        );
+        vm.stopPrank();
+
+        // Remove ERC20 pricing before approval. Service activation/payment distribution must
+        // fail closed instead of mixing raw token units into USD-normalized exposure weights.
+        oracle.setPrice(address(stakeToken), 0);
+
+        Types.AssetSecurityCommitment[] memory commits = new Types.AssetSecurityCommitment[](2);
+        commits[0] = Types.AssetSecurityCommitment({ asset: reqs[0].asset, exposureBps: 10_000 });
+        commits[1] = Types.AssetSecurityCommitment({ asset: reqs[1].asset, exposureBps: 1000 });
+
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(IPriceOracle.PriceNotAvailable.selector, address(stakeToken)));
+        tangle.approveServiceWithCommitments(requestId, commits);
     }
 }

--- a/test/tangle/SubscriptionEscrowInvariant.t.sol
+++ b/test/tangle/SubscriptionEscrowInvariant.t.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+
+import { BaseTest } from "../BaseTest.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { PaymentLib } from "../../src/libraries/PaymentLib.sol";
+import { MockServiceFeeDistributor } from "../mocks/MockServiceFeeDistributor.sol";
+
+interface ITanglePaymentsLike {
+    function fundService(uint64 serviceId, uint256 amount) external payable;
+    function billSubscription(uint64 serviceId) external;
+    function claimRewards() external;
+    function terminateService(uint64 serviceId) external;
+    function withdrawRemainingEscrow(uint64 serviceId) external;
+    function pendingRewards(address account) external view returns (uint256);
+    function getServiceEscrow(uint64 serviceId) external view returns (PaymentLib.ServiceEscrow memory);
+}
+
+contract SubscriptionEscrowHandler is Test {
+    uint256 internal constant MAX_TOP_UP = 2 ether;
+
+    ITanglePaymentsLike internal tangle;
+    address internal serviceOwner;
+    address internal operator;
+
+    uint64 public immutable serviceId;
+
+    uint256 public totalFunded;
+    uint256 public totalClaimedByOperator;
+    uint256 public totalRefundedToOwner;
+
+    constructor(ITanglePaymentsLike tangle_, uint64 serviceId_, address serviceOwner_, address operator_) {
+        tangle = tangle_;
+        serviceId = serviceId_;
+        serviceOwner = serviceOwner_;
+        operator = operator_;
+    }
+
+    function topUp(uint256 amount) external {
+        amount = bound(amount, 1 wei, MAX_TOP_UP);
+        vm.deal(serviceOwner, serviceOwner.balance + amount);
+        vm.prank(serviceOwner);
+        try tangle.fundService{ value: amount }(serviceId, amount) {
+            totalFunded += amount;
+        } catch { }
+    }
+
+    function warpForward(uint256 step) external {
+        step = bound(step, 1 days, 45 days);
+        vm.warp(block.timestamp + step);
+    }
+
+    function bill() external {
+        try tangle.billSubscription(serviceId) { } catch { }
+    }
+
+    function claimOperator() external {
+        uint256 beforeBalance = operator.balance;
+        vm.prank(operator);
+        try tangle.claimRewards() {
+            totalClaimedByOperator += operator.balance - beforeBalance;
+        } catch { }
+    }
+
+    function terminate() external {
+        vm.prank(serviceOwner);
+        try tangle.terminateService(serviceId) { } catch { }
+    }
+
+    function refundRemaining() external {
+        uint256 beforeBalance = serviceOwner.balance;
+        vm.prank(serviceOwner);
+        try tangle.withdrawRemainingEscrow(serviceId) {
+            totalRefundedToOwner += serviceOwner.balance - beforeBalance;
+        } catch { }
+    }
+}
+
+contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
+    MockServiceFeeDistributor internal distributor;
+    SubscriptionEscrowHandler internal handler;
+
+    uint64 internal serviceId;
+
+    uint256 internal initialDeveloperBalance;
+    uint256 internal initialTreasuryBalance;
+    uint256 internal initialDistributorBalance;
+
+    function setUp() public override {
+        super.setUp();
+
+        distributor = new MockServiceFeeDistributor();
+        vm.startPrank(admin);
+        tangle.setServiceFeeDistributor(address(distributor));
+        staking.setServiceFeeDistributor(address(distributor));
+        vm.stopPrank();
+
+        Types.BlueprintConfig memory config = Types.BlueprintConfig({
+            membership: Types.MembershipModel.Fixed,
+            pricing: Types.PricingModel.Subscription,
+            minOperators: 1,
+            maxOperators: 10,
+            subscriptionRate: 0.1 ether,
+            subscriptionInterval: 30 days,
+            eventRate: 0
+        });
+
+        vm.prank(developer);
+        uint64 bp = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://subscription-invariant", address(0), config));
+
+        _registerOperator(operator1, 5 ether);
+        _registerForBlueprint(operator1, bp);
+
+        address[] memory operators = new address[](1);
+        operators[0] = operator1;
+        address[] memory callers = new address[](0);
+
+        uint256 initialDeposit = 1 ether;
+        vm.prank(user1);
+        uint64 requestId = tangle.requestService{ value: initialDeposit }(
+            bp, operators, "", callers, 365 days, address(0), initialDeposit, Types.ConfidentialityPolicy.Any
+        );
+        _approveService(operator1, requestId);
+        serviceId = 0;
+
+        initialDeveloperBalance = developer.balance;
+        initialTreasuryBalance = treasury.balance;
+        initialDistributorBalance = address(distributor).balance;
+
+        handler = new SubscriptionEscrowHandler(ITanglePaymentsLike(address(tangle)), serviceId, user1, operator1);
+        vm.deal(address(handler), 100 ether);
+        targetContract(address(handler));
+    }
+
+    function invariant_subscriptionEscrowConservesNativeValue() external view {
+        PaymentLib.ServiceEscrow memory escrow = tangle.getServiceEscrow(serviceId);
+        uint256 pendingOperator = tangle.pendingRewards(operator1);
+
+        uint256 developerOut = developer.balance - initialDeveloperBalance;
+        uint256 treasuryOut = treasury.balance - initialTreasuryBalance;
+        uint256 stakerOut = address(distributor).balance - initialDistributorBalance;
+
+        uint256 lhs = 1 ether + handler.totalFunded();
+        uint256 rhs = escrow.balance + pendingOperator + handler.totalClaimedByOperator() + handler.totalRefundedToOwner()
+            + developerOut + treasuryOut + stakerOut;
+
+        assertEq(lhs, rhs, "subscription native value not conserved");
+        assertEq(address(tangle).balance, escrow.balance + pendingOperator, "tangle balance mismatch");
+    }
+}


### PR DESCRIPTION
## Summary
- enforce post-deploy governance handoff assertions in `FullDeploy`
- deploy `OperatorStatusRegistry` under the governance owner instead of leaving it on the bootstrap admin
- extend manifest verification to check critical roles and ownable owners over RPC
- record `serviceFeeDistributor` and `streamingPaymentManager` in the deployment manifest
- add deployment script regressions for timelock-owned status registry and bootstrap-role revocation

## Why
The deploy handoff path had a real failure mode: it revoked `DEFAULT_ADMIN_ROLE` before revoking the bootstrap key's remaining roles, which can break the handoff mid-flight under OpenZeppelin `AccessControl`. This makes the launch flow fail closed and reusable for testnet rollout.

## Verification
- `FOUNDRY_PROFILE=fast forge test --match-test testDeployCoreCanSetStatusRegistryOwnerToTimelock -vv`
- `FOUNDRY_PROFILE=fast forge test --match-test testFullDeployRoleHandoffRevokesBootstrapAndPinsGovernance -vv`
- `FOUNDRY_PROFILE=fast forge test --match-path test/scripts/DeploymentScriptsTest.t.sol -q`
- `FOUNDRY_PROFILE=fast forge test --match-path test/tangle/PerAssetExposureIntegration.t.sol -q`
- `bash -n script/sh/verify-full-deploy-manifest.sh`
