### PR TITLE
indexer: align with v0.15.0 ValidatorPodManager events

### DIFF
--- a/indexer/config.yaml
+++ b/indexer/config.yaml
@@ -114,12 +114,13 @@ networks:
           - event: PodCreated(address indexed owner, address indexed pod)
           - event: Delegated(address indexed delegator, address indexed operator, uint256 amount)
           - event: Undelegated(address indexed delegator, address indexed operator, uint256 amount)
-          - event: SharesUpdated(address indexed owner, int256 sharesDelta, int256 newShares)
+          - event: SharesUpdated(address indexed owner, int256 sharesDelta, uint256 newShares, uint256 totalAssets, uint256 totalSharesPool)
+          - event: BeaconRebase(address indexed owner, int256 assetsDelta, uint256 newTotalAssets, uint256 totalSharesPool)
           - event: OperatorRegistered(address indexed operator)
           - event: OperatorDeregistered(address indexed operator)
           - event: DelegatorSlashed(address indexed delegator, address indexed operator, uint256 amount)
-          - event: WithdrawalQueued(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares)
-          - event: WithdrawalCompleted(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares)
+          - event: WithdrawalQueued(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+          - event: WithdrawalCompleted(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
       - name: LiquidDelegationFactory
         address: []
         handler: src/EventHandlers.ts

--- a/indexer/schema.graphql
+++ b/indexer/schema.graphql
@@ -167,6 +167,25 @@ type ValidatorPodShareEvent {
   owner: String!
   sharesDelta: BigInt!
   newShares: BigInt!
+  "Pool totalAssets at the emit instant. Null on legacy events emitted before the share-pool refactor."
+  totalAssets: BigInt
+  "Pool totalShares at the emit instant. Null on legacy events emitted before the share-pool refactor."
+  totalSharesPool: BigInt
+  timestamp: BigInt!
+  txHash: String!
+}
+
+"""
+Beacon-chain rebase. Distinct from ValidatorPodShareEvent — share events fire on
+principal deposits (mint), rebases fire on rewards/slashes (totalAssets-only;
+share balances are invariant).
+"""
+type ValidatorPodBeaconRebase {
+  id: ID!
+  owner: String!
+  assetsDelta: BigInt!
+  newTotalAssets: BigInt!
+  totalSharesPool: BigInt!
   timestamp: BigInt!
   txHash: String!
 }
@@ -176,6 +195,10 @@ type ValidatorPodWithdrawal {
   withdrawalRoot: String!
   staker: String!
   shares: BigInt!
+  "Asset snapshot at queue time. Completion pays out min(snapshot, live)."
+  queuedAssets: BigInt
+  "Asset amount actually transferred on completion (≤ queuedAssets when the pool slashed in-between)."
+  completedAssets: BigInt
   status: RequestStatus!
   queuedAt: BigInt!
   completedAt: BigInt

--- a/indexer/src/handlers/validatorPods.ts
+++ b/indexer/src/handlers/validatorPods.ts
@@ -3,6 +3,7 @@ import type {
   Operator,
   ValidatorPod,
   ValidatorPodShareEvent,
+  ValidatorPodBeaconRebase,
   ValidatorPodWithdrawal,
   ValidatorPodSlash,
   NativeOperator,
@@ -77,10 +78,29 @@ export function registerValidatorPodHandlers() {
       owner: normalizeAddress(event.params.owner),
       sharesDelta: toBigInt(event.params.sharesDelta),
       newShares: toBigInt(event.params.newShares),
+      totalAssets: toBigInt(event.params.totalAssets),
+      totalSharesPool: toBigInt(event.params.totalSharesPool),
       timestamp,
       txHash: getTxHash(event),
     } as ValidatorPodShareEvent;
     context.ValidatorPodShareEvent.set(entity);
+  });
+
+  // Beacon rebases (rewards / slashes) move totalAssets only; shares are invariant.
+  // Tracked separately from SharesUpdated so analytics can distinguish principal
+  // mints from pool-price moves.
+  ValidatorPodManager.BeaconRebase.handler(async ({ event, context }) => {
+    const timestamp = getTimestamp(event);
+    const entity: ValidatorPodBeaconRebase = {
+      id: `rebase-${getTxHash(event)}-${event.logIndex}`,
+      owner: normalizeAddress(event.params.owner),
+      assetsDelta: toBigInt(event.params.assetsDelta),
+      newTotalAssets: toBigInt(event.params.newTotalAssets),
+      totalSharesPool: toBigInt(event.params.totalSharesPool),
+      timestamp,
+      txHash: getTxHash(event),
+    } as ValidatorPodBeaconRebase;
+    context.ValidatorPodBeaconRebase.set(entity);
   });
 
   ValidatorPodManager.OperatorRegistered.handler(async ({ event, context }) => {
@@ -129,6 +149,7 @@ export function registerValidatorPodHandlers() {
       withdrawalRoot: root,
       staker: normalizeAddress(event.params.staker),
       shares: toBigInt(event.params.shares),
+      queuedAssets: toBigInt(event.params.assets),
       status: "PENDING",
       queuedAt: timestamp,
       txHash: getTxHash(event),
@@ -143,6 +164,7 @@ export function registerValidatorPodHandlers() {
     if (!existing) return;
     const updated: ValidatorPodWithdrawal = {
       ...existing,
+      completedAssets: toBigInt(event.params.assets),
       status: "EXECUTED",
       completedAt: timestamp,
       txHash: getTxHash(event),


### PR DESCRIPTION
## Summary

Mirror the ValidatorPodManager event-signature changes that landed in #129 into the indexer config + handlers so the ingest pipeline doesn't silently drop or misread the new fields.

Three event signatures changed, one is new:

- `SharesUpdated` gained `totalAssets` + `totalSharesPool`; `newShares` moved int256 → uint256
- `WithdrawalQueued` / `WithdrawalCompleted` gained a trailing `assets`
- `BeaconRebase` (new) — beacon rewards/slashes that move totalAssets without changing share balances

## Schema

- `ValidatorPodShareEvent` gains nullable `totalAssets` / `totalSharesPool`
- `ValidatorPodWithdrawal` gains nullable `queuedAssets` / `completedAssets`
- New `ValidatorPodBeaconRebase` entity

## Test plan

- [x] `npm run codegen` clean
- [x] `npm run build` (tsc --build) clean
- [x] `npm test` 5/5 passing
- [ ] Sanity-check entity writes against a fixture replay (deferred to deployment)

Coordinates with `tnt-core-bindings v0.15.0` published to crates.io and tagged `bindings-v0.15.0`.