### PR TITLE
ci(foundry): add forge build cache + 45min timeout

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -23,6 +23,7 @@ jobs:
 
     name: Foundry project
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     outputs:
       foundry_changed: ${{ steps.changes.outputs.foundry_changed }}
     steps:
@@ -30,6 +31,17 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Cache Foundry build artifacts
+        if: steps.changes.outputs.foundry_changed != 'false'
+        uses: actions/cache@v4
+        with:
+          path: |
+            cache
+            out
+          key: foundry-${{ runner.os }}-${{ hashFiles('foundry.toml', 'soldeer.lock', 'remappings.txt', 'src/**', 'test/**', 'script/**', 'dependencies/**') }}
+          restore-keys: |
+            foundry-${{ runner.os }}-
 
       - name: Detect Foundry-relevant changes
         id: changes


### PR DESCRIPTION
Foundry CI has been failing on main with exit 143 (SIGTERM) at `Run Forge build` after ~17min — symptoms of solc OOM on the 220-file via-IR compile.

This adds:
- `actions/cache@v4` keyed on `foundry.toml` + `soldeer.lock` + `src/test/script/dependencies` content hashes, persisting `cache/` and `out/` between runs so unchanged files don't recompile.
- `timeout-minutes: 45` so future genuine timeouts surface as timeout errors rather than ambiguous SIGTERM exits.

Doesn't change runner size — keeping `ubuntu-latest` since I don't know if larger runners are enabled for the org. If this still OOMs even with cache, the follow-up is to switch to `ubuntu-latest-l` or split the build profile.