### PR TITLE
fix bindings release generation

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -50,7 +50,7 @@ jobs:
 
           echo "$CHANGED"
 
-          if echo "$CHANGED" | grep -Eq '^(src|test|script|dependencies|bindings|xtask)/|^(foundry.toml|remappings.txt|soldeer.lock|Cargo.toml|Cargo.lock)$'; then
+          if echo "$CHANGED" | grep -Eq '^(src|test|script|dependencies)/|^(foundry.toml|remappings.txt|soldeer.lock)$'; then
             echo "foundry_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "foundry_changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
           submodules: recursive
 
       - name: Install Foundry
@@ -62,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
           submodules: recursive
 
       - name: Install Foundry
@@ -87,7 +89,11 @@ jobs:
         env:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
         run: |
-          forge soldeer push tnt-core~${{ steps.version.outputs.version }}
+          if [ -z "${SOLDEER_API_TOKEN}" ]; then
+            echo "::error::SOLDEER_API_TOKEN repository secret is not configured"
+            exit 1
+          fi
+          forge soldeer push tnt-core~${{ steps.version.outputs.version }} --skip-warnings
 
   # Publish Rust bindings to crates.io
   publish-bindings:
@@ -100,6 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
           submodules: recursive
 
       - name: Install Foundry
@@ -120,5 +127,9 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN repository secret is not configured"
+            exit 1
+          fi
           cd bindings
           cargo publish --allow-dirty

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,6 +65,7 @@ fn gen_bindings() -> Result<()> {
                 "src/interfaces/ITangle.sol",
                 "src/interfaces/ITangleBlueprints.sol",
                 "src/interfaces/IBlueprintServiceManager.sol",
+                "src/interfaces/IMultiAssetDelegation.sol",
                 "src/staking/OperatorStatusRegistry.sol",
                 "src/staking/MultiAssetDelegation.sol",
             ]),


### PR DESCRIPTION
## Summary

Follow-up to #108 after the fixed release workflow reached publish jobs.

This fixes two publish-specific issues:

- `cargo xtask gen-bindings` now explicitly compiles `src/interfaces/IMultiAssetDelegation.sol`, so clean CI has the ABI artifact it later copies into `bindings/abi`.
- manual `workflow_dispatch` releases now check out `v${version}` instead of `main`, so publishing `0.10.9` uses the tagged source commit while still using the fixed workflow definition.
- release publish steps now fail early with a clear error if `SOLDEER_API_TOKEN` or `CARGO_REGISTRY_TOKEN` is missing.
- Soldeer publish uses `--skip-warnings` so CI will not fail on a non-interactive warning prompt once the token is configured.

## Validation

Ran locally:

- clean `cargo xtask gen-bindings` after deleting `out/local-build`, `cache/local-build`, `bindings/abi`, and `bindings/src/bindings`
- `cargo check -p xtask`

## Remaining external setup

The failed Soldeer publish job showed `SOLDEER_API_TOKEN` was empty in Actions. That repository secret still needs to be configured before Soldeer can publish from CI.
