### PR TITLE
fix dispatch bindings tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref }}
           submodules: recursive
 
       - name: Install Foundry
@@ -119,6 +118,20 @@ jobs:
 
       - name: Install dependencies
         run: forge soldeer update -d
+
+      - name: Verify binding source matches release tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION="${{ inputs.version }}"
+          TAG="v${VERSION}"
+          git fetch --depth=1 origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          TARGET_SHA="$(git rev-parse "${TAG}")"
+          echo "TNT_CORE_VERSION_OVERRIDE=${TARGET_SHA}" >> "$GITHUB_ENV"
+
+          if ! git diff --quiet "${TAG}" -- src foundry.toml remappings.txt soldeer.lock Cargo.toml Cargo.lock bindings/Cargo.toml bindings/README.md; then
+            echo "::error::Release-relevant source differs from ${TAG}; create a new tag or publish from the tag workflow instead"
+            exit 1
+          fi
 
       - name: Generate bindings
         run: cargo xtask gen-bindings

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -181,15 +181,20 @@ fn gen_bindings() -> Result<()> {
 
     // Step 5: Record version
     print_step(5, 5, "Recording git version...");
-    let git_rev = Command::new("git")
-        .current_dir(&repo_root)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .context("failed to query git rev")?;
-    if !git_rev.status.success() {
-        return Err(anyhow!("git rev-parse failed with {}", git_rev.status));
-    }
-    let version = String::from_utf8(git_rev.stdout)?.trim().to_string();
+    let version = match env::var("TNT_CORE_VERSION_OVERRIDE") {
+        Ok(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => {
+            let git_rev = Command::new("git")
+                .current_dir(&repo_root)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .context("failed to query git rev")?;
+            if !git_rev.status.success() {
+                return Err(anyhow!("git rev-parse failed with {}", git_rev.status));
+            }
+            String::from_utf8(git_rev.stdout)?.trim().to_string()
+        }
+    };
     fs::write(bindings_crate.join("TNT_CORE_VERSION"), &version)
         .context("failed to write TNT_CORE_VERSION")?;
     print_done();


### PR DESCRIPTION
## Summary

Follow-up release tooling fix after #109.

Manual `workflow_dispatch` needs to publish `0.10.9` using the fixed workflow/tooling on `main`, but still record the actual `v0.10.9` source tag in the generated bindings package.

This PR:

- lets `xtask gen-bindings` honor `TNT_CORE_VERSION_OVERRIDE` when recording `bindings/TNT_CORE_VERSION`
- keeps validation and Soldeer dispatch jobs checked out at `v${version}`
- lets the bindings dispatch job use current tooling, fetches `v${version}`, verifies release-relevant source matches the tag, and sets `TNT_CORE_VERSION_OVERRIDE` to the tag SHA before generation

## Validation

Ran locally:

- `cargo check -p xtask`
- `git diff --quiet v0.10.9 -- src foundry.toml remappings.txt soldeer.lock Cargo.toml Cargo.lock bindings/Cargo.toml bindings/README.md`
