### PR TITLE
chore(ci): update Foundry release toolchain

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.changes.outputs.foundry_changed == 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.5.1
 
       - name: Install Solidity Dependencies
         if: steps.changes.outputs.foundry_changed == 'true'
@@ -92,7 +92,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.5.1
 
       - name: Install Solidity Dependencies
         run: forge soldeer update -d

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.5.1
 
       - name: Install dependencies
         run: forge soldeer update -d
@@ -69,7 +69,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.5.1
 
       - name: Install dependencies
         run: forge soldeer update -d
@@ -111,7 +111,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v0.3.0
+          version: v1.5.1
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- update Foundry CI and release workflows from Foundry v0.3.0 to v1.5.1
- align CI binding generation with the local toolchain that produces crates.io-verifiable Alloy bindings
- keep release publishing on a pinned stable Foundry version instead of the 2024 build

## Verification
- git diff --check
- cargo check -p tnt-core-bindings
- cd bindings && cargo publish --dry-run --allow-dirty
- forge soldeer push tnt-core~0.10.9 --dry-run --skip-warnings