### PR TITLE
fix(security): slashing model, manager-hook reentrancy, lifecycle, EIP-712

### DIFF
--- a/script/DemoSimulation.s.sol
+++ b/script/DemoSimulation.s.sol
@@ -653,12 +653,23 @@ contract DemoSimulation is Script, BlueprintDefinitionHelper {
             vm.startBroadcast(operatorKeys[i]);
 
             bytes memory metrics = abi.encode("cpu", 50 + (tick % 50), "mem", 60 + (tick % 40));
-            bytes32 messageHash = keccak256(abi.encodePacked(serviceId, blueprintId, metrics));
-            bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
-            (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorKeys[i], ethSignedHash);
+            uint64 timestamp = uint64(block.timestamp);
+            bytes32 structHash = keccak256(
+                abi.encode(
+                    statusRegistry.HEARTBEAT_TYPEHASH(),
+                    vm.addr(operatorKeys[i]),
+                    serviceId,
+                    blueprintId,
+                    uint8(0),
+                    keccak256(metrics),
+                    timestamp
+                )
+            );
+            bytes32 digest = keccak256(abi.encodePacked("\x19\x01", statusRegistry.DOMAIN_SEPARATOR(), structHash));
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorKeys[i], digest);
             bytes memory signature = abi.encodePacked(r, s, v);
 
-            try statusRegistry.submitHeartbeat(serviceId, blueprintId, 0, metrics, signature) {
+            try statusRegistry.submitHeartbeat(serviceId, blueprintId, 0, metrics, timestamp, signature) {
                 totalHeartbeats++;
             } catch { }
 

--- a/script/LocalTestnet.s.sol
+++ b/script/LocalTestnet.s.sol
@@ -1393,12 +1393,22 @@ contract TestHeartbeat is Script {
 
         vm.startBroadcast(OPERATOR1_KEY);
 
-        // Create heartbeat signature using Foundry's vm.sign
+        // Build the EIP-712 typed-data digest for the new heartbeat schema.
         bytes memory metrics = "";
-        bytes32 messageHash = keccak256(abi.encodePacked(serviceId, blueprintId, metrics));
-        // Add Ethereum signed message prefix
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(OPERATOR1_KEY, ethSignedHash);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 structHash = keccak256(
+            abi.encode(
+                registry.HEARTBEAT_TYPEHASH(),
+                vm.addr(OPERATOR1_KEY),
+                serviceId,
+                blueprintId,
+                uint8(0),
+                keccak256(metrics),
+                timestamp
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", registry.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(OPERATOR1_KEY, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
 
         registry.submitHeartbeat(
@@ -1406,6 +1416,7 @@ contract TestHeartbeat is Script {
             blueprintId,
             0, // Healthy
             metrics,
+            timestamp,
             signature
         );
         console2.log("Heartbeat submitted");

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -78,8 +78,11 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @inheritdoc IBlueprintServiceManager
+    /// @dev One-shot binder. The BSM is paired with exactly one Tangle core on its first
+    ///      successful call; subsequent calls revert. A frontrunner can only DoS a single
+    ///      BSM deployment, which the deployer detects (the recorded `tangleCore` won't
+    ///      match the intended Tangle) and re-deploys to fix.
     function onBlueprintCreated(uint64 _blueprintId, address owner, address _tangleCore) external virtual {
-        // Can only be set once
         if (tangleCore != address(0)) revert AlreadyInitialized();
 
         blueprintId = _blueprintId;

--- a/src/MBSMRegistry.sol
+++ b/src/MBSMRegistry.sol
@@ -53,7 +53,7 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     mapping(uint32 => uint256) private _emergencyDeprecationReadyAt;
 
     /// @notice Storage gap for upgrades
-    uint256[47] private __gap;
+    uint256[50] private __gap;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EVENTS

--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -232,6 +232,12 @@ abstract contract TangleStorage {
     /// @notice Slash ID => Slash proposal
     mapping(uint64 => SlashingLib.SlashProposal) internal _slashProposals;
 
+    /// @notice Live count of pending (unresolved) slash proposals per operator. Used to
+    ///         enforce `SlashConfig.maxPendingSlashesPerOperator` so a malicious proposer
+    ///         can't grief an operator by spamming pending slashes that all bump the
+    ///         staking-side `_operatorPendingSlashCount`.
+    mapping(address => uint64) internal _operatorActiveSlashProposals;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // RFQ (QUOTE) STORAGE (Slot 81-90)
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/core/Base.sol
+++ b/src/core/Base.sol
@@ -62,6 +62,11 @@ abstract contract Base is
     /// @param registry The new registry address
     event MBSMRegistryUpdated(address indexed registry);
 
+    /// @notice Emitted when a best-effort blueprint-manager hook reverted or ran out of
+    ///         the capped gas stipend. Observable so off-chain monitors can detect a
+    ///         misbehaving BSM without halting the protocol path.
+    event ManagerHookFailed(address indexed manager, bytes4 indexed selector, bytes returnData);
+
     /// @notice Emitted when the metrics recorder is updated
     /// @param recorder The new recorder address (or zero to disable)
     event MetricsRecorderUpdated(address indexed recorder);
@@ -181,11 +186,21 @@ abstract contract Base is
             stakerBps: DEFAULT_STAKER_BPS
         });
 
-        // Initialize EIP-712 domain separator
+        // Domain separator is computed on-the-fly from `block.chainid` (see
+        // `_domainSeparatorView`) so a post-fork chainid mismatch invalidates quotes
+        // signed under the old chain id automatically. We keep the storage slot
+        // populated as a snapshot for off-chain indexers but never read it on-chain.
         _domainSeparator = SignatureLib.computeDomainSeparator("TangleQuote", "1", address(this));
 
         // Initialize slashing config
         SlashingLib.initializeConfig(_slashState);
+    }
+
+    /// @notice Compute the EIP-712 domain separator at the *current* chainid. Used by all
+    ///         on-chain quote / signature verification so a chain fork or upgrade does not
+    ///         allow replays signed under a different chainid.
+    function _domainSeparatorView() internal view returns (bytes32) {
+        return SignatureLib.computeDomainSeparator("TangleQuote", "1", address(this));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -683,9 +698,17 @@ abstract contract Base is
         }
     }
 
-    /// @notice Call manager with revert on failure
+    /// @notice Maximum gas forwarded to a blueprint manager hook.
+    /// @dev Capped to 500k so a malicious or buggy BSM cannot burn the entire transaction
+    ///      gas, and so that downstream protocol logic always has enough gas left to
+    ///      finalize state changes (CEI). Hooks should be lightweight; bookkeeping work
+    ///      belongs off-chain. The cap is generous enough for typical hook bodies and
+    ///      tightens the worst-case reentrancy / DoS surface significantly.
+    uint256 internal constant MANAGER_HOOK_GAS_LIMIT = 500_000;
+
+    /// @notice Call manager with revert on failure (capped gas).
     function _callManager(address manager, bytes memory data) internal {
-        (bool success, bytes memory returnData) = manager.call(data);
+        (bool success, bytes memory returnData) = manager.call{ gas: MANAGER_HOOK_GAS_LIMIT }(data);
         if (!success) {
             if (returnData.length > 0) {
                 revert Errors.ManagerReverted(manager, returnData);
@@ -694,10 +717,14 @@ abstract contract Base is
         }
     }
 
-    /// @notice Try to call manager, ignore failures
+    /// @notice Try to call manager, ignore failures (capped gas).
+    /// @dev Failure is observable via the `ManagerHookFailed` event so off-chain monitors
+    ///      can detect a misbehaving BSM without halting the protocol path.
     function _tryCallManager(address manager, bytes memory data) internal {
-        (bool success,) = manager.call(data);
-        success; // Silence unused variable warning
+        (bool success, bytes memory returnData) = manager.call{ gas: MANAGER_HOOK_GAS_LIMIT }(data);
+        if (!success) {
+            emit ManagerHookFailed(manager, bytes4(data), returnData);
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/core/BlueprintsCreate.sol
+++ b/src/core/BlueprintsCreate.sol
@@ -30,6 +30,7 @@ abstract contract BlueprintsCreate is Base {
     function createBlueprint(Types.BlueprintDefinition calldata def)
         external
         whenNotPaused
+        nonReentrant
         returns (uint64 blueprintId)
     {
         if (address(_mbsmRegistry) == address(0)) revert Errors.MBSMRegistryNotSet();

--- a/src/core/BlueprintsManage.sol
+++ b/src/core/BlueprintsManage.sol
@@ -77,7 +77,10 @@ abstract contract BlueprintsManage is Base {
     }
 
     /// @notice Update blueprint metadata
-    function updateBlueprint(uint64 blueprintId, string calldata metadataUri, bytes32 metadataHash) external {
+    function updateBlueprint(uint64 blueprintId, string calldata metadataUri, bytes32 metadataHash)
+        external
+        nonReentrant
+    {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         if (bp.owner != msg.sender) {
             revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
@@ -91,7 +94,7 @@ abstract contract BlueprintsManage is Base {
     }
 
     /// @notice Transfer blueprint ownership
-    function transferBlueprint(uint64 blueprintId, address newOwner) external {
+    function transferBlueprint(uint64 blueprintId, address newOwner) external nonReentrant {
         if (newOwner == address(0)) revert Errors.ZeroAddress();
 
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
@@ -105,7 +108,7 @@ abstract contract BlueprintsManage is Base {
     }
 
     /// @notice Deactivate a blueprint
-    function deactivateBlueprint(uint64 blueprintId) external {
+    function deactivateBlueprint(uint64 blueprintId) external nonReentrant {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         if (bp.owner != msg.sender) {
             revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
@@ -123,7 +126,10 @@ abstract contract BlueprintsManage is Base {
     /// @param blueprintId The blueprint ID
     /// @param jobIndexes Array of job indexes
     /// @param rates Array of per-job event rates (0 to clear override and use blueprint default)
-    function setJobEventRates(uint64 blueprintId, uint8[] calldata jobIndexes, uint256[] calldata rates) external {
+    function setJobEventRates(uint64 blueprintId, uint8[] calldata jobIndexes, uint256[] calldata rates)
+        external
+        nonReentrant
+    {
         if (jobIndexes.length != rates.length) revert Errors.LengthMismatch();
 
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
@@ -164,6 +170,7 @@ abstract contract BlueprintsManage is Base {
         Types.ResourceCommitment[] calldata requirements
     )
         external
+        nonReentrant
     {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         if (bp.owner != msg.sender) {

--- a/src/core/JobsRFQ.sol
+++ b/src/core/JobsRFQ.sol
@@ -172,8 +172,9 @@ abstract contract JobsRFQ is Base {
                 revert Errors.PaymentTooSmall(quote.details.price, PaymentLib.MINIMUM_PAYMENT_AMOUNT);
             }
 
-            // Verify EIP-712 signature and mark as used
-            SignatureLib.verifyAndMarkJobQuoteUsed(_usedQuotes, _domainSeparator, quote, maxQuoteAge);
+            // Verify EIP-712 signature and mark as used. Domain separator is recomputed
+            // per-call against current chainid so cross-fork replay is impossible.
+            SignatureLib.verifyAndMarkJobQuoteUsed(_usedQuotes, _domainSeparatorView(), quote, maxQuoteAge);
 
             totalPrice += quote.details.price;
         }

--- a/src/core/Operators.sol
+++ b/src/core/Operators.sol
@@ -207,11 +207,8 @@ abstract contract Operators is Base {
             revert Errors.OperatorHasActiveServices(blueprintId, msg.sender);
         }
 
-        // Call manager hook
-        if (bp.manager != address(0)) {
-            _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onUnregister, (msg.sender)));
-        }
-
+        // CEI: clear operator state BEFORE invoking the (untrusted) BSM hook so the
+        // hook observes a fully-finalized unregistration. Mirrors the registration path.
         bytes32 keyHash;
         if (prefs.ecdsaPublicKey.length != 0) {
             keyHash = keccak256(prefs.ecdsaPublicKey);
@@ -229,10 +226,14 @@ abstract contract Operators is Base {
             _operatorBlueprintCounts[msg.sender] -= 1;
         }
 
-        // Remove blueprint from operator's staking profile
         _staking.removeBlueprintForOperator(msg.sender, blueprintId);
 
         emit OperatorUnregistered(blueprintId, msg.sender);
+
+        // Hook fires last (interaction).
+        if (bp.manager != address(0)) {
+            _tryCallManager(bp.manager, abi.encodeCall(IBlueprintServiceManager.onUnregister, (msg.sender)));
+        }
     }
 
     /// @notice Update operator preferences for a blueprint

--- a/src/core/Operators.sol
+++ b/src/core/Operators.sol
@@ -74,6 +74,7 @@ abstract contract Operators is Base {
     )
         external
         whenNotPaused
+        nonReentrant
     {
         _registerOperator(blueprintId, ecdsaPublicKey, rpcAddress, bytes(""));
     }
@@ -87,6 +88,7 @@ abstract contract Operators is Base {
     )
         external
         whenNotPaused
+        nonReentrant
     {
         _registerOperator(blueprintId, ecdsaPublicKey, rpcAddress, registrationInputs);
     }
@@ -150,25 +152,13 @@ abstract contract Operators is Base {
 
         string memory rpcAddressCopy = rpcAddress;
 
-        // Encode preferences for backwards-compatible manager hooks
-        {
-            bytes memory encodedPreferences =
-                abi.encode(Types.OperatorPreferences({ ecdsaPublicKey: ecdsaPublicKey, rpcAddress: rpcAddressCopy }));
+        // CEI: complete every state write before invoking the (untrusted) BSM hook.
+        // The hook can revert to reject the registration; if it does, all the state
+        // writes are reverted along with it. The hook *cannot* observe partially-
+        // written state, so a malicious BSM cannot exploit half-initialized records.
+        _operatorPreferences[blueprintId][msg.sender] =
+            Types.OperatorPreferences({ ecdsaPublicKey: ecdsaPublicKey, rpcAddress: rpcAddressCopy });
 
-            // Call manager hook first (may reject)
-            if (bp.manager != address(0)) {
-                bytes memory managerPayload = registrationInputs.length > 0 ? registrationInputs : encodedPreferences;
-                _callManager(
-                    bp.manager, abi.encodeCall(IBlueprintServiceManager.onRegister, (msg.sender, managerPayload))
-                );
-            }
-
-            // Store preferences (including ECDSA public key for gossip)
-            _operatorPreferences[blueprintId][msg.sender] =
-                Types.OperatorPreferences({ ecdsaPublicKey: ecdsaPublicKey, rpcAddress: rpcAddressCopy });
-        }
-
-        // Register
         _operatorRegistrations[blueprintId][msg.sender] = Types.OperatorRegistration({
             registeredAt: uint64(block.timestamp), updatedAt: uint64(block.timestamp), active: true, online: true
         });
@@ -189,11 +179,21 @@ abstract contract Operators is Base {
 
         _recordBlueprintRegistration(blueprintId, msg.sender);
         emit OperatorRegistered(blueprintId, msg.sender, ecdsaPublicKey, rpcAddressCopy);
+
+        // Hook fires last so the BSM observes the fully-committed registration.
+        if (bp.manager != address(0)) {
+            bytes memory encodedPreferences =
+                abi.encode(Types.OperatorPreferences({ ecdsaPublicKey: ecdsaPublicKey, rpcAddress: rpcAddressCopy }));
+            bytes memory managerPayload = registrationInputs.length > 0 ? registrationInputs : encodedPreferences;
+            _callManager(
+                bp.manager, abi.encodeCall(IBlueprintServiceManager.onRegister, (msg.sender, managerPayload))
+            );
+        }
     }
 
     /// @notice Unregister from a blueprint
     /// @dev Reverts if operator has any active services for this blueprint
-    function unregisterOperator(uint64 blueprintId) external {
+    function unregisterOperator(uint64 blueprintId) external nonReentrant {
         Types.Blueprint storage bp = _getBlueprint(blueprintId);
         Types.OperatorRegistration storage reg = _operatorRegistrations[blueprintId][msg.sender];
         Types.OperatorPreferences storage prefs = _operatorPreferences[blueprintId][msg.sender];

--- a/src/core/Payments.sol
+++ b/src/core/Payments.sol
@@ -58,7 +58,11 @@ abstract contract Payments is Base, PaymentsEffectiveExposure {
     // ESCROW MANAGEMENT
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Fund a service's escrow
+    /// @notice Fund a service's escrow.
+    /// @dev Re-checks (a) the service hasn't expired and (b) the blueprint manager still
+    ///      whitelists the escrow's payment token. Without these checks a service could
+    ///      be funded after expiry (escrow stuck) or after a manager policy revoke
+    ///      (ongoing top-ups for a token the protocol now disallows).
     function fundService(uint64 serviceId, uint256 amount) external payable nonReentrant {
         Types.Service storage svc = _getService(serviceId);
         if (svc.status != Types.ServiceStatus.Active) {
@@ -67,9 +71,17 @@ abstract contract Payments is Base, PaymentsEffectiveExposure {
         if (svc.pricing != Types.PricingModel.Subscription) {
             revert Errors.InvalidState();
         }
+        if (svc.ttl > 0 && block.timestamp > svc.createdAt + svc.ttl) {
+            revert Errors.ServiceExpired(serviceId);
+        }
 
         PaymentLib.ServiceEscrow storage escrow = _serviceEscrows[serviceId];
         address token = escrow.token;
+
+        Types.Blueprint storage bp = _blueprints[svc.blueprintId];
+        if (bp.manager != address(0) && !_isPaymentAssetAllowedByManager(bp.manager, serviceId, token)) {
+            revert Errors.TokenNotAllowed(token);
+        }
 
         PaymentLib.depositToEscrow(escrow, token, amount, msg.value);
 

--- a/src/core/QuotesCreate.sol
+++ b/src/core/QuotesCreate.sol
@@ -151,7 +151,7 @@ abstract contract QuotesCreate is Base {
         returns (uint256 totalCost)
     {
         (totalCost,) = SignatureLib.verifyQuoteBatch(
-            _usedQuotes, _domainSeparator, quotes, blueprintId, ttl, msg.sender
+            _usedQuotes, _domainSeparatorView(), quotes, blueprintId, ttl, msg.sender
         );
         _ensureQuoteConfidentialityConsistent(quotes);
     }

--- a/src/core/QuotesExtend.sol
+++ b/src/core/QuotesExtend.sol
@@ -146,7 +146,7 @@ abstract contract QuotesExtend is Base {
         returns (uint256 totalCost)
     {
         (totalCost,) = SignatureLib.verifyQuoteBatch(
-            _usedQuotes, _domainSeparator, quotes, blueprintId, ttl, msg.sender
+            _usedQuotes, _domainSeparatorView(), quotes, blueprintId, ttl, msg.sender
         );
     }
 

--- a/src/core/ServicesApprovals.sol
+++ b/src/core/ServicesApprovals.sol
@@ -9,6 +9,7 @@ import { Errors } from "../libraries/Errors.sol";
 import { PaymentLib } from "../libraries/PaymentLib.sol";
 import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager.sol";
 import { BN254 } from "../libraries/BN254.sol";
+import { ProtocolConfig } from "../config/ProtocolConfig.sol";
 
 /// @title ServicesApprovals
 /// @notice Single approval entrypoint for service requests.
@@ -36,6 +37,7 @@ abstract contract ServicesApprovals is Base {
 
     event ServiceApproved(uint64 indexed requestId, address indexed operator);
     event ServiceRejected(uint64 indexed requestId, address indexed operator);
+    event ServiceRequestExpired(uint64 indexed requestId, address indexed expiredBy);
 
     /// @notice Emitted on every approval that carries TEE commitments. The
     ///         `commitments` payload is the full array exactly as supplied —
@@ -156,6 +158,8 @@ abstract contract ServicesApprovals is Base {
     function rejectService(uint64 requestId) external nonReentrant {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected) revert Errors.ServiceRequestAlreadyProcessed(requestId);
+        if (req.activated) revert Errors.ServiceRequestAlreadyProcessed(requestId);
+        _requireRequestNotExpired(req, requestId);
         if (!_staking.isOperatorActive(msg.sender)) revert Errors.OperatorNotActive(msg.sender);
 
         if (!_isRequestOperator(requestId, msg.sender)) revert Errors.Unauthorized();
@@ -310,6 +314,44 @@ abstract contract ServicesApprovals is Base {
             Types.BN254G2Point({ x: [blsPubkey[0], blsPubkey[1]], y: [blsPubkey[2], blsPubkey[3]] })
         );
         if (!ok) revert Errors.InvalidBLSSignature();
+    }
+
+    /// @notice Permissionlessly expire a stale service request and refund the requester.
+    /// @dev Anyone can call this once `block.timestamp > req.createdAt + grace`. The grace
+    ///      period is `_requestExpiryGracePeriod` (or `ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD`
+    ///      when unset). Without this path stale unapproved requests would linger indefinitely
+    ///      with their payment locked; cleanup is now permissionless and incentive-aligned
+    ///      (the requester gets refunded, the caller pays the gas).
+    ///      Once a request is fully approved and activated (`req.activated == true`) the
+    ///      escrowed payment has been transferred to the service; refunding from here
+    ///      would double-spend, so activated requests are no longer expirable.
+    function expireServiceRequest(uint64 requestId) external nonReentrant {
+        Types.ServiceRequest storage req = _getServiceRequest(requestId);
+        if (req.rejected || req.activated) revert Errors.ServiceRequestAlreadyProcessed(requestId);
+
+        uint64 grace = _requestExpiryGracePeriod;
+        if (grace == 0) grace = ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD;
+        if (block.timestamp <= uint256(req.createdAt) + grace) {
+            revert Errors.ServiceRequestNotExpired(requestId);
+        }
+
+        req.rejected = true;
+        PaymentLib.refundPayment(req.requester, req.paymentToken, req.paymentAmount);
+
+        emit ServiceRequestExpired(requestId, msg.sender);
+    }
+
+    /// @dev Reverts if the request has lingered past its grace window or has already
+    ///      been activated. Activated requests are functionally closed: their escrow
+    ///      has been routed to the service record and any further mutation here would
+    ///      contradict that state.
+    function _requireRequestNotExpired(Types.ServiceRequest storage req, uint64 requestId) private view {
+        if (req.activated) revert Errors.ServiceRequestAlreadyProcessed(requestId);
+        uint64 grace = _requestExpiryGracePeriod;
+        if (grace == 0) grace = ProtocolConfig.REQUEST_EXPIRY_GRACE_PERIOD;
+        if (block.timestamp > uint256(req.createdAt) + grace) {
+            revert Errors.ServiceRequestExpiredError(requestId);
+        }
     }
 
     /// @notice True iff the request's only security requirement is the protocol-default

--- a/src/core/ServicesApprovals.sol
+++ b/src/core/ServicesApprovals.sol
@@ -322,9 +322,9 @@ abstract contract ServicesApprovals is Base {
     ///      when unset). Without this path stale unapproved requests would linger indefinitely
     ///      with their payment locked; cleanup is now permissionless and incentive-aligned
     ///      (the requester gets refunded, the caller pays the gas).
-    ///      Once a request is fully approved and activated (`req.activated == true`) the
-    ///      escrowed payment has been transferred to the service; refunding from here
-    ///      would double-spend, so activated requests are no longer expirable.
+    ///      Refund is bounded to requests that were never activated AND never rejected.
+    ///      `req.activated` is set inside `_activateService` so an activated request — whose
+    ///      `paymentAmount` has already been routed to operators — cannot be drained again.
     function expireServiceRequest(uint64 requestId) external nonReentrant {
         Types.ServiceRequest storage req = _getServiceRequest(requestId);
         if (req.rejected || req.activated) revert Errors.ServiceRequestAlreadyProcessed(requestId);
@@ -344,7 +344,8 @@ abstract contract ServicesApprovals is Base {
     /// @dev Reverts if the request has lingered past its grace window or has already
     ///      been activated. Activated requests are functionally closed: their escrow
     ///      has been routed to the service record and any further mutation here would
-    ///      contradict that state.
+    ///      contradict that state. Operators that let a request sit too long must wait
+    ///      for someone to call `expireServiceRequest` before requesting again.
     function _requireRequestNotExpired(Types.ServiceRequest storage req, uint64 requestId) private view {
         if (req.activated) revert Errors.ServiceRequestAlreadyProcessed(requestId);
         uint64 grace = _requestExpiryGracePeriod;

--- a/src/core/ServicesRequests.sol
+++ b/src/core/ServicesRequests.sol
@@ -427,7 +427,8 @@ abstract contract ServicesRequests is Base {
             minOperators: bounds.minOperators,
             maxOperators: bounds.maxOperators,
             confidentiality: confidentiality,
-            rejected: false
+            rejected: false,
+            activated: false
         });
     }
 

--- a/src/core/Slashing.sol
+++ b/src/core/Slashing.sol
@@ -46,8 +46,9 @@ abstract contract Slashing is Base {
 
         bool authorized = msg.sender == svc.owner || msg.sender == bp.owner;
         if (!authorized && bp.manager != address(0)) {
-            // The slashing origin returned by blueprint manager is trusted.
-            // Operators should audit blueprint manager code before registering.
+            // Blueprint manager declares an additional slashing origin (e.g. a service-
+            // specific oracle / committee). Operators audit the BSM and its upgradeability
+            // before registering — that is the documented trust boundary.
             try IBlueprintServiceManager(bp.manager).querySlashingOrigin(serviceId) returns (address origin) {
                 authorized = msg.sender == origin;
             } catch { }
@@ -78,6 +79,15 @@ abstract contract Slashing is Base {
             evidence,
             false
         );
+
+        // Cap concurrent pending slashes per operator so a malicious proposer can't
+        // grief by spamming.
+        uint64 perOpCap = _slashState.config.maxPendingSlashesPerOperator;
+        if (perOpCap == 0) perOpCap = 32;
+        if (_operatorActiveSlashProposals[operator] >= perOpCap) {
+            revert Errors.InvalidState();
+        }
+        _operatorActiveSlashProposals[operator] += 1;
 
         // M-9 FIX: Increment pending slash count to block delegator withdrawals
         _staking.incrementPendingSlash(operator);
@@ -193,46 +203,54 @@ abstract contract Slashing is Base {
     // DISPUTE
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Dispute a pending slash within the dispute window
-    /// @param slashId The slash proposal ID to dispute
-    /// @param reason A human-readable reason for the dispute
-    function disputeSlash(uint64 slashId, string calldata reason) external {
+    /// @notice Dispute a pending slash within the dispute window.
+    /// @dev SLASH_ADMIN can dispute without a bond (it's the official escalation path).
+    ///      The slashed operator must post `_slashState.config.disputeBond` in native
+    ///      asset. Bond is forfeit to treasury if the dispute auto-fails or the slash
+    ///      executes; refunded if SLASH_ADMIN cancels the slash.
+    function disputeSlash(uint64 slashId, string calldata reason) external payable {
         SlashingLib.SlashProposal storage proposal = _slashProposals[slashId];
 
-        if (msg.sender != proposal.operator && !hasRole(SLASH_ADMIN_ROLE, msg.sender)) {
+        bool isAdmin = hasRole(SLASH_ADMIN_ROLE, msg.sender);
+        if (msg.sender != proposal.operator && !isAdmin) {
             revert Errors.NotSlashDisputer(slashId, msg.sender);
         }
 
-        SlashingLib.disputeSlash(_slashProposals, slashId, msg.sender, reason);
+        uint256 requiredBond = isAdmin ? 0 : _slashState.config.disputeBond;
+        if (msg.value != requiredBond) {
+            revert Errors.InvalidMsgValue(requiredBond, msg.value);
+        }
+
+        SlashingLib.disputeSlash(_slashProposals, slashId, msg.sender, reason, msg.value);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // EXECUTION
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Execute a pending slash after dispute window
-    /// @dev Operators are expected to call this via their node software.
-    ///      Uses blueprint-aware slashing to only affect delegators exposed to this blueprint.
-    /// @param slashId The slash ID to execute
-    /// @return actualSlashed Amount actually slashed (accounting reduction)
+    /// @notice Execute a pending slash after dispute window.
+    /// @dev Routes through `slashForService` when the operator made explicit commitments
+    ///      to this service so we only slash assets they actually backed. Falls back to
+    ///      blueprint-wide slashing when there are no commitments (legacy services).
     function executeSlash(uint64 slashId) external nonReentrant returns (uint256 actualSlashed) {
         SlashingLib.SlashProposal storage proposal = _slashProposals[slashId];
 
-        if (!SlashingLib.isExecutable(proposal)) {
+        if (!SlashingLib.isExecutable(proposal, _slashState.config)) {
             revert Errors.SlashNotExecutable(slashId);
         }
 
         Types.Service storage svc = _services[proposal.serviceId];
 
-        // Use blueprint-aware slashing - only affects delegators exposed to this blueprint
-        actualSlashed = _staking.slashForBlueprint(
-            proposal.operator, svc.blueprintId, proposal.serviceId, proposal.effectiveSlashBps, proposal.evidence
-        );
+        actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
 
-        SlashingLib.markExecuted(_slashProposals, slashId, actualSlashed);
+        SlashingLib.markExecuted(_slashProposals, _slashState.config, slashId, actualSlashed);
+
+        // Forfeit any dispute bond to the treasury — the dispute failed.
+        _settleDisputeBond(proposal, /*refund*/ false);
 
         // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
         _staking.decrementPendingSlash(proposal.operator);
+        _decrementOperatorPendingTracker(proposal.operator);
 
         // Record slash for metrics tracking (affects rewards distribution)
         _recordSlash(proposal.operator, proposal.serviceId, actualSlashed);
@@ -242,7 +260,6 @@ abstract contract Slashing is Base {
             uint16 slashPercentBps = proposal.effectiveSlashBps;
             if (slashPercentBps > BPS_DENOMINATOR) slashPercentBps = BPS_DENOMINATOR;
 
-            // Convert to uint8 for hook (hook uses 0-100 percent, so we convert from bps)
             // forge-lint: disable-next-line(unsafe-typecast)
             uint8 slashPercent = uint8(slashPercentBps / BPS_TO_PERCENT);
             if (slashPercent > MAX_PERCENT) slashPercent = MAX_PERCENT;
@@ -272,19 +289,19 @@ abstract contract Slashing is Base {
             SlashingLib.SlashProposal storage proposal = _slashProposals[slashIds[i]];
 
             // Skip non-executable slashes instead of reverting
-            if (!SlashingLib.isExecutable(proposal)) continue;
+            if (!SlashingLib.isExecutable(proposal, _slashState.config)) continue;
 
             Types.Service storage svc = _services[proposal.serviceId];
 
-            // Use blueprint-aware slashing
-            uint256 actualSlashed = _staking.slashForBlueprint(
-                proposal.operator, svc.blueprintId, proposal.serviceId, proposal.effectiveSlashBps, proposal.evidence
-            );
+            uint256 actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
 
-            SlashingLib.markExecuted(_slashProposals, slashIds[i], actualSlashed);
+            SlashingLib.markExecuted(_slashProposals, _slashState.config, slashIds[i], actualSlashed);
+
+            _settleDisputeBond(proposal, /*refund*/ false);
 
             // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
             _staking.decrementPendingSlash(proposal.operator);
+            _decrementOperatorPendingTracker(proposal.operator);
 
             // Record slash for metrics tracking (affects rewards distribution)
             _recordSlash(proposal.operator, proposal.serviceId, actualSlashed);
@@ -319,7 +336,7 @@ abstract contract Slashing is Base {
         // First pass: count matching
         uint64 count = 0;
         for (uint64 i = fromId; i < toId; i++) {
-            if (SlashingLib.isExecutable(_slashProposals[i])) {
+            if (SlashingLib.isExecutable(_slashProposals[i], _slashState.config)) {
                 count++;
             }
         }
@@ -328,7 +345,7 @@ abstract contract Slashing is Base {
         ids = new uint64[](count);
         uint64 idx = 0;
         for (uint64 i = fromId; i < toId && idx < count; i++) {
-            if (SlashingLib.isExecutable(_slashProposals[i])) {
+            if (SlashingLib.isExecutable(_slashProposals[i], _slashState.config)) {
                 ids[idx++] = i;
             }
         }
@@ -347,32 +364,44 @@ abstract contract Slashing is Base {
             revert Errors.NotSlashCanceller(slashId, msg.sender);
         }
 
-        // M-9 FIX: Get operator before cancelling (proposal may be cleared)
-        address operator = _slashProposals[slashId].operator;
+        SlashingLib.SlashProposal storage proposal = _slashProposals[slashId];
+        address operator = proposal.operator;
+
+        // Refund any dispute bond — admin agrees with the dispute.
+        _settleDisputeBond(proposal, /*refund*/ true);
 
         SlashingLib.cancelSlash(_slashProposals, slashId, msg.sender, reason);
 
         // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
         _staking.decrementPendingSlash(operator);
+        _decrementOperatorPendingTracker(operator);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // ADMIN
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Update slashing configuration
-    /// @param disputeWindow The dispute window duration in seconds
-    /// @param instantSlashEnabled Whether instant slashing (bypassing dispute) is enabled
-    /// @param maxSlashBps Maximum slash amount in basis points (0-10000)
+    /// @notice Update slashing configuration.
     function setSlashConfig(
         uint64 disputeWindow,
         bool instantSlashEnabled,
-        uint16 maxSlashBps
+        uint16 maxSlashBps,
+        uint64 disputeResolutionDeadline,
+        uint256 disputeBond,
+        uint16 maxPendingSlashesPerOperator
     )
         external
         onlyRole(ADMIN_ROLE)
     {
-        SlashingLib.updateConfig(_slashState, disputeWindow, instantSlashEnabled, maxSlashBps);
+        SlashingLib.updateConfig(
+            _slashState,
+            disputeWindow,
+            instantSlashEnabled,
+            maxSlashBps,
+            disputeResolutionDeadline,
+            disputeBond,
+            maxPendingSlashesPerOperator
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -384,5 +413,66 @@ abstract contract Slashing is Base {
     /// @return The slash proposal struct with all details
     function getSlashProposal(uint64 slashId) external view returns (SlashingLib.SlashProposal memory) {
         return _slashProposals[slashId];
+    }
+
+    /// @dev Internal helper that picks the right slashing API based on whether the
+    ///      operator made explicit per-asset commitments to the offending service.
+    function _executeSlashOnStaking(
+        SlashingLib.SlashProposal storage proposal,
+        uint64 blueprintId
+    ) internal returns (uint256 actualSlashed) {
+        Types.AssetSecurityCommitment[] memory commitments = _loadServiceCommitments(proposal.serviceId, proposal.operator);
+
+        if (commitments.length == 0) {
+            return _staking.slashForBlueprint(
+                proposal.operator, blueprintId, proposal.serviceId, proposal.effectiveSlashBps, proposal.evidence
+            );
+        }
+        return _staking.slashForService(
+            proposal.operator,
+            blueprintId,
+            proposal.serviceId,
+            commitments,
+            proposal.effectiveSlashBps,
+            proposal.evidence
+        );
+    }
+
+    function _loadServiceCommitments(
+        uint64 serviceId,
+        address operator
+    ) internal view returns (Types.AssetSecurityCommitment[] memory copy) {
+        Types.AssetSecurityCommitment[] storage stored = _serviceSecurityCommitments[serviceId][operator];
+        uint256 len = stored.length;
+        copy = new Types.AssetSecurityCommitment[](len);
+        for (uint256 i = 0; i < len; i++) {
+            copy[i] = stored[i];
+        }
+    }
+
+    /// @dev Refund dispute bond to the disputer (cancel) or forward to treasury (execute /
+    ///      auto-fail). No-op when no bond was posted.
+    function _settleDisputeBond(SlashingLib.SlashProposal storage proposal, bool refund) internal {
+        uint256 bond = proposal.disputeBond;
+        if (bond == 0) return;
+        address disputer = proposal.disputer;
+
+        // Clear before transfer (CEI).
+        proposal.disputeBond = 0;
+        proposal.disputer = address(0);
+
+        address payable to = refund && disputer != address(0) ? payable(disputer) : _treasury;
+        if (to == address(0)) return; // Treasury unset — bond stays in contract; observable via storage.
+        (bool ok,) = to.call{ value: bond }("");
+        if (!ok && refund) {
+            // Restore so disputer can retry; do not strand on a failed payable recipient.
+            proposal.disputeBond = bond;
+            proposal.disputer = disputer;
+        }
+    }
+
+    function _decrementOperatorPendingTracker(address operator) internal {
+        uint64 cur = _operatorActiveSlashProposals[operator];
+        if (cur > 0) _operatorActiveSlashProposals[operator] = cur - 1;
     }
 }

--- a/src/core/Slashing.sol
+++ b/src/core/Slashing.sol
@@ -81,10 +81,9 @@ abstract contract Slashing is Base {
         );
 
         // Cap concurrent pending slashes per operator so a malicious proposer can't
-        // grief by spamming.
-        uint64 perOpCap = _slashState.config.maxPendingSlashesPerOperator;
-        if (perOpCap == 0) perOpCap = 32;
-        if (_operatorActiveSlashProposals[operator] >= perOpCap) {
+        // grief by spamming. `maxPendingSlashesPerOperator` is validated non-zero in
+        // both `initializeConfig` and `updateConfig`, so we trust it here.
+        if (_operatorActiveSlashProposals[operator] >= _slashState.config.maxPendingSlashesPerOperator) {
             revert Errors.InvalidState();
         }
         _operatorActiveSlashProposals[operator] += 1;
@@ -221,7 +220,7 @@ abstract contract Slashing is Base {
             revert Errors.InvalidMsgValue(requiredBond, msg.value);
         }
 
-        SlashingLib.disputeSlash(_slashProposals, slashId, msg.sender, reason, msg.value);
+        SlashingLib.disputeSlash(_slashProposals, _slashState.config, slashId, msg.sender, reason, msg.value);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -235,7 +234,7 @@ abstract contract Slashing is Base {
     function executeSlash(uint64 slashId) external nonReentrant returns (uint256 actualSlashed) {
         SlashingLib.SlashProposal storage proposal = _slashProposals[slashId];
 
-        if (!SlashingLib.isExecutable(proposal, _slashState.config)) {
+        if (!SlashingLib.isExecutable(proposal)) {
             revert Errors.SlashNotExecutable(slashId);
         }
 
@@ -243,17 +242,13 @@ abstract contract Slashing is Base {
 
         actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
 
-        SlashingLib.markExecuted(_slashProposals, _slashState.config, slashId, actualSlashed);
-
-        // Forfeit any dispute bond to the treasury — the dispute failed.
-        _settleDisputeBond(proposal, /*refund*/ false);
-
-        // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
+        SlashingLib.markExecuted(_slashProposals, slashId, actualSlashed);
         _staking.decrementPendingSlash(proposal.operator);
         _decrementOperatorPendingTracker(proposal.operator);
-
-        // Record slash for metrics tracking (affects rewards distribution)
         _recordSlash(proposal.operator, proposal.serviceId, actualSlashed);
+
+        // Bond forfeit (interaction) AFTER all state is finalized.
+        _settleDisputeBond(proposal, /*refund*/ false);
 
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
         if (bp.manager != address(0)) {
@@ -289,22 +284,19 @@ abstract contract Slashing is Base {
             SlashingLib.SlashProposal storage proposal = _slashProposals[slashIds[i]];
 
             // Skip non-executable slashes instead of reverting
-            if (!SlashingLib.isExecutable(proposal, _slashState.config)) continue;
+            if (!SlashingLib.isExecutable(proposal)) continue;
 
             Types.Service storage svc = _services[proposal.serviceId];
 
             uint256 actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
 
-            SlashingLib.markExecuted(_slashProposals, _slashState.config, slashIds[i], actualSlashed);
-
-            _settleDisputeBond(proposal, /*refund*/ false);
-
-            // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
+            SlashingLib.markExecuted(_slashProposals, slashIds[i], actualSlashed);
             _staking.decrementPendingSlash(proposal.operator);
             _decrementOperatorPendingTracker(proposal.operator);
-
-            // Record slash for metrics tracking (affects rewards distribution)
             _recordSlash(proposal.operator, proposal.serviceId, actualSlashed);
+
+            // Bond forfeit (interaction) AFTER all state is finalized.
+            _settleDisputeBond(proposal, /*refund*/ false);
 
             totalSlashed += actualSlashed;
             executedCount++;
@@ -336,7 +328,7 @@ abstract contract Slashing is Base {
         // First pass: count matching
         uint64 count = 0;
         for (uint64 i = fromId; i < toId; i++) {
-            if (SlashingLib.isExecutable(_slashProposals[i], _slashState.config)) {
+            if (SlashingLib.isExecutable(_slashProposals[i])) {
                 count++;
             }
         }
@@ -345,7 +337,7 @@ abstract contract Slashing is Base {
         ids = new uint64[](count);
         uint64 idx = 0;
         for (uint64 i = fromId; i < toId && idx < count; i++) {
-            if (SlashingLib.isExecutable(_slashProposals[i], _slashState.config)) {
+            if (SlashingLib.isExecutable(_slashProposals[i])) {
                 ids[idx++] = i;
             }
         }
@@ -356,10 +348,11 @@ abstract contract Slashing is Base {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Cancel a pending slash proposal
-    /// @dev Only callable by SLASH_ADMIN_ROLE
-    /// @param slashId The slash proposal ID to cancel
-    /// @param reason A human-readable reason for the cancellation
-    function cancelSlash(uint64 slashId, string calldata reason) external {
+    /// @dev Only callable by SLASH_ADMIN_ROLE. Strict CEI: every state mutation
+    ///      (status flip, pending-count decrements) finalizes BEFORE the bond ETH
+    ///      transfer, so a malicious disputer contract cannot re-enter and observe
+    ///      a half-cancelled state. `nonReentrant` is defense-in-depth on top.
+    function cancelSlash(uint64 slashId, string calldata reason) external nonReentrant {
         if (!hasRole(SLASH_ADMIN_ROLE, msg.sender)) {
             revert Errors.NotSlashCanceller(slashId, msg.sender);
         }
@@ -367,14 +360,12 @@ abstract contract Slashing is Base {
         SlashingLib.SlashProposal storage proposal = _slashProposals[slashId];
         address operator = proposal.operator;
 
-        // Refund any dispute bond — admin agrees with the dispute.
-        _settleDisputeBond(proposal, /*refund*/ true);
-
         SlashingLib.cancelSlash(_slashProposals, slashId, msg.sender, reason);
-
-        // M-9 FIX: Decrement pending slash count to allow delegator withdrawals
         _staking.decrementPendingSlash(operator);
         _decrementOperatorPendingTracker(operator);
+
+        // Bond refund last (interaction).
+        _settleDisputeBond(proposal, /*refund*/ true);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -450,8 +441,9 @@ abstract contract Slashing is Base {
         }
     }
 
-    /// @dev Refund dispute bond to the disputer (cancel) or forward to treasury (execute /
-    ///      auto-fail). No-op when no bond was posted.
+    /// @dev Refund dispute bond to the disputer (cancel) or forward to treasury (execute
+    ///      / auto-fail). No-op when no bond was posted. On transfer failure both paths
+    ///      restore the bond so it remains claimable rather than silently stranded.
     function _settleDisputeBond(SlashingLib.SlashProposal storage proposal, bool refund) internal {
         uint256 bond = proposal.disputeBond;
         if (bond == 0) return;
@@ -462,10 +454,16 @@ abstract contract Slashing is Base {
         proposal.disputer = address(0);
 
         address payable to = refund && disputer != address(0) ? payable(disputer) : _treasury;
-        if (to == address(0)) return; // Treasury unset — bond stays in contract; observable via storage.
+        if (to == address(0)) {
+            // Treasury / disputer unset — restore the bond so it can be claimed once
+            // the recipient is configured, rather than silently stranding ETH.
+            proposal.disputeBond = bond;
+            proposal.disputer = disputer;
+            return;
+        }
         (bool ok,) = to.call{ value: bond }("");
-        if (!ok && refund) {
-            // Restore so disputer can retry; do not strand on a failed payable recipient.
+        if (!ok) {
+            // Symmetric restore on either path — the bond is never silently lost.
             proposal.disputeBond = bond;
             proposal.disputer = disputer;
         }

--- a/src/facets/tangle/TangleServicesFacet.sol
+++ b/src/facets/tangle/TangleServicesFacet.sol
@@ -60,6 +60,12 @@ contract TangleServicesFacet is ServicesApprovals, IFacetSelectors {
     /// @notice Activate a fully approved service (called from Services mixin)
     function _activateService(uint64 requestId) internal override {
         Types.ServiceRequest storage req = _serviceRequests[requestId];
+        // Close the request lifecycle BEFORE any other state writes or external
+        // calls. Once flipped, expireServiceRequest cannot refund this escrow and
+        // late approve/reject paths revert. Set first so a malicious manager hook
+        // re-entering through any of those paths sees the closed state.
+        req.activated = true;
+
         uint64 serviceId = _serviceCount++;
         Types.Blueprint storage bp = _blueprints[req.blueprintId];
 

--- a/src/governance/GovernanceDeployer.sol
+++ b/src/governance/GovernanceDeployer.sol
@@ -261,29 +261,32 @@ contract GovernanceDeployer {
         roles[1] = keccak256("UPGRADER_ROLE");
     }
 
-    /// @notice Get default governance parameters for mainnet
+    /// @notice Get default governance parameters for mainnet.
+    /// @dev TangleToken uses ERC-6372 timestamp clock, so `votingDelay` and `votingPeriod`
+    ///      are denominated in seconds and are chain-agnostic (same values on Ethereum,
+    ///      Base, Arbitrum, etc.).
     function getDefaultMainnetParams(address admin) external pure returns (DeployParams memory) {
         return DeployParams({
             tokenAdmin: admin,
             initialTokenSupply: 50_000_000 * 1e18, // 50M initial supply
             existingToken: address(0),
             timelockDelay: 2 days,
-            votingDelay: 7200, // ~1 day (assuming 12s blocks)
-            votingPeriod: 50_400, // ~1 week
+            votingDelay: uint48(1 days), // 1 day exit window before voting opens
+            votingPeriod: uint32(7 days), // 1 week voting window
             proposalThreshold: 100_000 * 1e18, // 100k TNT to propose
             quorumPercent: 4 // 4% quorum
         });
     }
 
-    /// @notice Get governance parameters for testnet (faster)
+    /// @notice Get governance parameters for testnet (faster).
     function getDefaultTestnetParams(address admin) external pure returns (DeployParams memory) {
         return DeployParams({
             tokenAdmin: admin,
             initialTokenSupply: 50_000_000 * 1e18,
             existingToken: address(0),
             timelockDelay: 1 days, // Shorter for testing
-            votingDelay: 100, // ~20 minutes
-            votingPeriod: 1000, // ~3 hours
+            votingDelay: uint48(20 minutes),
+            votingPeriod: uint32(3 hours),
             proposalThreshold: 1000 * 1e18, // 1k TNT to propose
             quorumPercent: 1 // 1% quorum for easier testing
         });

--- a/src/governance/TangleToken.sol
+++ b/src/governance/TangleToken.sol
@@ -112,16 +112,18 @@ contract TangleToken is
     // CLOCK (ERC-6372)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Clock used for voting checkpoints (block number based)
+    /// @notice Clock used for voting checkpoints (timestamp based, ERC-6372).
+    /// @dev Timestamp clock makes voting delay/period chain-agnostic — `1 days` means the
+    ///      same thing on Ethereum (12s blocks), Base (2s blocks), or any other chain.
     function clock() public view override returns (uint48) {
-        return uint48(block.number);
+        return uint48(block.timestamp);
     }
 
-    /// @notice Description of the clock mode
+    /// @notice Description of the clock mode (ERC-6372).
     // solhint-disable-next-line func-name-mixedcase
     // forge-lint: disable-next-line(mixed-case-function)
     function CLOCK_MODE() public pure override returns (string memory) {
-        return "mode=blocknumber&from=default";
+        return "mode=timestamp&from=default";
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/interfaces/ITangleSlashing.sol
+++ b/src/interfaces/ITangleSlashing.sol
@@ -51,7 +51,17 @@ interface ITangleSlashing {
     function cancelSlash(uint64 slashId, string calldata reason) external;
 
     /// @notice Update slashing configuration
-    function setSlashConfig(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps) external;
+    /// @param disputeResolutionDeadline How long SLASH_ADMIN has to resolve a dispute
+    /// @param disputeBond Native asset bond required to dispute (0 = disabled)
+    /// @param maxPendingSlashesPerOperator Cap on concurrent pending slashes per operator
+    function setSlashConfig(
+        uint64 disputeWindow,
+        bool instantSlashEnabled,
+        uint16 maxSlashBps,
+        uint64 disputeResolutionDeadline,
+        uint256 disputeBond,
+        uint16 maxPendingSlashesPerOperator
+    ) external;
 
     /// @notice Get slash proposal details
     function getSlashProposal(uint64 slashId) external view returns (SlashingLib.SlashProposal memory);

--- a/src/interfaces/ITangleSlashing.sol
+++ b/src/interfaces/ITangleSlashing.sol
@@ -34,7 +34,10 @@ interface ITangleSlashing {
         returns (uint64 slashId);
 
     /// @notice Dispute a slash proposal
-    function disputeSlash(uint64 slashId, string calldata reason) external;
+    /// @dev `payable` because the implementation requires `msg.value == config.disputeBond`
+    ///      when the bond is non-zero (and zero otherwise). Typed callers must use a payable
+    ///      reference so `disputeSlash{value: bond}(...)` compiles.
+    function disputeSlash(uint64 slashId, string calldata reason) external payable;
 
     /// @notice Execute a slash proposal
     function executeSlash(uint64 slashId) external returns (uint256 actualSlashed);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -115,6 +115,12 @@ library Errors {
     /// @notice Service request already processed
     error ServiceRequestAlreadyProcessed(uint64 requestId);
 
+    /// @notice Service request grace period elapsed; cannot approve.
+    error ServiceRequestExpiredError(uint64 requestId);
+
+    /// @notice Service request grace period not yet elapsed; cannot expire.
+    error ServiceRequestNotExpired(uint64 requestId);
+
     /// @notice Service not found
     error ServiceNotFound(uint64 serviceId);
 

--- a/src/libraries/SlashingLib.sol
+++ b/src/libraries/SlashingLib.sol
@@ -59,10 +59,12 @@ library SlashingLib {
         // Native-asset bond locked when the slash was disputed. Refunded on cancel,
         // forfeit to treasury when the dispute auto-fails or the slash executes.
         uint256 disputeBond;
-        // Timestamp the dispute was raised (0 when undisputed). After
-        // `disputedAt + config.disputeResolutionDeadline`, `isExecutable` returns
-        // true even though `status == Disputed`, which auto-resolves stale disputes.
+        // Timestamp the dispute was raised (0 when undisputed).
         uint64 disputedAt;
+        // Snapshot of `config.disputeResolutionDeadline` at the moment the dispute was
+        // raised. Stored on the proposal so that admin shrinking the live config later
+        // cannot retroactively shorten an already-disputed slash's review window.
+        uint64 disputeDeadline;
     }
 
     /// @notice Slashing configuration
@@ -112,7 +114,14 @@ library SlashingLib {
 
     event SlashCancelled(uint64 indexed slashId, address indexed canceller, string reason);
 
-    event SlashConfigUpdated(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps);
+    event SlashConfigUpdated(
+        uint64 disputeWindow,
+        bool instantSlashEnabled,
+        uint16 maxSlashBps,
+        uint64 disputeResolutionDeadline,
+        uint256 disputeBond,
+        uint16 maxPendingSlashesPerOperator
+    );
 
     // ═══════════════════════════════════════════════════════════════════════════
     // INITIALIZATION
@@ -167,7 +176,14 @@ library SlashingLib {
             maxPendingSlashesPerOperator: maxPendingSlashesPerOperator
         });
 
-        emit SlashConfigUpdated(disputeWindow, instantSlashEnabled, maxSlashBps);
+        emit SlashConfigUpdated(
+            disputeWindow,
+            instantSlashEnabled,
+            maxSlashBps,
+            disputeResolutionDeadline,
+            disputeBond,
+            maxPendingSlashesPerOperator
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -252,7 +268,8 @@ library SlashingLib {
             disputeReason: "",
             disputer: address(0),
             disputeBond: 0,
-            disputedAt: 0
+            disputedAt: 0,
+            disputeDeadline: 0
         });
 
         emit SlashProposed(slashId, serviceId, operator, proposer, slashBps, effectiveSlashBps, evidence, executeAfter);
@@ -263,13 +280,12 @@ library SlashingLib {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Dispute a pending slash proposal.
-    /// @param proposals Storage mapping for proposals
-    /// @param slashId The slash ID to dispute
-    /// @param disputer Who is disputing
-    /// @param reason Reason for dispute
-    /// @param bondPosted Native-asset bond that the caller posted with the dispute call.
+    /// @dev Snapshots `config.disputeResolutionDeadline` onto the proposal so a later
+    ///      admin-driven shrink of the live config cannot retroactively shorten an
+    ///      already-disputed slash's review window.
     function disputeSlash(
         mapping(uint64 => SlashProposal) storage proposals,
+        SlashConfig storage config,
         uint64 slashId,
         address disputer,
         string memory reason,
@@ -296,6 +312,7 @@ library SlashingLib {
         proposal.disputer = disputer;
         proposal.disputeBond = bondPosted;
         proposal.disputedAt = uint64(block.timestamp);
+        proposal.disputeDeadline = uint64(block.timestamp) + config.disputeResolutionDeadline;
 
         emit SlashDisputed(slashId, disputer, reason);
     }
@@ -306,18 +323,16 @@ library SlashingLib {
 
     /// @notice Check if a slash is ready to execute.
     /// @dev A `Pending` slash becomes executable after the dispute window plus a
-    ///      timestamp-manipulation buffer. A `Disputed` slash auto-fails (and becomes
-    ///      executable) once `disputedAt + disputeResolutionDeadline` has elapsed,
-    ///      which prevents permanent delegator lockup if SLASH_ADMIN never acts.
-    function isExecutable(
-        SlashProposal storage proposal,
-        SlashConfig storage config
-    ) internal view returns (bool) {
+    ///      timestamp-manipulation buffer. A `Disputed` slash auto-fails once
+    ///      `proposal.disputeDeadline` (snapshotted from config at dispute time) has
+    ///      elapsed. The deadline is read from the proposal — not live config — so
+    ///      admin cannot retroactively shorten the operator's review window.
+    function isExecutable(SlashProposal storage proposal) internal view returns (bool) {
         if (proposal.status == SlashStatus.Pending) {
             return block.timestamp >= proposal.executeAfter + TIMESTAMP_BUFFER;
         }
         if (proposal.status == SlashStatus.Disputed) {
-            return block.timestamp >= uint256(proposal.disputedAt) + config.disputeResolutionDeadline;
+            return block.timestamp >= uint256(proposal.disputeDeadline);
         }
         return false;
     }
@@ -325,7 +340,6 @@ library SlashingLib {
     /// @notice Mark a slash as executed.
     function markExecuted(
         mapping(uint64 => SlashProposal) storage proposals,
-        SlashConfig storage config,
         uint64 slashId,
         uint256 actualSlashed
     )
@@ -338,7 +352,7 @@ library SlashingLib {
             revert Errors.SlashNotFound(slashId);
         }
 
-        if (!isExecutable(proposal, config)) {
+        if (!isExecutable(proposal)) {
             revert Errors.SlashNotExecutable(slashId);
         }
 

--- a/src/libraries/SlashingLib.sol
+++ b/src/libraries/SlashingLib.sol
@@ -54,6 +54,15 @@ library SlashingLib {
         uint64 executeAfter; // When slash can be executed
         SlashStatus status; // Current status
         string disputeReason; // Reason if disputed
+        // Address that posted the dispute bond. address(0) when undisputed.
+        address disputer;
+        // Native-asset bond locked when the slash was disputed. Refunded on cancel,
+        // forfeit to treasury when the dispute auto-fails or the slash executes.
+        uint256 disputeBond;
+        // Timestamp the dispute was raised (0 when undisputed). After
+        // `disputedAt + config.disputeResolutionDeadline`, `isExecutable` returns
+        // true even though `status == Disputed`, which auto-resolves stale disputes.
+        uint64 disputedAt;
     }
 
     /// @notice Slashing configuration
@@ -61,6 +70,17 @@ library SlashingLib {
         uint64 disputeWindow; // Time before slash can be executed
         bool instantSlashEnabled; // Allow immediate slashing (for emergencies)
         uint16 maxSlashBps; // Maximum slash as % of stake (default 10000 = 100%)
+        // Once a slash is disputed, SLASH_ADMIN has this long to resolve it (cancel
+        // or convert back to pending). After the deadline, the dispute auto-fails and
+        // the slash becomes executable. Prevents permanent delegator lockup.
+        uint64 disputeResolutionDeadline;
+        // Native-asset bond required to dispute a slash. Forfeit to treasury if the
+        // dispute is rejected (slash executes); refunded if the slash is cancelled.
+        // Defeats free-DoS where an operator self-disputes to lock their own delegators.
+        uint256 disputeBond;
+        // Maximum number of pending slashes a single operator can carry simultaneously.
+        // Defends against spam-griefing the pending-slash counter.
+        uint16 maxPendingSlashesPerOperator;
     }
 
     /// @notice Slashing state storage
@@ -104,7 +124,10 @@ library SlashingLib {
         state.config = SlashConfig({
             disputeWindow: DEFAULT_DISPUTE_WINDOW,
             instantSlashEnabled: false,
-            maxSlashBps: BPS_DENOMINATOR // 100%
+            maxSlashBps: BPS_DENOMINATOR, // 100%
+            disputeResolutionDeadline: 14 days,
+            disputeBond: 0, // Defaults to disabled; admin enables via setSlashConfig.
+            maxPendingSlashesPerOperator: 32
         });
     }
 
@@ -117,7 +140,10 @@ library SlashingLib {
         SlashState storage state,
         uint64 disputeWindow,
         bool instantSlashEnabled,
-        uint16 maxSlashBps
+        uint16 maxSlashBps,
+        uint64 disputeResolutionDeadline,
+        uint256 disputeBond,
+        uint16 maxPendingSlashesPerOperator
     )
         internal
     {
@@ -127,9 +153,18 @@ library SlashingLib {
         if (maxSlashBps == 0 || maxSlashBps > BPS_DENOMINATOR) {
             revert Errors.InvalidSlashConfig();
         }
+        if (disputeResolutionDeadline < 1 days || disputeResolutionDeadline > 60 days) {
+            revert Errors.InvalidSlashConfig();
+        }
+        if (maxPendingSlashesPerOperator == 0) revert Errors.InvalidSlashConfig();
 
         state.config = SlashConfig({
-            disputeWindow: disputeWindow, instantSlashEnabled: instantSlashEnabled, maxSlashBps: maxSlashBps
+            disputeWindow: disputeWindow,
+            instantSlashEnabled: instantSlashEnabled,
+            maxSlashBps: maxSlashBps,
+            disputeResolutionDeadline: disputeResolutionDeadline,
+            disputeBond: disputeBond,
+            maxPendingSlashesPerOperator: maxPendingSlashesPerOperator
         });
 
         emit SlashConfigUpdated(disputeWindow, instantSlashEnabled, maxSlashBps);
@@ -214,7 +249,10 @@ library SlashingLib {
             proposedAt: uint64(block.timestamp),
             executeAfter: executeAfter,
             status: SlashStatus.Pending,
-            disputeReason: ""
+            disputeReason: "",
+            disputer: address(0),
+            disputeBond: 0,
+            disputedAt: 0
         });
 
         emit SlashProposed(slashId, serviceId, operator, proposer, slashBps, effectiveSlashBps, evidence, executeAfter);
@@ -224,16 +262,18 @@ library SlashingLib {
     // DISPUTE
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Dispute a pending slash proposal
+    /// @notice Dispute a pending slash proposal.
     /// @param proposals Storage mapping for proposals
     /// @param slashId The slash ID to dispute
     /// @param disputer Who is disputing
     /// @param reason Reason for dispute
+    /// @param bondPosted Native-asset bond that the caller posted with the dispute call.
     function disputeSlash(
         mapping(uint64 => SlashProposal) storage proposals,
         uint64 slashId,
         address disputer,
-        string memory reason
+        string memory reason,
+        uint256 bondPosted
     )
         internal
     {
@@ -253,6 +293,9 @@ library SlashingLib {
 
         proposal.status = SlashStatus.Disputed;
         proposal.disputeReason = reason;
+        proposal.disputer = disputer;
+        proposal.disputeBond = bondPosted;
+        proposal.disputedAt = uint64(block.timestamp);
 
         emit SlashDisputed(slashId, disputer, reason);
     }
@@ -261,29 +304,28 @@ library SlashingLib {
     // EXECUTION
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Check if a slash is ready to execute
-    /// @dev Only Pending slashes can be executed - Disputed slashes are blocked.
-    ///      Uses TIMESTAMP_BUFFER to protect against block timestamp manipulation.
-    /// @param proposal The slash proposal
-    /// @return True if ready
-    function isExecutable(SlashProposal storage proposal) internal view returns (bool) {
-        // Disputed slashes cannot be executed - they require admin resolution
-        if (proposal.status == SlashStatus.Disputed) {
-            return false;
+    /// @notice Check if a slash is ready to execute.
+    /// @dev A `Pending` slash becomes executable after the dispute window plus a
+    ///      timestamp-manipulation buffer. A `Disputed` slash auto-fails (and becomes
+    ///      executable) once `disputedAt + disputeResolutionDeadline` has elapsed,
+    ///      which prevents permanent delegator lockup if SLASH_ADMIN never acts.
+    function isExecutable(
+        SlashProposal storage proposal,
+        SlashConfig storage config
+    ) internal view returns (bool) {
+        if (proposal.status == SlashStatus.Pending) {
+            return block.timestamp >= proposal.executeAfter + TIMESTAMP_BUFFER;
         }
-        // M-6 FIX: Add buffer to protect against timestamp manipulation
-        // Miners can adjust block.timestamp within ~15 seconds, so we require
-        // the timestamp to exceed executeAfter + buffer
-        return proposal.status == SlashStatus.Pending && block.timestamp >= proposal.executeAfter + TIMESTAMP_BUFFER;
+        if (proposal.status == SlashStatus.Disputed) {
+            return block.timestamp >= uint256(proposal.disputedAt) + config.disputeResolutionDeadline;
+        }
+        return false;
     }
 
-    /// @notice Mark a slash as executed
-    /// @param proposals Storage mapping for proposals
-    /// @param slashId The slash ID
-    /// @param actualSlashed Actual amount that was slashed
-    /// @return proposal The executed proposal
+    /// @notice Mark a slash as executed.
     function markExecuted(
         mapping(uint64 => SlashProposal) storage proposals,
+        SlashConfig storage config,
         uint64 slashId,
         uint256 actualSlashed
     )
@@ -296,7 +338,7 @@ library SlashingLib {
             revert Errors.SlashNotFound(slashId);
         }
 
-        if (!isExecutable(proposal)) {
+        if (!isExecutable(proposal, config)) {
             revert Errors.SlashNotExecutable(slashId);
         }
 

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -378,7 +378,7 @@ library Types {
     ///      Slot 1: createdAt (8) + ttl (8) + operatorCount (4) + approvalCount (4) = 24 bytes
     ///      Slot 2: paymentToken (20) + membership (1) + minOperators (4) = 25 bytes
     ///      Slot 3: paymentAmount (32)
-    ///      Slot 4: maxOperators (4) + rejected (1) + confidentiality (1) = 6 bytes
+    ///      Slot 4: maxOperators (4) + rejected (1) + activated (1) + confidentiality (1) = 7 bytes
     struct ServiceRequest {
         uint64 blueprintId;
         address requester;
@@ -392,6 +392,11 @@ library Types {
         uint32 minOperators; // For dynamic: minimum required
         uint32 maxOperators; // For dynamic: maximum allowed (0 = unlimited)
         bool rejected;
+        // True once `_activateService` has fully spawned the service. Stops
+        // `expireServiceRequest` from refunding escrow that has already been
+        // transferred to the service, and stops late approve/reject paths
+        // from mutating a request whose lifecycle is already complete.
+        bool activated;
         ConfidentialityPolicy confidentiality; // Requested execution confidentiality
     }
 

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -374,7 +374,7 @@ library Types {
 
     /// @notice Service request - pending service awaiting approval
     /// @dev Struct layout for storage optimization:
-    ///      Slot 0: blueprintId (8) + requester (20) = 28 bytes (could be tighter but crossing slot)
+    ///      Slot 0: blueprintId (8) + requester (20) = 28 bytes
     ///      Slot 1: createdAt (8) + ttl (8) + operatorCount (4) + approvalCount (4) = 24 bytes
     ///      Slot 2: paymentToken (20) + membership (1) + minOperators (4) = 25 bytes
     ///      Slot 3: paymentAmount (32)
@@ -391,7 +391,7 @@ library Types {
         MembershipModel membership; // Fixed or Dynamic
         uint32 minOperators; // For dynamic: minimum required
         uint32 maxOperators; // For dynamic: maximum allowed (0 = unlimited)
-        bool rejected;
+        bool rejected; // Set true on operator rejection or permissionless expiry
         // True once `_activateService` has fully spawned the service. Stops
         // `expireServiceRequest` from refunding escrow that has already been
         // transferred to the service, and stops late approve/reject paths

--- a/src/staking/OperatorManager.sol
+++ b/src/staking/OperatorManager.sol
@@ -240,10 +240,19 @@ abstract contract OperatorManager is DelegationStorage {
         meta.status = Types.OperatorStatus.Inactive;
         _operators.remove(msg.sender);
 
+        // Clear ancillary per-operator state so a fully-exited operator does not leave
+        // stale entries that downstream iteration (rewards, exposure) would still pick up.
+        delete _operatorBondLessRequests[msg.sender];
+        EnumerableSet.UintSet storage operatorBlueprintSet = _operatorBlueprints[msg.sender];
+        uint256 bpCount = operatorBlueprintSet.length();
+        // Iterate in reverse and pop so the EnumerableSet's internal indices stay valid.
+        for (uint256 i = bpCount; i > 0; i--) {
+            operatorBlueprintSet.remove(operatorBlueprintSet.at(i - 1));
+        }
+
         // Cache storage variable to save gas
         address bondToken = _operatorBondToken;
         if (bondToken == address(0)) {
-            // Return stake
             (bool success,) = msg.sender.call{ value: stake }("");
             if (!success) revert DelegationErrors.TransferFailed();
         } else {

--- a/src/staking/OperatorManager.sol
+++ b/src/staking/OperatorManager.sol
@@ -188,17 +188,26 @@ abstract contract OperatorManager is DelegationStorage {
     // OPERATOR LEAVING
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Schedule leaving as operator
-    /// @dev M-10 FIX: Blocks exit if operator has active service commitments
+    /// @notice Schedule leaving as operator.
+    /// @dev Blocks exit if the operator still has active service commitments OR any
+    ///      pending slashes. Allows transitioning from `Inactive` (e.g. an operator that
+    ///      was forced inactive by being slashed below minimum stake) to `Leaving` so
+    ///      their remaining stake is not stranded.
     function _startLeaving() internal {
         Types.OperatorMetadata storage meta = _operatorMetadata[msg.sender];
-        if (meta.status != Types.OperatorStatus.Active) {
+        if (
+            meta.status != Types.OperatorStatus.Active
+                && meta.status != Types.OperatorStatus.Inactive
+        ) {
             revert DelegationErrors.OperatorNotActive(msg.sender);
+        }
+
+        if (_operatorPendingSlashCount[msg.sender] > 0) {
+            revert DelegationErrors.PendingSlashExists(msg.sender, _operatorPendingSlashCount[msg.sender]);
         }
 
         // M-10 FIX: Check for active services via Tangle core
         if (_tangleCore != address(0)) {
-            // Query Tangle for operator's total active service count
             (bool success, bytes memory data) =
                 _tangleCore.staticcall(abi.encodeWithSignature("getOperatorTotalActiveServices(address)", msg.sender));
             if (success && data.length >= 32) {

--- a/src/staking/OperatorStatusRegistry.sol
+++ b/src/staking/OperatorStatusRegistry.sol
@@ -51,12 +51,15 @@ interface IOperatorStatusRegistry {
         bytes32 lastMetricsHash;
     }
 
-    /// @notice Submit a heartbeat to prove operator is online
+    /// @notice Submit a heartbeat to prove operator is online (EIP-712 signed).
+    /// @dev `timestamp` must be within `HEARTBEAT_MAX_AGE` of `block.timestamp` to prevent
+    ///      replay of stale "healthy" heartbeats.
     function submitHeartbeat(
         uint64 serviceId,
         uint64 blueprintId,
         uint8 statusCode,
         bytes calldata metrics,
+        uint64 timestamp,
         bytes calldata signature
     )
         external;
@@ -191,12 +194,11 @@ contract OperatorStatusRegistry is IOperatorStatusRegistry, Ownable2Step {
     /// @notice Domain separator for EIP-712 signatures (kept for backwards compatibility)
     bytes32 public immutable DOMAIN_SEPARATOR;
 
-    /// @notice Heartbeat message typehash (for reference - actual signing uses raw keccak256)
-    /// @dev Signature: keccak256(abi.encodePacked(serviceId, blueprintId, abiEncodedStatus)) with Ethereum prefix
-    ///      HeartbeatStatus = (uint64 blockNumber, uint64 timestamp, uint64 serviceId, uint64 blueprintId, uint32
-    /// statusCode, string statusMessage)
+    /// @notice EIP-712 typehash for `Heartbeat`. Binds operator + service + blueprint +
+    ///         status + metrics + timestamp; the domain separator binds it to chainId +
+    ///         verifying contract. Closes cross-fork / cross-service / replay surface.
     bytes32 public constant HEARTBEAT_TYPEHASH = keccak256(
-        "HeartbeatStatus(uint64 blockNumber,uint64 timestamp,uint64 serviceId,uint64 blueprintId,uint32 statusCode,string statusMessage)"
+        "Heartbeat(address operator,uint64 serviceId,uint64 blueprintId,uint8 statusCode,bytes32 metricsHash,uint64 timestamp)"
     );
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -295,37 +297,50 @@ contract OperatorStatusRegistry is IOperatorStatusRegistry, Ownable2Step {
     // HEARTBEAT SUBMISSION
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Submit a heartbeat to prove operator is online
-    /// @dev Signature: ECDSA over keccak256(abi.encodePacked(serviceId, blueprintId, statusCode, metrics))
-    ///      NOTE: Uses native EVM big-endian encoding. Blueprint-SDK must use to_be_bytes() not to_le_bytes()
-    /// @param serviceId The service ID
-    /// @param blueprintId The blueprint ID
-    /// @param statusCode Operator-reported status code (0 = healthy)
-    /// @param metrics Encoded metrics data (can be empty)
-    /// @param signature ECDSA signature of the heartbeat message
+    /// @notice Maximum staleness for a heartbeat signature.
+    /// @dev Beyond this, replays of an old "healthy" heartbeat would mask current liveness.
+    uint64 public constant HEARTBEAT_MAX_AGE = 5 minutes;
+
+    error HeartbeatStale(uint64 signed, uint64 now_);
+    error HeartbeatFromFuture(uint64 signed, uint64 now_);
+
+    /// @notice Submit a heartbeat to prove operator is online (EIP-712 signed).
+    /// @dev Signature is over the EIP-712 typed struct `Heartbeat` defined above. The
+    ///      `timestamp` field bounds the freshness so replays of stale "healthy"
+    ///      heartbeats cannot mask an offline operator. The domain separator includes
+    ///      `chainId` and `address(this)` so signatures cannot replay across forks or
+    ///      deployments.
     function submitHeartbeat(
         uint64 serviceId,
         uint64 blueprintId,
         uint8 statusCode,
         bytes calldata metrics,
+        uint64 timestamp,
         bytes calldata signature
     )
         external
         override
         onlyRegisteredOperator(serviceId)
     {
-        // Verify signature using native EVM encoding (big-endian):
-        // message = abi.encodePacked(serviceId, blueprintId, statusCode, metrics)
-        // hash = keccak256(message)
-        // signature = ECDSA.sign(ethSignedMessageHash(hash))
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 messageHash = keccak256(abi.encodePacked(serviceId, blueprintId, statusCode, metrics));
+        if (timestamp > block.timestamp) revert HeartbeatFromFuture(timestamp, uint64(block.timestamp));
+        if (block.timestamp - timestamp > HEARTBEAT_MAX_AGE) {
+            revert HeartbeatStale(timestamp, uint64(block.timestamp));
+        }
 
-        // Recover signer using Ethereum signed message format
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                HEARTBEAT_TYPEHASH,
+                msg.sender,
+                serviceId,
+                blueprintId,
+                statusCode,
+                keccak256(metrics),
+                timestamp
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash));
 
-        address signer = ethSignedHash.recover(signature);
+        address signer = digest.recover(signature);
         require(signer == msg.sender, "Invalid signature");
 
         _processHeartbeat(serviceId, blueprintId, msg.sender, statusCode, metrics);

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -134,25 +134,22 @@ contract GovernanceTest is Test {
     }
 
     function test_TokenHistoricalVotes() public {
-        // Store checkpoint before transfer (we're at block 2 after setUp's vm.roll)
-        uint256 checkpointBlock = block.number - 1;
+        // Token uses ERC-6372 timestamp clock — historical lookups take a timestamp,
+        // not a block number. (Coincidentally `block.number == block.timestamp == 1`
+        // in Foundry's default, so prior block-number reads passed by accident.)
+        uint256 checkpointTimestamp = block.timestamp - 1;
 
-        // Transfer some tokens
         vm.prank(voter1);
         token.transfer(voter2, 500_000 * 1e18);
 
-        // Mine blocks to create checkpoints and allow historical lookup
         vm.warp(block.timestamp + 2);
-        vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        // Current votes should reflect transfer
         assertEq(token.getVotes(voter1), 500_000 * 1e18);
         assertEq(token.getVotes(voter2), 2_500_000 * 1e18);
 
-        // Historical votes at checkpoint should be unchanged
-        assertEq(token.getPastVotes(voter1, checkpointBlock), 1_000_000 * 1e18);
-        assertEq(token.getPastVotes(voter2, checkpointBlock), 2_000_000 * 1e18);
+        assertEq(token.getPastVotes(voter1, checkpointTimestamp), 1_000_000 * 1e18);
+        assertEq(token.getPastVotes(voter2, checkpointTimestamp), 2_000_000 * 1e18);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -166,9 +163,9 @@ contract GovernanceTest is Test {
     }
 
     function test_GovernorQuorum() public view {
-        // Quorum should be 4% of total supply
+        // Quorum is 4% of total supply, queried at a past timestamp (ERC-6372 clock).
         uint256 expectedQuorum = (INITIAL_SUPPLY * QUORUM_PERCENT) / 100;
-        assertEq(governor.quorum(block.number - 1), expectedQuorum);
+        assertEq(governor.quorum(block.timestamp - 1), expectedQuorum);
     }
 
     function test_CreateProposal() public {

--- a/test/Governance.t.sol
+++ b/test/Governance.t.sol
@@ -30,8 +30,9 @@ contract GovernanceTest is Test {
 
     uint256 constant INITIAL_SUPPLY = 50_000_000 * 1e18;
     uint256 constant TIMELOCK_DELAY = 1 days;
-    uint48 constant VOTING_DELAY = 100;
-    uint32 constant VOTING_PERIOD = 1000;
+    // Token uses ERC-6372 timestamp clock; voting delay/period are in SECONDS.
+    uint48 constant VOTING_DELAY = 100; // 100 seconds (smaller than 1 day to keep tests fast)
+    uint32 constant VOTING_PERIOD = 1000; // 1000 seconds
     uint256 constant PROPOSAL_THRESHOLD = 1000 * 1e18;
     uint256 constant QUORUM_PERCENT = 4;
 
@@ -75,7 +76,12 @@ contract GovernanceTest is Test {
         vm.prank(proposer);
         token.delegate(proposer);
 
-        // Mine a block to activate voting power
+        // Advance one second so checkpoints from delegate() are strictly in the past.
+        // OZ Governor reads votes at `clock() - 1`, which would otherwise look up the
+        // checkpoint at the same timestamp it was written and revert ERC5805FutureLookup.
+        vm.warp(block.timestamp + 1);
+        vm.warp(block.timestamp + 1);
+        vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
     }
 
@@ -118,6 +124,8 @@ contract GovernanceTest is Test {
         vm.prank(voter1);
         token.delegate(voter2);
 
+        vm.warp(block.timestamp + 1);
+        vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
         assertEq(token.delegates(voter1), voter2);
@@ -134,7 +142,9 @@ contract GovernanceTest is Test {
         token.transfer(voter2, 500_000 * 1e18);
 
         // Mine blocks to create checkpoints and allow historical lookup
-        vm.roll(block.number + 2);
+        vm.warp(block.timestamp + 2);
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
 
         // Current votes should reflect transfer
         assertEq(token.getVotes(voter1), 500_000 * 1e18);
@@ -186,6 +196,8 @@ contract GovernanceTest is Test {
 
         vm.prank(lowVoter);
         token.delegate(lowVoter);
+        vm.warp(block.timestamp + 1);
+        vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
         address[] memory targets = new address[](1);
@@ -211,7 +223,8 @@ contract GovernanceTest is Test {
         uint256 proposalId = governor.propose(targets, values, calldatas, "Mint tokens");
 
         // Move past voting delay
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Active));
 
@@ -239,7 +252,8 @@ contract GovernanceTest is Test {
         vm.prank(proposer);
         uint256 proposalId = governor.propose(targets, values, calldatas, "Test proposal");
 
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         vm.prank(voter1);
         governor.castVoteWithReason(proposalId, 1, "I support this because...");
@@ -260,7 +274,8 @@ contract GovernanceTest is Test {
         uint256 proposalId = governor.propose(targets, values, calldatas, "Grant minter to timelock");
 
         // Move to active
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         // Vote in favor (need quorum: 4% of 50M = 2M tokens)
         vm.prank(voter2); // 2M votes
@@ -270,7 +285,8 @@ contract GovernanceTest is Test {
         governor.castVote(proposalId, 1);
 
         // Move past voting period
-        vm.roll(block.number + VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + VOTING_PERIOD + 1);
+        vm.roll(block.number + 1);
 
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Succeeded));
     }
@@ -284,13 +300,15 @@ contract GovernanceTest is Test {
         vm.prank(proposer);
         uint256 proposalId = governor.propose(targets, values, calldatas, "Low turnout proposal");
 
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         // Only voter1 votes (1M, below 2M quorum)
         vm.prank(voter1);
         governor.castVote(proposalId, 1);
 
-        vm.roll(block.number + VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + VOTING_PERIOD + 1);
+        vm.roll(block.number + 1);
 
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Defeated));
     }
@@ -304,7 +322,8 @@ contract GovernanceTest is Test {
         vm.prank(proposer);
         uint256 proposalId = governor.propose(targets, values, calldatas, "Unpopular proposal");
 
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         // voter3 (3M) votes against, voter2 (2M) votes for
         vm.prank(voter2);
@@ -313,7 +332,8 @@ contract GovernanceTest is Test {
         vm.prank(voter3);
         governor.castVote(proposalId, 0); // Against
 
-        vm.roll(block.number + VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + VOTING_PERIOD + 1);
+        vm.roll(block.number + 1);
 
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Defeated));
     }
@@ -355,7 +375,8 @@ contract GovernanceTest is Test {
         uint256 proposalId = governor.propose(targets, values, calldatas, description);
 
         // 3. Move to active and vote
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
 
         vm.prank(voter2);
         governor.castVote(proposalId, 1);
@@ -363,7 +384,8 @@ contract GovernanceTest is Test {
         governor.castVote(proposalId, 1);
 
         // 4. Move past voting period
-        vm.roll(block.number + VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + VOTING_PERIOD + 1);
+        vm.roll(block.number + 1);
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Succeeded));
 
         // 5. Queue the proposal
@@ -411,13 +433,15 @@ contract GovernanceTest is Test {
         );
         governor.queue(targets, values, calldatas, descriptionHash);
 
-        vm.roll(block.number + VOTING_DELAY + 1);
+        vm.warp(block.timestamp + VOTING_DELAY + 1);
+        vm.roll(block.number + 1);
         vm.prank(voter2);
         governor.castVote(proposalId, 1);
         vm.prank(voter3);
         governor.castVote(proposalId, 1);
 
-        vm.roll(block.number + VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + VOTING_PERIOD + 1);
+        vm.roll(block.number + 1);
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernor.ProposalState.Succeeded));
         assertTrue(governor.proposalNeedsQueuing(proposalId));
 
@@ -498,16 +522,18 @@ contract GovernanceTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_DeployerDefaultParams() public view {
+        // Token uses ERC-6372 timestamp clock; voting delay/period are in SECONDS,
+        // chain-agnostic between Ethereum / Base / Arbitrum / etc.
         GovernanceDeployer.DeployParams memory mainnetParams = deployer.getDefaultMainnetParams(admin);
         assertEq(mainnetParams.timelockDelay, 2 days);
-        assertEq(mainnetParams.votingDelay, 7200);
-        assertEq(mainnetParams.votingPeriod, 50_400);
+        assertEq(mainnetParams.votingDelay, 1 days);
+        assertEq(mainnetParams.votingPeriod, 7 days);
         assertEq(mainnetParams.quorumPercent, 4);
 
         GovernanceDeployer.DeployParams memory testnetParams = deployer.getDefaultTestnetParams(admin);
         assertEq(testnetParams.timelockDelay, 1 days);
-        assertEq(testnetParams.votingDelay, 100);
-        assertEq(testnetParams.votingPeriod, 1000);
+        assertEq(testnetParams.votingDelay, 20 minutes);
+        assertEq(testnetParams.votingPeriod, 3 hours);
         assertEq(testnetParams.quorumPercent, 1);
     }
 
@@ -613,6 +639,8 @@ contract GovernanceUpgradeTest is Test {
 
         vm.prank(voter);
         token.delegate(voter);
+        vm.warp(block.timestamp + 1);
+        vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
     }
 
@@ -633,11 +661,15 @@ contract GovernanceUpgradeTest is Test {
         uint256 proposalId = governor.propose(targets, values, calldatas, description);
 
         // Vote and pass
-        vm.roll(block.number + 11);
+        vm.warp(block.timestamp + 11);
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
         vm.prank(voter);
         governor.castVote(proposalId, 1);
 
-        vm.roll(block.number + 101);
+        vm.warp(block.timestamp + 101);
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
 
         // Queue and execute
         bytes32 descHash = keccak256(bytes(description));
@@ -671,11 +703,15 @@ contract GovernanceUpgradeTest is Test {
         vm.prank(voter);
         uint256 proposalId = governor.propose(targets, values, calldatas, description);
 
-        vm.roll(block.number + 11);
+        vm.warp(block.timestamp + 11);
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
         vm.prank(voter);
         governor.castVote(proposalId, 1);
 
-        vm.roll(block.number + 101);
+        vm.warp(block.timestamp + 101);
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
 
         bytes32 descHash = keccak256(bytes(description));
         governor.queue(targets, values, calldatas, descHash);

--- a/test/blueprints/BlueprintServiceManagerBase.t.sol
+++ b/test/blueprints/BlueprintServiceManagerBase.t.sol
@@ -42,6 +42,7 @@ contract BlueprintServiceManagerBaseTest is Test {
 
     function setUp() public {
         bsm = new BlueprintServiceManagerBaseHarness();
+        vm.prank(tangle);
         bsm.onBlueprintCreated(42, blueprintOwner, tangle);
     }
 
@@ -52,6 +53,7 @@ contract BlueprintServiceManagerBaseTest is Test {
     }
 
     function test_OnBlueprintCreated_CannotBeCalledTwice() public {
+        vm.prank(tangle);
         vm.expectRevert(BlueprintServiceManagerBase.AlreadyInitialized.selector);
         bsm.onBlueprintCreated(1, blueprintOwner, tangle);
     }

--- a/test/fuzz/InvariantFuzz.t.sol
+++ b/test/fuzz/InvariantFuzz.t.sol
@@ -393,10 +393,10 @@ contract InvariantFuzzTest is Test, BlueprintDefinitionHelper {
         if (window < 1 hours || window > 30 days) {
             vm.prank(admin);
             vm.expectRevert(Errors.InvalidSlashConfig.selector);
-            tangle.setSlashConfig(window, false, 10_000);
+            tangle.setSlashConfig(window, false, 10_000, 14 days, 0, 32);
         } else {
             vm.prank(admin);
-            tangle.setSlashConfig(window, false, 10_000);
+            tangle.setSlashConfig(window, false, 10_000, 14 days, 0, 32);
 
             // Verify by creating slash
             vm.prank(user1);

--- a/test/fuzz/SlashingFuzz.t.sol
+++ b/test/fuzz/SlashingFuzz.t.sol
@@ -276,7 +276,7 @@ contract SlashingFuzzTest is BaseTest {
         disputeWindow = uint64(bound(uint256(disputeWindow), 1 hours, 30 days));
 
         vm.prank(admin);
-        tangle.setSlashConfig(disputeWindow, false, 10_000);
+        tangle.setSlashConfig(disputeWindow, false, 10_000, 14 days, 0, 32);
 
         uint256 stakeBefore = staking.getOperatorSelfStake(operator1);
         uint256 proposalTime = block.timestamp;
@@ -320,7 +320,7 @@ contract SlashingFuzzTest is BaseTest {
         proposedBps = uint16(bound(uint256(proposedBps), 1, 10_000));
 
         vm.prank(admin);
-        tangle.setSlashConfig(7 days, false, 3000);
+        tangle.setSlashConfig(7 days, false, 3000, 14 days, 0, 32);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, proposedBps, keccak256("cap"));
@@ -342,11 +342,11 @@ contract SlashingFuzzTest is BaseTest {
         if (invalidWindow || invalidMax) {
             vm.prank(admin);
             vm.expectRevert(Errors.InvalidSlashConfig.selector);
-            tangle.setSlashConfig(disputeWindow, false, maxSlashBps);
+            tangle.setSlashConfig(disputeWindow, false, maxSlashBps, 14 days, 0, 32);
         } else {
             // Valid config should succeed
             vm.prank(admin);
-            tangle.setSlashConfig(disputeWindow, false, maxSlashBps);
+            tangle.setSlashConfig(disputeWindow, false, maxSlashBps, 14 days, 0, 32);
         }
     }
 
@@ -356,7 +356,7 @@ contract SlashingFuzzTest is BaseTest {
         maxSlashBps = uint16(bound(uint256(maxSlashBps), 1, 10_000));
 
         vm.prank(admin);
-        tangle.setSlashConfig(disputeWindow, false, maxSlashBps);
+        tangle.setSlashConfig(disputeWindow, false, maxSlashBps, 14 days, 0, 32);
 
         // Verify config applied by creating slash with new window
         uint256 proposalTime = block.timestamp;

--- a/test/staking/OperatorStatusRegistry.t.sol
+++ b/test/staking/OperatorStatusRegistry.t.sol
@@ -70,9 +70,27 @@ contract OperatorStatusRegistryTest is Test {
     }
 
     function _signHeartbeat(uint8 statusCode, bytes memory metricsData) internal view returns (bytes memory) {
-        bytes32 messageHash = keccak256(abi.encodePacked(SERVICE_ID, BLUEPRINT_ID, statusCode, metricsData));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorKey, ethSignedHash);
+        return _signHeartbeatAt(statusCode, metricsData, uint64(block.timestamp));
+    }
+
+    function _signHeartbeatAt(uint8 statusCode, bytes memory metricsData, uint64 timestamp)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                registry.HEARTBEAT_TYPEHASH(),
+                operatorAddr,
+                SERVICE_ID,
+                BLUEPRINT_ID,
+                statusCode,
+                keccak256(metricsData),
+                timestamp
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", registry.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(operatorKey, digest);
         return abi.encodePacked(r, s, v);
     }
 
@@ -81,7 +99,7 @@ contract OperatorStatusRegistryTest is Test {
         bytes memory signature = _signHeartbeat(0, metricsData);
 
         vm.prank(operatorAddr);
-        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, metricsData, signature);
+        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, metricsData, uint64(block.timestamp), signature);
 
         IOperatorStatusRegistry.StatusCode status = registry.getOperatorStatus(SERVICE_ID, operatorAddr);
         assertEq(uint8(status), uint8(IOperatorStatusRegistry.StatusCode.Healthy));
@@ -93,7 +111,7 @@ contract OperatorStatusRegistryTest is Test {
         bytes memory signature = abi.encodePacked(bytes32(uint256(1)), bytes32(uint256(2)), uint8(27));
         vm.prank(operatorAddr);
         vm.expectRevert("Invalid signature");
-        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, "", signature);
+        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, "", uint64(block.timestamp), signature);
     }
 
     function test_customMetricsStoredWhenEnabled() public {
@@ -167,7 +185,7 @@ contract OperatorStatusRegistryTest is Test {
 
         bytes memory signature = _signHeartbeat(0, "");
         vm.prank(operatorAddr);
-        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, "", signature);
+        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 0, "", uint64(block.timestamp), signature);
 
         assertEq(metrics.heartbeatCount(), 1);
         assertEq(metrics.lastOperator(), operatorAddr);
@@ -703,12 +721,12 @@ contract OperatorStatusRegistryTest is Test {
         bytes memory signature = _signHeartbeat(0, "");
         vm.prank(operatorAddr);
         vm.expectRevert("Invalid signature");
-        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 1, "", signature);
+        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 1, "", uint64(block.timestamp), signature);
 
         // Sign with correct statusCode=1, submit with statusCode=1 => should pass
         bytes memory correctSig = _signHeartbeat(1, "");
         vm.prank(operatorAddr);
-        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 1, "", correctSig);
+        registry.submitHeartbeat(SERVICE_ID, BLUEPRINT_ID, 1, "", uint64(block.timestamp), correctSig);
 
         assertEq(
             uint8(registry.getOperatorStatus(SERVICE_ID, operatorAddr)),

--- a/test/tangle/HeartbeatConfig.t.sol
+++ b/test/tangle/HeartbeatConfig.t.sol
@@ -13,7 +13,7 @@ contract MockStatusRegistry is IOperatorStatusRegistry {
     uint64 public configuredInterval;
     uint8 public configuredMaxMissed;
 
-    function submitHeartbeat(uint64, uint64, uint8, bytes calldata, bytes calldata) external override { }
+    function submitHeartbeat(uint64, uint64, uint8, bytes calldata, uint64, bytes calldata) external override { }
 
     function isOnline(uint64, address) external pure override returns (bool) {
         return false;

--- a/test/tangle/ServiceLifecycleEdgeCases.t.sol
+++ b/test/tangle/ServiceLifecycleEdgeCases.t.sol
@@ -713,8 +713,14 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
     }
 
     function test_ApproveService_AlreadyApproved_Reverts() public {
-        address[] memory ops = new address[](1);
+        // 2-operator service so the first approve does NOT activate the service.
+        // After activation the request is marked `activated`, and any further approve
+        // call hits `ServiceRequestAlreadyProcessed` (the activation guard) before the
+        // per-caller `AlreadyApproved` check. We need a non-activated state to exercise
+        // the duplicate-approve revert.
+        address[] memory ops = new address[](2);
         ops[0] = operator1;
+        ops[1] = operator2;
         address[] memory callers = new address[](0);
 
         vm.prank(user1);
@@ -723,7 +729,7 @@ contract ServiceLifecycleEdgeCasesTest is BaseTest {
 
         _approveService(operator1, requestId);
 
-        // Approve again
+        // operator1 approves again (request is still pending operator2's approval).
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.AlreadyApproved.selector, requestId, operator1));
         tangle.approveService(_approve(requestId));

--- a/test/tangle/Slashing.t.sol
+++ b/test/tangle/Slashing.t.sol
@@ -441,7 +441,7 @@ contract SlashingTest is BaseTest {
 
     function test_SetSlashConfig_UpdatesDisputeWindow() public {
         vm.prank(admin);
-        tangle.setSlashConfig(14 days, false, 10_000);
+        tangle.setSlashConfig(14 days, false, 10_000, 14 days, 0, 32);
 
         // New proposal should use updated window
         vm.prank(user1);
@@ -455,22 +455,22 @@ contract SlashingTest is BaseTest {
         // Too short
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(30 minutes, false, 10_000);
+        tangle.setSlashConfig(30 minutes, false, 10_000, 14 days, 0, 32);
 
         // Too long
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(60 days, false, 10_000);
+        tangle.setSlashConfig(60 days, false, 10_000, 14 days, 0, 32);
     }
 
     function test_SetSlashConfig_RevertInvalidMaxSlash() public {
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(7 days, false, 0);
+        tangle.setSlashConfig(7 days, false, 0, 14 days, 0, 32);
 
         vm.prank(admin);
         vm.expectRevert(Errors.InvalidSlashConfig.selector);
-        tangle.setSlashConfig(7 days, false, 15_000); // > 100%
+        tangle.setSlashConfig(7 days, false, 15_000, 14 days, 0, 32); // > 100%
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/tangle/SlashingEdgeCases.t.sol
+++ b/test/tangle/SlashingEdgeCases.t.sol
@@ -475,4 +475,104 @@ contract SlashingEdgeCasesTest is BaseTest {
         uint256 expectedSlash = (stakeBefore * 1) / 10_000;
         assertEq(stakeAfter, stakeBefore - expectedSlash, "Should slash 1 bps of stake");
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // DISPUTE BOND COVERAGE
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    uint256 constant DISPUTE_BOND = 1 ether;
+
+    function _enableDisputeBond() internal {
+        vm.prank(admin);
+        tangle.setSlashConfig(7 days, false, 10_000, 14 days, DISPUTE_BOND, 32);
+    }
+
+    function test_DisputeSlash_RevertsOnWrongBond() public {
+        _enableDisputeBond();
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        vm.deal(operator1, DISPUTE_BOND);
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidMsgValue.selector, DISPUTE_BOND, 0));
+        tangle.disputeSlash(slashId, "no bond");
+    }
+
+    function test_DisputeSlash_BondRefundedOnCancel() public {
+        _enableDisputeBond();
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        vm.deal(operator1, DISPUTE_BOND);
+        uint256 balBefore = operator1.balance;
+
+        vm.prank(operator1);
+        tangle.disputeSlash{ value: DISPUTE_BOND }(slashId, "valid dispute");
+        assertEq(operator1.balance, balBefore - DISPUTE_BOND, "bond escrowed");
+
+        // Admin agrees with the dispute → cancel refunds the bond.
+        vm.prank(admin);
+        tangle.cancelSlash(slashId, "admin agrees");
+
+        assertEq(operator1.balance, balBefore, "bond refunded on cancel");
+    }
+
+    function test_DisputeSlash_BondForfeitOnExecute() public {
+        _enableDisputeBond();
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        vm.deal(operator1, DISPUTE_BOND);
+        vm.prank(operator1);
+        tangle.disputeSlash{ value: DISPUTE_BOND }(slashId, "spurious dispute");
+
+        uint256 treasuryBefore = treasury.balance;
+
+        // Auto-resolution after the snapshotted disputeResolutionDeadline (14 days).
+        vm.warp(block.timestamp + 14 days + 1);
+        tangle.executeSlash(slashId);
+
+        assertEq(treasury.balance, treasuryBefore + DISPUTE_BOND, "bond forfeit to treasury");
+    }
+
+    function test_DisputeSlash_AdminDoesNotPostBond() public {
+        _enableDisputeBond();
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        // SLASH_ADMIN is the official escalation path and posts no bond.
+        vm.prank(admin);
+        tangle.disputeSlash(slashId, "admin escalation");
+
+        SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
+        assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Disputed));
+        assertEq(proposal.disputeBond, 0);
+    }
+
+    function test_DisputeDeadlineSnapshot_IgnoresAdminShrink() public {
+        // Admin sets a long deadline; operator disputes; admin then shrinks live config.
+        // The disputed slash must still honor the original (snapshotted) deadline.
+        vm.prank(admin);
+        tangle.setSlashConfig(7 days, false, 10_000, 30 days, 0, 32);
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        vm.prank(operator1);
+        tangle.disputeSlash(slashId, "review");
+
+        // Admin tries to shrink the deadline retroactively.
+        vm.prank(admin);
+        tangle.setSlashConfig(7 days, false, 10_000, 1 days, 0, 32);
+
+        // 2 days later the slash must still NOT be executable — the snapshotted
+        // 30-day deadline governs, not the live 1-day config.
+        vm.warp(block.timestamp + 2 days);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SlashNotExecutable.selector, slashId));
+        tangle.executeSlash(slashId);
+    }
 }

--- a/test/tangle/SlashingEdgeCases.t.sol
+++ b/test/tangle/SlashingEdgeCases.t.sol
@@ -43,7 +43,7 @@ contract SlashingEdgeCasesTest is BaseTest {
         assertEq(stakeBefore, 10 ether);
 
         vm.prank(admin);
-        tangle.setSlashConfig(7 days, false, 5000);
+        tangle.setSlashConfig(7 days, false, 5000, 14 days, 0, 32);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 8000, keccak256("evidence"));
@@ -58,7 +58,7 @@ contract SlashingEdgeCasesTest is BaseTest {
 
     function test_SlashBpsExceedsMax_ProposalStoresCappedBps() public {
         vm.prank(admin);
-        tangle.setSlashConfig(7 days, false, 5000);
+        tangle.setSlashConfig(7 days, false, 5000, 14 days, 0, 32);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 8000, keccak256("evidence"));
@@ -330,7 +330,7 @@ contract SlashingEdgeCasesTest is BaseTest {
     function test_CustomSlashingWindow_ShortWindow() public {
         // Set short dispute window
         vm.prank(admin);
-        tangle.setSlashConfig(1 hours, false, 10_000);
+        tangle.setSlashConfig(1 hours, false, 10_000, 14 days, 0, 32);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
@@ -348,7 +348,7 @@ contract SlashingEdgeCasesTest is BaseTest {
     function test_CustomSlashingWindow_LongWindow() public {
         // Set long dispute window
         vm.prank(admin);
-        tangle.setSlashConfig(30 days, false, 10_000);
+        tangle.setSlashConfig(30 days, false, 10_000, 14 days, 0, 32);
 
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
@@ -414,18 +414,23 @@ contract SlashingEdgeCasesTest is BaseTest {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function test_ManyPendingSlashProposals() public {
-        // Create many pending proposals
-        for (uint256 i = 0; i < 50; i++) {
+        // Per-operator pending-slash cap defaults to 32 (`SlashConfig.maxPendingSlashesPerOperator`).
+        // Verify the cap holds and that proposals up to the cap remain Pending.
+        uint256 cap = 32;
+        for (uint256 i = 0; i < cap; i++) {
             vm.prank(user1);
             tangle.proposeSlash(serviceId, operator1, 100, keccak256(abi.encode("evidence", i)));
         }
-
-        // All should be valid proposals
-        for (uint64 i = 0; i < 50; i++) {
+        for (uint64 i = 0; i < uint64(cap); i++) {
             SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(i);
             assertEq(proposal.slashBps, 100);
             assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Pending));
         }
+
+        // The 33rd proposal must revert via the spam-grief guard.
+        vm.prank(user1);
+        vm.expectRevert(Errors.InvalidState.selector);
+        tangle.proposeSlash(serviceId, operator1, 100, keccak256("over-cap"));
     }
 
     function test_SlashAndDisputeRace() public {


### PR DESCRIPTION
## Summary

Greenfield-posture hardening that closes a broad class of pre-mainnet correctness gaps across slashing, manager-hook reentrancy, service lifecycle, EIP-712 replay, and Base-aware governance. **1478 / 1478 tests passing** on the `fast` profile.

This is the third (and final pre-audit-firm) hardening PR after #115 and #116. After this lands, the protocol is at the "code-complete for external review" bar — operational items (multisig wiring, ISM/DVN pinning) remain.

## Changes

### Slashing model
- **Auto-resolve disputed slashes after `disputeResolutionDeadline`** (default 14 days). Closes the permanent-delegator-lockup path where SLASH_ADMIN never resolves a dispute.
- **`disputeBond` for non-admin disputers** (configurable, default 0 = disabled). Forfeit to treasury on auto-fail or execute, refunded on cancel. Defeats free-DoS via self-dispute.
- **`maxPendingSlashesPerOperator` cap** (default 32). Defends the pending-slash counter against spam-grief.
- **`executeSlash` routes through `slashForService`** when the operator made explicit per-asset commitments to the offending service. Falls back to blueprint-wide slashing only when no commitments exist (legacy services). Closes over-broad slashing of uncommitted assets.
- **`_startLeaving` blocks operators with pending slashes** and **allows `Inactive`→`Leaving`** so operators forced inactive (slashed below minimum stake) can exit instead of stranding stake.
- `setSlashConfig` now takes the three new knobs (`disputeResolutionDeadline`, `disputeBond`, `maxPendingSlashesPerOperator`).

### Manager-hook reentrancy + CEI
- **`_callManager` / `_tryCallManager` capped at 500k gas.** A malicious BSM can no longer burn the entire transaction gas to grief callers, and downstream protocol logic always has gas left to finalize state.
- **`ManagerHookFailed(manager, selector, returnData)` event** so off-chain monitors detect misbehaving BSMs without the protocol path halting.
- **`Operators.registerOperator` reordered to CEI:** every state write completes before the BSM hook fires. Both `registerOperator` entrypoints + `unregisterOperator` gain `nonReentrant`.
- **`createBlueprint`, `transferBlueprint`, `updateBlueprint`, `deactivateBlueprint`, `setJobEventRates`, `setBlueprintResourceRequirements`** gain `nonReentrant`.

### Service lifecycle
- **`fundService` re-checks (a) the blueprint manager's payment-asset policy and (b) service TTL** before accepting a top-up. Closes top-ups to expired services and to tokens whose policy was revoked.
- **New permissionless `expireServiceRequest(requestId)`** refunds the requester after the configured grace period. All approve paths now reject expired requests, and the grace period (already configurable on `Base`) is finally enforced.

### EIP-712 / replay
- **Quote domain separator computed per-call** via new `_domainSeparatorView()`. Stale-cached separator can no longer be replayed across a chainid change / fork.
- **`OperatorStatusRegistry.submitHeartbeat` is full EIP-712** with an explicit `timestamp` parameter and `HEARTBEAT_MAX_AGE` (5 min) freshness. Closes cross-fork / cross-service / cross-deployment replay of stale "healthy" signals.

### Governance for Base
- **`TangleToken.clock()` switched to `block.timestamp`** (ERC-6372). `votingDelay` and `votingPeriod` are now in **seconds**, chain-agnostic across Ethereum / Base / Arbitrum.
- **Default mainnet params:** 1 day delay / 7 day period (was 7200 / 50_400 blocks, which on Base 2s blocks would have been ~4h / ~28h).
- **Default testnet params:** 20 minutes / 3 hours.

## Tests

- Governance suite (27 tests) migrated to timestamp-clock semantics (`vm.warp` + `vm.roll`) and updated default-param assertions.
- Heartbeat tests rewritten for EIP-712 typed digest with the timestamp parameter.
- Slashing tests updated for the new 6-arg `setSlashConfig` and a new `test_ManyPendingSlashProposals` that exercises the per-operator cap.
- **1478 / 1478 passing** on `fast` profile.

## Test plan

- [x] `forge build` clean
- [x] `forge test` -- 1478 / 1478 passing on `fast` profile
- [ ] CI green (default profile, with via_ir)
- [ ] Reviewer walks the new lifecycle paths (especially `expireServiceRequest`, `executeSlash` routing)

## Deliberately NOT in this PR

The following audit findings were re-evaluated under the "no overengineering" lens and judged not worth their cost:

- **Slashing-origin caching at activation:** breaks legitimate dynamic-origin tests (`test_V3_CustomSlashingOrigin_Works`). The original concern (compromised BSM owner) is operator-side trust they accepted by joining a blueprint with that BSM. Reverted to dynamic query.
- **BSM `onBlueprintCreated` `msg.sender == _tangleCore` check:** the BSM frontrun is a one-shot deploy concern, not exploitable beyond DoS of a single BSM. The deployer detects and redeploys. Kept the original one-shot binder.
- **Vault VIRTUAL_SHARES symmetric `1e3 / 1e3`:** correct long-term but breaks dozens of tight-equality assertions due to changed rounding. Deferred to a separate PR with proper test updates.
- **Bridge `messageId` nonce restoration (H-32):** legitimate-retry collision is contained — the L2SlashingReceiver layer already dedupes correctly via the per-message nonce I added in #115.
- **Per-job ETH escrow refund on terminate (H-18):** narrow exposure (jobs are short-lived; EventDriven services aren't common). Deferred.

## Operational items still owed (separate PR)

- Populate `deploy/config/base-mainnet.json` with real multisig addresses.
- Deploy `TangleTimelock` + `TangleGovernor` and pin their addresses (`FullDeploy` doesn't deploy them today).
- Pin Hyperlane ISM and LayerZero DVN/ULN configs.
- Wire L2 sequencer-uptime feed (the function exists since #115; needs the admin call on Base).