### PR TITLE
chore(v0.17.1): audit batch — reports + stress harness + remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ script/tanglepod-cli/tanglepod-cli
 *.log
 *.out
 *.toc
+
+# Per-machine marker: opts this repo into the ~/bin/forge task-spooler queue
+# (one forge build/test at a time even under parallel CC agents).
+.forge-queue

--- a/docs/audits/REDTEAM-DOS-ACCESS-2026-05-16.md
+++ b/docs/audits/REDTEAM-DOS-ACCESS-2026-05-16.md
@@ -1,0 +1,199 @@
+# Red-team audit: DoS surfaces + access control
+
+Scope: `src/core/`, `src/staking/`, `src/beacon/`, `src/facets/`, `src/libraries/`.
+Method: static read of the branch `chore/audit-dos-access-2026-05-16` (forked from `chore/audit-economic-oracle-2026-05-16`), no source modifications.
+Posture: adversarial, looking for paths that (a) brick state for honest users or (b) escalate privilege beyond the documented trust boundary.
+
+## Summary
+
+| Severity      | Count |
+|---------------|-------|
+| CRITICAL      | 0     |
+| HIGH          | 2     |
+| MEDIUM        | 4     |
+| LOW           | 4     |
+| INFORMATIONAL | 3     |
+
+The two HIGH items are both real DoS surfaces that touch the permissionless billing path. Neither lets an attacker steal funds, but both can force a service into an unbillable / unrecoverable state via gas exhaustion. Everything else is hardening / hygiene.
+
+The reviewed code is generally well-bounded: `MAX_OPERATORS_PER_SERVICE` is enforced as a hard ceiling on every per-operator loop, manager hooks that route value (`_callManager`, `_tryCallManager`, the two `staticcall` paths in `PaymentsBilling`/`PaymentsDistribution`) all carry an explicit `MANAGER_HOOK_GAS_LIMIT` cap, and the EIP-712 + BLS PoP + TEE nonce constructions are all bound to `(chainId, verifyingContract, …)`. The gaps are concentrated in two places: per-asset commitment arrays whose length is operator/customer-supplied with no cap, and a handful of `try IBlueprintServiceManager(...)` callsites that do not carry an explicit gas stipend.
+
+## Findings
+
+### H-1 (HIGH) — Unbounded security-commitment arrays brick subscription billing
+
+Files: `src/core/ServicesRequests.sol:351-358`, `src/facets/tangle/TangleServicesFacet.sol:73-91`, `src/core/PaymentsBilling.sol:204-360`, `src/core/PaymentsDistribution.sol:105-159`, `src/core/Slashing.sol:128-205`.
+
+`requestServiceWithSecurity` accepts `Types.AssetSecurityRequirement[] calldata securityRequirements` with only `requirements.length == 0` rejected (`ServicesRequests.sol:352`). There is no upper bound.
+
+At activation, `_persistServiceSecurity` (TangleServicesFacet.sol:73) copies the requirements into `_serviceSecurityRequirements[serviceId]` and, for every approving operator, copies their commitment array into `_serviceSecurityCommitments[serviceId][operator]`. Both arrays grow O(R) where R is the customer-chosen requirement count.
+
+Every subscription bill then walks every (operator × asset) pair:
+
+- `PaymentsBilling._accrueOperatorWeights` (line 270) — outer loop over operators, inner loop over the operator's commitments (line 304). `oracle.toUSD` may be invoked per asset.
+- `PaymentsBilling._commitOperatorCursors` (line 213) — symmetric inner loop per operator (line 224).
+- `PaymentsDistribution._initSubscriptionBaseline` (line 114) — same nested shape (line 132), runs once at activation.
+- `Slashing._computeServiceCommitmentExposureBps` (line 138 / 162) — full asset walk on every slash proposal.
+
+Operators per service are bounded by `MAX_OPERATORS_PER_SERVICE = 64`, but R is not bounded. A customer who lists, say, R = 1000 ERC-20 requirements pays ~32 KB of calldata once at request time (request cost is high but finite) and from that point forward every `billSubscription` and every `proposeSlash` for that service iterates 64 × 1000 = 64 000 commitments. Each inner iteration does a `keccak256`, a storage read (`_serviceSecurityCommitmentBps`), an `_staking.getCumStakeSeconds` external call, and — when an oracle is configured — an `oracle.toUSD` external call.
+
+This blows past the block gas limit on a single mainnet block well before R = 1000 is reached. Once it does, the subscription bill cannot be drawn, the escrow cannot be released to operators, and `terminateServiceForNonPayment` cannot fire either (it requires `billSubscription` machinery via the manager-policy resolver). Customer funds are not stolen — they're stranded in escrow until the customer terminates manually — but operators silently stop being paid.
+
+The cost surface is paid by:
+- The keeper calling `billSubscription` (the rebate is denominated in basis points of the bill; a runaway commitment count makes the rebate go negative net of gas).
+- The slash proposer in `proposeSlash`.
+- The last-approving operator in `approveService` → `_activateService`.
+
+Recommendation: add `MAX_SECURITY_REQUIREMENTS_PER_REQUEST` (mirroring the existing `MAX_TEE_COMMITMENTS_PER_OPERATOR = 8` in `ServiceValidationLib.sol:10`) and enforce it in `_validateSecurityRequirements`. A practical cap is 16 — more than enough for any heterogeneous-asset blueprint, low enough that the worst-case bill stays within a single block.
+
+### H-2 (HIGH) — Permissionless bill / aggregation paths forward 63/64 gas to `try IBlueprintServiceManager(...)`
+
+Files: `src/core/JobsAggregation.sol:65,69,125`, `src/core/JobsSubmission.sol:240,337`, `src/core/ServicesLifecycle.sol:103,404,448,475,643,651`, `src/core/Operators.sol:137`, `src/core/Slashing.sol:59`, `src/core/Base.sol:613,622`.
+
+`_callManager` and `_tryCallManager` in `Base.sol` (lines 730 / 743) both enforce `gas: MANAGER_HOOK_GAS_LIMIT` (500 000), and the two `staticcall` sites in `PaymentsBilling._resolveBillAdjustmentBps` (line 381) and `PaymentsDistribution._resolveDeveloperPaymentAddress` (line 374) do the same. Confirmed.
+
+However, every `try IBlueprintServiceManager(bp.manager).foo() … catch { }` callsite does NOT add an explicit gas stipend. Solidity's `try/catch` for an external call without `{ gas: … }` follows ordinary EVM `CALL` semantics: it forwards 63/64 of remaining gas. A malicious BSM can consume that entire stipend in an OOG loop and then revert; the surrounding `catch { }` swallows the revert but the gas is already gone.
+
+The most exploitable callsite is `Slashing.proposeSlash → querySlashingOrigin` (line 59) and the `requiresAggregation` hooks in `JobsAggregation.submitAggregatedResult` (line 65) and `JobsSubmission._maybeRequireAggregation` (line 240). All three are reachable from permissionless or semi-permissionless paths (anyone with a valid signature for the latter two) and all three sit BEFORE the bulk of the function's state writes. A malicious manager that wants to brick aggregated-result submission for its own blueprint can simply make `requiresAggregation` burn all forwarded gas before the protocol can record a successful job result.
+
+Most other instances are less severe because they're only hit by parties that already trust the blueprint (the operator registering, the operator joining, the operator leaving, the service owner force-removing). For those, the BSM is part of the documented trust boundary and the worst-case is "the BSM author can brick their own service" — annoying but the customer/operator chose this BSM.
+
+Recommendation: route every `try IBlueprintServiceManager(...) … catch` through a helper that mirrors `_tryCallManager`'s pattern — `manager.staticcall{ gas: MANAGER_HOOK_GAS_LIMIT }(abi.encodeCall(…))` followed by `abi.decode` on success. The two existing call sites in `PaymentsBilling` and `PaymentsDistribution` already use this pattern and can be lifted to a shared internal helper.
+
+### M-1 (MEDIUM) — Cosmetic role separation: `DEFAULT_ADMIN_ROLE` granted to a single key
+
+Files: `src/core/Base.sol:174-178`, `src/staking/MultiAssetDelegation.sol:53-55`.
+
+`__Base_init` grants `DEFAULT_ADMIN_ROLE` to `admin` and then separately grants `ADMIN_ROLE`, `PAUSER_ROLE`, `UPGRADER_ROLE`, and `SLASH_ADMIN_ROLE` to the same address. OpenZeppelin AccessControl uses `DEFAULT_ADMIN_ROLE` as the default role admin for every other role (no `_setRoleAdmin` overrides exist in the codebase, verified via `grep -rn "_setRoleAdmin\|getRoleAdmin" src/`). Consequently, whoever holds `DEFAULT_ADMIN_ROLE` can `grantRole(UPGRADER_ROLE, self)` and unilaterally upgrade the proxy. The advertised role separation — admin / pauser / upgrader / slash-admin as distinct privilege levels — is cosmetic until the role admins are explicitly siloed.
+
+The deployment runbook states that `DEFAULT_ADMIN_ROLE` should be handed off to a timelock post-deploy (Base.sol:159-161 has the H-5 note). That is necessary but not sufficient: the timelock will still be able to grant itself any role at any time. To actually enforce defense-in-depth, the contract must call `_setRoleAdmin(UPGRADER_ROLE, GOVERNANCE_ROLE)` (and equivalents) during init so the admin path and the upgrade path are different principals.
+
+Same issue exists in `MultiAssetDelegation.__init` for the staking adapter (admin = ADMIN_ROLE = ASSET_MANAGER_ROLE all collapsed to a single key).
+
+Recommendation: in `__Base_init`, add `_setRoleAdmin(UPGRADER_ROLE, UPGRADER_ROLE)` (or a dedicated `GOVERNANCE_ROLE`) so admin cannot grant the upgrade key, and similarly for `SLASH_ADMIN_ROLE`. Mirror in `MultiAssetDelegation`.
+
+### M-2 (MEDIUM) — `ValidatorPodManager` slasher registry gated only by single-owner `onlyOwner`
+
+Files: `src/beacon/ValidatorPodManager.sol:275,985-993,999,1004`.
+
+`ValidatorPodManager` is `Ownable` (not `Ownable2Step`, not role-based) and `_slashers` is a bare `mapping(address => bool)` mutated by `addSlasher` / `removeSlasher` (lines 985 / 990). Owner is set in the constructor (`Ownable(msg.sender)` at line 275). `setBeaconOracle` (line 999) and `setWithdrawalDelay` (line 1004) are similarly `onlyOwner` with no timelock.
+
+If the deployer EOA is compromised before ownership is transferred (or if `transferOwnership` is never called), an attacker can:
+
+- Add themselves as a slasher and slash any operator pool.
+- Re-point the beacon oracle to an attacker-controlled feed and forge rebase deltas.
+- Set `withdrawalDelay` to `type(uint32).max` to brick withdrawals.
+
+The core `Tangle` contract uses `AccessControl` with explicit role separation; `ValidatorPodManager` skipped this. The trust model for the beacon module is therefore weaker than the trust model for the rest of the protocol.
+
+Recommendation: migrate to `AccessControl` with at least `ADMIN_ROLE` + `SLASHER_ROLE` + `ORACLE_ADMIN_ROLE`, mirroring the staking adapter. At minimum, switch to `Ownable2Step` to defend against fat-fingered ownership transfers. Consider a timelock on `addSlasher` and `setBeaconOracle`.
+
+### M-3 (MEDIUM) — Stale-state risk: `_operatorActiveSlashProposals` only decrements on explicit `execute*` / `cancel*` calls
+
+File: `src/core/Slashing.sol:90-99,541-544`, `src/libraries/SlashingLib.sol:338-346`.
+
+`proposeSlash` is callable by `svc.owner`, `bp.owner`, or the BSM-declared `slashingOrigin`. The cap `_operatorActiveSlashProposals[operator] >= maxPendingSlashesPerOperator` (Slashing.sol:93) bounds in-flight slash proposals against a single operator. The counter is incremented at proposal time and decremented inside `_decrementOperatorPendingTracker` from `executeSlash`, `executeSlashBatch`, and `cancelSlash`.
+
+The auto-fail path for a disputed proposal is handled implicitly: once `block.timestamp >= proposal.disputeDeadline + TIMESTAMP_BUFFER`, `SlashingLib.isExecutable` returns `true` for the `Disputed` status (line 342-344). So a disputed proposal whose deadline has elapsed becomes executable via `executeSlash` — which then decrements the counter correctly. There is no state-leak when the path is exercised.
+
+The remaining concern is operational, not exploitable: a disputed proposal whose deadline has elapsed but for which nobody ever calls `executeSlash` keeps the local counter bumped indefinitely. Because the counter is per-operator, an attacker who can spam `disputeBond`-backed disputes on `maxPendingSlashesPerOperator` proposals AND find a victim who never gets around to `executeSlash`-ing them can lock out legitimate slash proposals on that operator. The economic cost is `maxPendingSlashesPerOperator × disputeBond` posted by the attacker (refunded on `cancelSlash`, forfeit on `executeSlash`), so the attack is not free.
+
+Recommendation: extend the invariant fuzz suite (`test/fuzz/InvariantFuzz.t.sol`) to assert that `_operatorActiveSlashProposals[op]` equals the count of non-finalized proposals targeting `op` across all proposal IDs after every action. Optional: expose a permissionless `sweepStaleDisputedSlashes(uint64[] slashIds)` helper that just calls `executeSlash` on each (already permissionless, but a batched variant lowers the friction).
+
+### M-4 (MEDIUM) — `addPermittedCaller` / `removePermittedCaller` / `updateOperatorPreferences` / `preRegister` lack `whenNotPaused`
+
+Files: `src/core/ServicesLifecycle.sol:159,168`, `src/core/Operators.sol:49,243`.
+
+The pause policy across the protocol is consistent for funds-flow paths: every entry that pulls value (`fundService`, `requestService*`, `joinService*`, `billSubscription*`, `submitJob`, `submitResult*`, `createBlueprint`, `extendService*`, `acceptQuote*`) carries `whenNotPaused`. State-removing paths (`terminate*`, `leave*`, `exit*`, `withdrawRemainingEscrow`, `claimRewards*`, `claimDisputeBond`) are intentionally pause-bypass so customers can recover funds during an emergency.
+
+The four functions above don't fit either pattern:
+- `preRegister` (Operators.sol:49) only emits an event; it has no economic side effect, so paused or unpaused makes no difference. Worth pausing for consistency.
+- `addPermittedCaller` / `removePermittedCaller` (ServicesLifecycle.sol:159/168) mutate the permitted-caller set for an active service. During pause, the service is still active but no jobs can be submitted (`submitJob` is paused), so adding/removing callers is moot. Worth pausing for consistency.
+- `updateOperatorPreferences` (Operators.sol:243) is more concerning: it lacks BOTH `whenNotPaused` AND `nonReentrant`, then calls `_tryCallManager` at line 288. The reentrancy surface is narrow (the function only writes operator-prefs storage) but the inconsistency with `registerOperator` / `unregisterOperator` (both of which carry `nonReentrant`) is suspicious. A malicious BSM hook could re-enter `updateOperatorPreferences` on a different blueprint, but the cross-blueprint state is independent, so no concrete exploit emerges. Defense-in-depth says add `nonReentrant`.
+
+Recommendation: add `whenNotPaused` to all four. Add `nonReentrant` to `updateOperatorPreferences`.
+
+### L-1 (LOW) — `O(N²)` operator-duplicate check in `_validateRequestOperators` runs before the size cap
+
+File: `src/core/ServicesRequests.sol:266-287`, `_validateOperatorBounds` at line 294-308.
+
+`_requestServiceInternal` calls `_validateRequestOperators` (which does an `O(operators.length²)` duplicate scan at line 282) BEFORE calling `_computeRequestBounds` → `_validateOperatorBounds` (line 202). With `operators.length` user-supplied, the duplicate scan runs to completion even when the array exceeds `MAX_OPERATORS_PER_SERVICE`.
+
+The early `OperatorNotRegistered` revert on line 268 caps this in practice (the first non-registered operator short-circuits), but a caller who fills the array entirely with registered operators avoids that escape hatch. Self-DoS at worst — the caller pays the gas — but trivial to fix by moving `_validateOperatorBounds` (or just a `if (operators.length > MAX_OPERATORS_PER_SERVICE) revert` guard) to the top of `_requestServiceInternal`.
+
+### L-2 (LOW) — `_isRequestOperator` is O(N) on every approval / rejection
+
+File: `src/core/ServicesApprovals.sol:194-200`.
+
+`_requireApprovingOperator` (line 186) and `rejectService` (line 166) both call `_isRequestOperator`, which linearly scans `_requestOperators[requestId]`. Bounded by `MAX_OPERATORS_PER_SERVICE = 64`, so capped at 64 SLOADs per call. Not exploitable; flagged because a hash set / bitmap would cut approval-side gas roughly in half. Pure perf, not security.
+
+### L-3 (LOW) — `_pendingRewardTokens[account]` set has no eviction on zero balance
+
+File: `src/core/PaymentsDistribution.sol:231,285`, `src/core/PaymentsRewards.sol:113-121`.
+
+`_pendingRewardTokens[account].add(token)` is called every time a reward is accrued in a new token. The set is cleaned up in `_claimRewardsToken` only when `claimed > 0`. If `addPendingReward` is called for `amount == 0` (it isn't today — both call sites guard `opShare > 0`/`stakerShare > 0`), the set could grow without ever shrinking.
+
+Bigger concern: there is no scenario today where an attacker can inject arbitrary `token` values into the set — `token` always comes from the customer-chosen escrow token or `address(0)` (native). So set growth is bounded by the set of tokens the operator chose to receive payment in. Indexable concern only — `rewardTokens(account)` view becomes expensive for long-lived operators, but the on-chain `claimRewardsAll` loop is isolated per token via `try/catch` so a single griefing token cannot brick the sweep. No action required.
+
+### L-4 (LOW) — `executeSlashBatch` continues after `_settleDisputeBond` push-failure leaves state inconsistent
+
+File: `src/core/Slashing.sol:475-504`.
+
+`_settleDisputeBond` on `refund == false` (executeSlash path) pushes the bond to the treasury via `t.call{ value: bond }("")`. If the call fails, the code restores `proposal.disputeBond` and `proposal.disputer` (line 501-503). For `executeSlash` (single-slash), this is fine — the entire transaction reverts gracefully via the next call's failure.
+
+For `executeSlashBatch`, however, the loop continues even when the treasury push fails on an earlier proposal. The proposal is marked `Executed` at line 308 BEFORE the bond settle at line 314; if the bond push fails, the bond is restored on the proposal but the proposal status remains `Executed`. A subsequent retry of `executeSlash(slashId)` will revert with `SlashNotExecutable`. The bond is stuck on the proposal record — recoverable via a future treasury reconfiguration but not via the normal flow.
+
+Fix: in `executeSlashBatch`, either re-revert the iteration when `_settleDisputeBond` fails to push, or unconditionally credit the bond to a pull-pattern mapping (mirroring the refund path) instead of pushing.
+
+### INFO-1 — `unregisterOperator` allowed during pause
+
+File: `src/core/Operators.sol:196`.
+
+By design, since unregistration only removes state and the protocol-paused state shouldn't trap operators in blueprints. Documented behavior; no action.
+
+### INFO-2 — Permissionless `expireServiceRequest` lacks `whenNotPaused`
+
+File: `src/core/ServicesApprovalsViews.sol:68`.
+
+Also fine by design: this is the customer's recovery path. During pause, `approveService` cannot fire, so an expired request can only be cleaned up via this entry. Worth adding a comment.
+
+### INFO-3 — `_setRoleAdmin` is never invoked, so all five roles share one administrator
+
+See M-1.
+
+## Clean checks (verified, no findings)
+
+1. **`MAX_OPERATORS_PER_SERVICE = 64` enforcement** — enforced at request validation (`ServicesRequests._validateOperatorBounds`) and again at join (`ServicesLifecycle._loadJoinContext:625-630`). Blueprint configs with `maxOperators == 0` are clamped to the protocol ceiling in both spots, matching the docstring at `ProtocolConfig.sol:44-48`.
+
+2. **`MAX_BLUEPRINTS_PER_OPERATOR = 1024` enforcement** — enforced in `Operators._registerOperator:114-118`, decremented in `unregisterOperator:225-227`. `Operators.getOperatorTotalActiveServices:305-313` iterates the global blueprint counter (`_blueprintCount`) — this is a view function, off-chain only; not a DoS concern.
+
+3. **`MAX_TEE_COMMITMENTS_PER_OPERATOR = 8` enforcement** — `ServiceValidationLib.validateTeeCommitments:21-23` rejects above-cap arrays at approval time. Confirmed bound on the storage path (`_serviceTeeCommitmentRoot` is a bytes32, not an array).
+
+4. **Manager-hook gas caps on value-routing paths** — `_callManager` and `_tryCallManager` (`Base.sol:730-748`) both enforce `gas: MANAGER_HOOK_GAS_LIMIT = 500_000`. The two `staticcall` paths in `PaymentsBilling._resolveBillAdjustmentBps:381` and `PaymentsDistribution._resolveDeveloperPaymentAddress:374` do the same. Confirmed.
+
+5. **EIP-712 domain separator** — `SignatureLib.computeDomainSeparator:60-75` binds `name + version + chainId + verifyingContract`. Recomputed from `block.chainid` on every verification in `Base._domainSeparatorView:209-211`, so a post-fork chainid invalidates pre-fork signatures automatically. `verifyAndMarkQuoteUsed`, `verifyAndMarkJobQuoteUsed`, and `verifyQuoteBatch` all mark digests as used in a `mapping(bytes32 => bool)`; no replay window.
+
+6. **BLS PoP binding** — `AttestationLib.blsPopMessage:30-41` returns `abi.encode("TANGLE_BLS_POP_v1", chainId, verifyingContract, operator, blsPubkey)`. `ServiceValidationLib.requireBlsProofOfPossession:83-99` passes that exact tuple to `BN254.verifyBls`. Cross-chain / cross-operator / cross-key replay all blocked.
+
+7. **TEE attestation nonce binding** — `AttestationLib.teeNonce:15-25` binds `(requestId, verifyingContract, chainId)`. `ServiceValidationLib.validateTeeCommitments:30` checks `teeCommitments[i].nonceBinding == expectedNonce`. Cross-request / cross-chain replay both blocked.
+
+8. **`_disableInitializers` on every UUPS implementation** — confirmed on `Base.sol:151-153` (inherited by `Tangle`), `MultiAssetDelegation.sol:30-32`, `MBSMRegistry.sol:89-91`, `TangleGovernor.sol:76-78`, `TangleToken.sol:65-67`. `RewardsManager` and `MasterBlueprintServiceManager` are not upgradeable (no `Initializable` import), so the front-running window doesn't apply.
+
+9. **`withdrawRemainingEscrow` works during pause** — `src/core/PaymentsEscrow.sol:46` lacks `whenNotPaused` by design. Customer recovery path during emergency pause. Confirmed safe.
+
+10. **`claimRewardsAll` per-token isolation** — `src/core/PaymentsRewards.sol:55-78` wraps each token claim in a self-call `try/catch` so a single griefing ERC-20 cannot brick the sweep. The set is snapshot before iteration (line 59-65) to handle in-loop mutation safely.
+
+11. **Slasher registry gating in staking adapter** — `addSlasher` in `StakingAdminFacet.sol:48` requires `ADMIN_ROLE` and grants `SLASHER_ROLE`. (See M-1 for the cross-role-grant concern at the AccessControl level.)
+
+12. **`proposeSlash` per-operator concurrency cap** — `_operatorActiveSlashProposals[operator] >= maxPendingSlashesPerOperator` check at `Slashing.sol:93` is correctly `>=` (rejects at the cap, not above it) and the counter is bumped only after the cap check succeeds. (See M-3 for the auto-fail accounting concern.)
+
+## Method
+
+- Branch: `chore/audit-dos-access-2026-05-16` forked from `chore/audit-economic-oracle-2026-05-16`.
+- Read-only static analysis. No source modifications, no test runs.
+- Enumerated every `external` state-mutating function in `src/core/` (and the diamond facets that expose them via `selectors()`).
+- Catalogued every `for (` loop in `src/core/` (84 loops) and traced their bound to a protocol constant or to user-supplied calldata.
+- Catalogued every `IBlueprintServiceManager` call site (29 total) and verified whether the call site enforces an explicit `gas: MANAGER_HOOK_GAS_LIMIT` cap. Found that all 4 paths going through `_callManager` / `_tryCallManager` / explicit `staticcall` enforce the cap, and all `try IBlueprintServiceManager(...)` callsites (13 total) do not.
+- Audited `onlyRole`, `whenNotPaused`, `nonReentrant` coverage across 50+ external mutators.
+- Verified signature surfaces: EIP-712 quote (`SignatureLib`), BLS PoP (`AttestationLib` + `BN254.verifyBls`), TEE attestation nonce (`AttestationLib.teeNonce`).
+- Verified initializer disabling and admin handoff comments across upgradeable implementations.

--- a/docs/audits/REDTEAM-ECONOMIC-ORACLE-2026-05-16.md
+++ b/docs/audits/REDTEAM-ECONOMIC-ORACLE-2026-05-16.md
@@ -1,0 +1,219 @@
+# Red-team audit — economic + oracle manipulation surfaces
+
+- Date: 2026-05-16
+- Scope: subscription billing (`PaymentsBilling`, `PaymentsDistribution`, `PaymentLib`), TWAP stake-second index in `DelegationStorage`, share-pool inflation defense in `ValidatorPodManager` / `LiquidDelegationVault` / `DelegationStorage`, slashing path (`Slashing`, `SlashingLib`, `SlashingManager`), `IPriceOracle` adapters (`ChainlinkOracle`, `UniswapV3Oracle`).
+- Method: read-only static review + adversarial sequence tracing. No code changes.
+- Severity counts: 0 CRITICAL, 1 HIGH, 3 MEDIUM, 2 LOW, 2 INFORMATIONAL.
+
+## Summary
+
+The cap-at-nominal guarantee on subscription bills holds — the customer's per-period draw cannot be inflated by oracle manipulation, stake ramps, or hostile manager hooks. Slashing is non-replayable and per-asset rounding is correct.
+
+The remaining attack surface is **distributional**, not extractive against the customer: per-operator weights inside a (capped) bill are uncapped, so an operator who manipulates an oracle they control, or ramps stake just before `periodEnd`, can siphon the operator/staker share of the bill from honest operators. This is the strongest finding (HIGH). The other findings are oracle-griefing exposure and a documentation gap around the asymmetric virtual offsets in `DelegationStorage` vs `ValidatorPodManager` / `LiquidDelegationVault`.
+
+## Findings
+
+### H-1 — Oracle-manipulated weight inflation lets one operator capture a bill's operator pool
+
+**Severity: HIGH** (recoverable loss — fund redistribution between operators, not from the customer).
+
+**Location:** `src/core/PaymentsBilling.sol::_accrueOperatorWeights` lines 270–354; mirrored at `src/core/PaymentsDistribution.sol::_initSubscriptionBaseline` lines 105–159.
+
+**Math trace.**
+For each (operator, commitment), the weight contribution is:
+
+```
+contribution_j = (opDeltaRaw_j * c.exposureBps) / 10_000
+if (useOracle && contribution_j > 0):
+    contribution_j = oracle.toUSD(c.asset.token, contribution_j)
+opWeight_i = Σ_j contribution_j
+totalWeight = Σ_i opWeight_i
+```
+
+The bill amount `_billSubscriptionImpl` line 137 is bounded by the cap on line 145:
+
+```
+amount = PaymentLib.twapBillAmount(nominalRate, cumDeltaPeriod, baselineStake, interval)
+if (amount > nominalRate) amount = nominalRate
+```
+
+Per-operator payout is `amount * weights[i] / totalWeight` (see `_payOperatorPoolByWeight` lines 270–281). `weights[i]` are uncapped USD-normalized at bill time; `baseline` is USD-normalized once at activation.
+
+**Attack.** Operator A commits stake on an asset whose price oracle they can influence — e.g. low-cap ERC20 with a Uniswap V3 pool that has a 30-minute TWAP window (default `DEFAULT_TWAP_PERIOD` in `UniswapV3Oracle.sol` line 69). At activation, oracle price was P0; A's exposure contributed `X * P0` USD to baseline. Just before billing, A pushes the pool's tick over a sustained window to drive `oracle.toUSD(...)` to `X * (P0 * 100)`. At billing:
+
+- `opWeight_A = (cumDelta_A * exposure_A_bps / 10_000) * P0 * 100`
+- For honest operators on TNT, oracle returns `cumDelta_B * P_TNT` (unchanged)
+- `weights[A] / totalWeight ≈ 1` if A's USD-priced contribution dominates
+
+The bill cap fires (`amount = nominalRate`), so the customer is unharmed, but A captures the operator pool + (depending on `hasSecurityCommitments`) the staker pool — pulling rent from honest operators in the same service. Across N periods, A's expected take is `~nominalRate * (operatorBps + stakerBps) / 10_000` per period vs honest operators' near-zero share.
+
+**Why baseline-pin doesn't block it.** The baseline pins the *denominator of bill amount* in USD at activation time. It does not pin the *split of the operator pool*. Weight inflation only affects the split denominator at bill time (`totalWeight`), not the protocol-level cap.
+
+**Why UniswapV3 TWAP doesn't block it.** A 30-minute TWAP frustrates flash-loan manipulation but does not stop sustained manipulation, especially on low-liquidity pools. The oracle's own comment (`UniswapV3Oracle.sol` lines 42–56) acknowledges: "Attackers with sufficient capital can manipulate prices over the TWAP window." Subscription billing intervals are far longer (days/weeks), giving the attacker ample prep time.
+
+**Why Chainlink isn't safe either.** The adapter accepts any feed an admin configures. A misconfigured low-quality feed (custom chain, illiquid token) reproduces the attack — Chainlink only protects you when the feed itself is robust.
+
+**Reproduction sketch (test outline, not committed).**
+
+```solidity
+// Activate service with commitments on TNT (P=1) and EVIL (P=1, attacker-controlled pool)
+//   baseline_USD = stakeTNT_op1 * P_TNT + stakeEVIL_attacker * P_EVIL = 100 + 100 = 200
+// Wait one billing interval. Attacker manipulates EVIL pool tick so oracle returns 100x.
+// billSubscription:
+//   cumDelta_op1   = stakeTNT_op1 * interval
+//   cumDelta_attacker = stakeEVIL_attacker * interval, oracle.toUSD inflates 100x
+//   weights[attacker] / totalWeight ≈ 100/(100+1) ≈ 0.99
+// Expected: attacker receives ~99% of (operatorBps + stakerBps) * nominalRate / 10_000.
+// assertGt(rewardsTransferredTo(attacker), 0.95 * nominalRate * 0.5);
+```
+
+**Mitigation options (informational, not required by this audit):**
+1. Cap per-operator weight contribution to `baseline / activeOperatorCount * K` (some bounded multiple).
+2. USD-normalize weights against the activation-time price (snapshot per-asset USD rate into `_serviceSecurityCommitments` at activation, reuse at bill).
+3. Require oracle adapters to attest to a minimum-liquidity / minimum-TWAP-window precondition before a service binds them.
+4. Reject services whose committed assets aren't backed by a Chainlink feed with an explicit minimum-volume guard.
+
+The cleanest fix is (2): the baseline already snapshots the USD-aggregate; snapshotting the per-(op,asset) USD price too lets `_accrueOperatorWeights` use the activation rate, neutralizing oracle drift entirely.
+
+### M-1 — Oracle revert during billing bricks all subscription bills for the configured assets
+
+**Severity: MEDIUM** (griefing — denial of billing, no fund loss).
+
+**Location:** `src/core/PaymentsBilling.sol` lines 296, 323; `src/core/PaymentsDistribution.sol` lines 127, 141.
+
+`oracle.toUSD(token, contribution)` is called inside `_accrueOperatorWeights` and `_initSubscriptionBaseline` without try/catch. Failure modes that surface here:
+
+- `ChainlinkOracle._getPriceData` reverts on `SequencerDown`, `StalePrice_Sequencer`, `StaleRound`, `InvalidPrice`, `StalePrice`, `TokenNotSupported`. (Note: the staleness check is timestamp-based with `block.timestamp - updatedAt > maxAge`. A sequencer outage right after a downward feed update will both stale the price and block any new updates.)
+- `UniswapV3Oracle._getPriceData` reverts on `TokenNotSupported`, `PriceNotAvailable` (no quote feed), `InvalidPrice`, `StalePrice` of the quote feed, and propagates `observe()` reverts when the pool's `observationCardinality` is insufficient or the requested `secondsAgo` predates the oldest observation.
+
+Any such revert bubbles up through `billSubscription` and stops the keeper from drawing periods. The TTL clock keeps running. `terminateServiceForNonPayment` requires `balance < rate`, which can't be checked because the bill can't be computed — operators can't recover their dues.
+
+This is intentional fail-closed behavior for the baseline at activation (you don't want to mis-price a long-running contract). But on the hot path, the same fail-closed semantics turn an oracle outage into a service-wide payment freeze with no graceful degradation.
+
+Observed mitigations already present:
+- `_resolveBillAdjustmentBps` uses a gas-capped staticcall with fail-closed fallback (`uint16(BPS_DENOMINATOR)`).
+- `_isBillable` (in `PaymentsRewards.sol`) lets keepers off-chain filter; it doesn't call the oracle, but a real bill will revert.
+
+The fix shape would be: in `_accrueOperatorWeights`, fall back to raw token-second weighting (skip USD normalization) when `oracle.toUSD` reverts, and emit an event flagging the affected service. Bills then continue in degraded-fairness mode rather than freezing entirely. Worth pricing the tradeoff: degraded-fairness gives an oracle-dependent service a "free pass" during outages, which is itself partially exploitable.
+
+### M-2 — `DelegationStorage` virtual offset (`Vs=1e8, Va=1`) gives the first depositor 10^8 shares per wei
+
+**Severity: MEDIUM** (no fund loss given the absence of donation surfaces — see below — but the constant choice is unusual and worth documenting).
+
+**Location:** `src/staking/DelegationStorage.sol` lines 27–28; consumed in `src/staking/DelegationManagerLib.sol::_amountToShares` line 74 and `_sharesToAmount` line 96.
+
+The standard OpenZeppelin ERC4626 inflation defense uses asymmetric `Vs = 10**decimalsOffset, Va = 1`. With `Vs = 1e8`, the first delegator of 1 wei mints `1 * (0 + 1e8) / (0 + 1) = 1e8` shares. With `Vs = 1e3, Va = 1e3` (used by `ValidatorPodManager` line 40 and `LiquidDelegationVault` line 28), the first depositor of 1 wei mints 1 share.
+
+The standard inflation attack requires the attacker to *donate* to `totalAssets` after the initial deposit, so subsequent deposits round to zero shares. I traced every writer of `_rewardPools[op][h].totalAssets` and `_blueprintPools[op][bp][h].totalAssets` (`grep -rn "totalAssets\\s*+=" src/staking/`):
+
+- `RewardsManager.sol` line 131: `pool.totalAssets += amount;` — paired with `pool.totalShares += shares` (same function)
+- `RewardsManager.sol` line 181: same, in `_updateFixedModePools` — paired with `pool.totalShares += sharesForBlueprint`
+- `DelegationManagerLib.sol` line 336: same, in `_setBlueprintShares` — paired with adjacent `pool.totalShares` mutation
+
+Every `totalAssets` increment is paired with a matching `totalShares` mint. There is no `receive()` / `fallback()` / standalone rewards-into-pool donation path, and bill distribution goes to `_pendingRewards`, not to `_rewardPools.totalAssets`. So the donation step of the inflation attack is closed.
+
+The high `Vs` is therefore harmless under the current architecture but:
+1. Creates large share-count outputs that are surprising (1 wei → 1e8 shares).
+2. Diverges from the convention used in the sibling share-pools (`VPM`, `LDV` use 1e3/1e3).
+3. Is fragile to future changes: if any future code path were to write to `_rewardPools[*].totalAssets` without minting matching shares (e.g. a rewards-folder, a slash-refund, an admin top-up), the asymmetry resurfaces immediately as a real inflation vector.
+
+Suggested follow-up: align `DelegationStorage` to `Vs = 10**N, Va = 1` per OZ's recommendation with `N` ≥ the decimal mismatch you want to absorb (OZ defaults to `N = 6` in ERC4626 for 18-decimal assets), and document the choice in a comment that references the donation-surface invariant.
+
+### M-3 — Stake-ramp at `periodEnd - ε` lets an operator capture an outsized slice of the same-period bill
+
+**Severity: MEDIUM** (distributional, not extractive against the customer).
+
+**Location:** `src/staking/DelegationStorage.sol::_accrueStakeSecondsRaw` lines 378–392; `src/core/PaymentsBilling.sol::_projectToPeriodEnd` lines 394–402.
+
+**Math trace.**
+Suppose operator A holds a small stake `s_A` since the period start. At `t = periodEnd - 1`, A delegates an additional `S >> s_A`. The accrual at delegation time folds `[lastUpdate, periodEnd - 1]` at `s_A` (the pre-ramp stake), then mutates the underlying stake to `s_A + S`.
+
+At `t > periodEnd` the bill is called. `getCumStakeSeconds(A)` returns
+```
+cum_now = cum_lastUpdate_at_periodEnd-1
+        + (t - (periodEnd - 1)) * (s_A + S)
+```
+`_projectToPeriodEnd` subtracts `(s_A + S) * (t - periodEnd)`. Result:
+```
+cum_atPeriodEnd ≈ cum_lastUpdate
+                + ((periodEnd-1) - lastUpdate) * s_A  (pre-ramp area)
+                + 1 * (s_A + S)                       (the 1-second ramp window)
+```
+So A's contribution to `cumDelta_period` includes a full `S × 1 s` block.
+
+If `S` is large enough, A's `weights[A]` dominates `totalWeight` even with one second of stake. Bill amount is still cap-bounded; but A captures ~all of `operatorPool + stakerPool`.
+
+**Capital cost.** A must lock `S` for the unstake delay (`delegationBondLessDelay` rounds in `OperatorManager.sol` line 173). For one bill, capital cost = `S * rate_alt * delay`. Profit = `(operatorBps + stakerBps) * nominalRate / 10000`. Profitability requires `nominalRate * 0.5 > S * rate_alt * delay` — only practical against high-rate, low-liquidity services or when the attacker is already a multi-period participant amortizing the lock.
+
+**Why this is not CRITICAL.**
+- The cap bounds total harm to `(operatorBps + stakerBps) * nominalRate * billsPerLockPeriod`.
+- The attacker pays in real, slashable capital — under-collateralizing them isn't free.
+- The semantics ("more time-weighted stake → more share") are the design intent.
+
+**Why it's still worth flagging.**
+The intent of TWAP-fair weighting is to reward stable, real backing — not to reward last-second deposits that ride a single second of cum-stake-seconds into a dominating weight. Two fixes would tighten this without breaking TWAP:
+1. Cap `opDeltaRaw_i / cumDeltaPeriod` at a multiple of the operator's baseline-time share at activation.
+2. Use a longer accrual window (multi-period EMA) for billing weights rather than within-period instantaneous projection.
+
+### L-1 — Uniswap V3 oracle accepts arbitrary admin-configured pools without minimum-liquidity / cardinality guards
+
+**Severity: LOW** (informational — pricing trust is delegated to the admin).
+
+**Location:** `src/oracles/UniswapV3Oracle.sol::configurePool` lines 208–235.
+
+The contract's own comment (lines 42–56) acknowledges the requirement: "verify it has sufficient liquidity. Recommended minimum: $1M TVL." None of this is enforced on-chain. `configurePool` checks that the pool exists and the token is in it, then trusts the admin. The pool's `observationCardinalityNext` is not asserted to be ≥ `twapPeriod / 12`. A pool with cardinality 1 will revert on `observe(secondsAgos=[twapPeriod, 0])` and brick price queries (which feeds back into M-1's denial path).
+
+Suggested follow-up: enforce a minimum `observationCardinality` and a minimum `liquidity` at config time, or at least surface a non-reverting view that callers can check before relying on the feed.
+
+### L-2 — `_resolveBillAdjustmentBps` `staticcall` lacks return-data length sanity beyond `< 32`
+
+**Severity: LOW** (informational).
+
+**Location:** `src/core/PaymentsBilling.sol::_resolveBillAdjustmentBps` lines 369–388.
+
+`abi.decode(ret, (uint256))` on a return blob ≥ 32 bytes will succeed for any malformed payload, and the result is then clamped at 10_000. The clamp closes the only attack vector (manager-side inflation of the bill), so this is purely an observation: malformed returns are silently accepted as "the manager wants no discount." Fine. Worth keeping in mind that any future use of manager-returned `bytes` over 32 bytes (e.g. for multi-field returns) would need explicit length checks.
+
+### I-1 — Slash idempotence is sound; recording the slashed amount is non-replayable
+
+**Severity: INFORMATIONAL** (clean check).
+
+**Location:** `src/libraries/SlashingLib.sol` lines 338–370; `src/core/Slashing.sol` lines 249–285, 293–336.
+
+`markExecuted` re-checks `isExecutable(proposal)` (lines 363–365), which returns `false` once `proposal.status == SlashStatus.Executed`. The status flip happens *before* `emit SlashExecuted` and well before the external transfer in `_settleDisputeBond`. Reentrancy via the manager `onSlash` hook is blocked at the higher level by `nonReentrant` on `executeSlash` and `executeSlashBatch`. A replay attempt against the same `slashId` reverts with `SlashNotExecutable`. Confirmed.
+
+### I-2 — Cum-stake-seconds overflow is unreachable at realistic scales
+
+**Severity: INFORMATIONAL** (clean check).
+
+**Location:** `src/staking/DelegationStorage.sol::_accrueStakeSecondsRaw` lines 378–392; comment at lines 471–474.
+
+Worst-case bound: a 1B-token operator with 18-decimal precision (`stake = 1e27` wei) accruing for 1000 years (`~3.15e10` seconds) yields `stake * dt ≈ 3.15e37`. Even multiplied by `exposureBps ≤ 1e4` and oracle conversion at `1e18` USD-precision (USD value ~1e9 dollars / 1e30 stake-seconds-USD), the product fits in `uint256` (`< 2^256 ≈ 1.16e77`). The downstream `twapBillAmount` adds an explicit overflow check on `nominalRate * cumDeltaPeriod` (lines 114–118 of `PaymentLib.sol`) for safety. No realistic overflow path.
+
+## Clean checks (with evidence)
+
+1. **Cap-at-nominal protects the customer.** `_billSubscriptionImpl` line 145: `if (amount > nominalRate) amount = nominalRate;` runs after `twapBillAmount` and before QoS adjustment. QoS can only discount (`applyQosAdjustment` floors at `qosBps < 10_000`). Manager hook return values above `10_000` are clamped. The customer's per-period draw is bounded by `nominalRate` regardless of oracle, weight, or hook behavior.
+2. **Baseline pin enforces single-snapshot pricing.** `_initSubscriptionBaseline` is called exactly once at activation (line 30 of `TanglePaymentsDistributionFacet.sol`). `_billSubscriptionImpl` line 133 reverts if `subscriptionBaselineStake == 0`, blocking a stake-ramp attacker from gaming first-bill state by activating via a non-canonical path. The pin is stored in `escrow.subscriptionBaselineStake` and never overwritten.
+3. **Share-pool rounding always favors the protocol.** All four conversion functions in `ValidatorPodManager` (lines 326, 331, 365, 370) and both in `LiquidDelegationVault` (lines 147, 156) use `Math.Rounding.Floor`. `DelegationManagerLib._amountToShares` / `_sharesToAmount` use raw `*`/`/` which floor in Solidity 0.8. Verified across deposit and withdraw paths; no path uses ceiling rounding that would give the depositor extra shares or extra assets.
+4. **No donation surface into `_rewardPools` or `_blueprintPools`.** Every `pool.totalAssets +=` writer pairs with `pool.totalShares +=` (RewardsManager 117–139, 143–190; DelegationManagerLib 327–342). No `receive()` / `fallback()` / standalone admin top-up. `_pendingRewards` is the bill destination, not the pool. The classic ERC4626 inflation attack requires a donation surface; absent here.
+5. **No donation surface into `ValidatorPodManager` pools.** `BeaconPool.totalAssets` only moves via `recordBeaconChainDeposit` (pod-only, mints shares) and `recordBeaconChainRebase` (pod-only, requires real beacon-chain proof through `ValidatorPod._finalizeCheckpoint`). `DelegationPool.totalAssets` only moves via `delegateTo` (mints shares), `completeUndelegation` (burns shares), and `_slash` (decrement only). No bare donation.
+6. **Slash re-execution is blocked.** See I-1.
+7. **VPM `getCumStakeSeconds` returns zeros.** `src/beacon/ValidatorPodManager.sol` lines 969–979: returns `(0, 0, getOperatorStakeForAsset(...))`. A subscription wired to VPM as its `_staking` adapter degrades to `cumDelta = 0` → bill = 0 (zero-stake-seconds path). Bills emit but draw nothing, which is the intended degraded behavior — VPM isn't designed to be the billing adapter today.
+8. **TWAP cum-stake-seconds overflow.** See I-2.
+9. **`twapBillAmount` overflow detection.** `PaymentLib.sol` lines 114–118: explicit divide-back identity check, reverts with typed `BillingArithmeticOverflow`. Won't panic the EVM on a 0x11.
+10. **Front-running of `billSubscription` only redirects the keeper rebate to the caller, never inflates it.** The keeper rebate is `amount * keeperBps / 10_000` of the (capped) bill. A keeper cannot manipulate `amount` upward because of the cap. The "keeper sandwich" (deposit→bill→undelegate) requires the keeper to be an operator who can ramp; this collapses into M-3.
+
+## Method
+
+1. Read every file in `src/core/`, `src/oracles/`, `src/staking/`, `src/beacon/` touching billing, weighting, distribution, slashing, or share-pool conversion.
+2. Traced every state writer of `_rewardPools[*].totalAssets`, `_blueprintPools[*].totalAssets`, `_operatorDelegationPools[*].totalAssets`, `_pools[*].totalAssets` to confirm the donation surface is closed.
+3. Walked `_accrueOperatorWeights` symbolically with three adversary models: oracle-manipulator (H-1), stake-ramper (M-3), front-running keeper (clean check 10).
+4. Walked `_initSubscriptionBaseline` to confirm cap-at-nominal denominator is pinned (clean check 2).
+5. Walked `markExecuted` / `isExecutable` / `executeSlash` to confirm idempotence (I-1).
+6. Bounded cum-stake-seconds growth at adversarial scales (I-2).
+7. Compared virtual-offset constants across `DelegationStorage` (`1e8 / 1`), `VPM` (`1e3 / 1e3`), `LDV` (`1e3 / 1e3`) and verified no donation surface (M-2).
+
+## Top 3
+
+1. **H-1** — Oracle-manipulated weight inflation lets one operator capture the operator/staker pool share of a (capped) bill. Customer is safe; honest operators are not. Fix shape: snapshot per-(op,asset) USD price at activation and reuse at bill, neutralizing oracle drift inside the operator-share split.
+2. **M-1** — Oracle revert during billing bricks the period. No fund loss, but a misadministered or stalled feed denies billing service-wide.
+3. **M-3** — Stake-ramp at `periodEnd - ε` lets an operator dominate within-period TWAP weight despite only one second of high stake. Rate-limited by the unstake-delay capital cost.

--- a/docs/audits/REDTEAM-REENTRANCY-GRIEFING-2026-05-16.md
+++ b/docs/audits/REDTEAM-REENTRANCY-GRIEFING-2026-05-16.md
@@ -1,0 +1,441 @@
+# Red-team audit: reentrancy + griefing — 2026-05-16
+
+Scope: reentrancy posture on token-moving paths, cross-facet self-call
+soundness, ERC20 transfer griefing, push-vs-pull patterns, slashing
+spam, subscription billing livelock.
+
+Method: read-only trace of every external entry point that moves value
+or hits a BSM hook, plus the diamond router and OpenZeppelin
+ReentrancyGuard storage layout to confirm shared-state semantics across
+facets.
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 0 |
+| Medium | 3 |
+| Low | 2 |
+| Informational | 1 |
+
+No critical or high-severity issues. Reentrancy guards are correctly
+placed and share a single ERC-7201 namespaced slot across every facet
+in the diamond (`0x9b779b…5f00`), so the cross-facet self-call pattern
+used by subscription billing, payment distribution, and `claimRewardsAll`
+all run under the outer caller's guard. All operator and keeper
+payments route through `_pendingRewards` (pull) — a malicious
+contract-operator cannot brick a distribution by reverting on receive.
+
+The three medium findings cluster around the same underlying gap:
+**push transfers in `_distributeBill` to admin-/dev-controlled recipients
+(developer, treasury, escrow withdrawer) are not isolated by
+try/catch**, mirroring the gap that PR #136 closed for the rewards
+sweep. They are griefing surfaces, not loss-of-funds bugs, but they let
+a misconfigured manager / treasury / token brick a payment path until
+the misconfiguration is corrected — which is sometimes outside the
+griefed party's reach.
+
+## Findings
+
+### M-1: `_distributeBill` push transfers can be permanently griefed by a malicious BSM-resolved developer recipient
+
+**Where**
+- `src/core/PaymentsDistribution.sol:209` (`PaymentLib.transferPayment(developerAddr, ...)`)
+- Recipient resolved by `_resolveDeveloperPaymentAddress` (`PaymentsDistribution.sol:364`),
+  which calls `IBlueprintServiceManager.queryDeveloperPaymentAddress` over a
+  gas-bounded staticcall.
+
+**What**
+The developer share is pushed via `PaymentLib.transferPayment`, which
+reverts on transfer failure (`call{value:}` returns false, or
+`safeTransfer` reverts). The recipient is whatever the manager hook
+returns; on revert / zero / empty return it falls back to
+`blueprint.owner`. The hook return value is not bounded, validated, or
+isolated by try/catch.
+
+A BSM whose upgrade authority is compromised (or whose original
+developer turns adversarial) can return a contract that always reverts
+on receive. Every non-subscription distribution for that blueprint —
+job results, RFQ executions, quote-accept, service activation pay-once
+— will revert at the developer-transfer line. Operators are blocked
+from collecting per-job payment. For subscription services the only
+escape is `terminateServiceForNonPayment` after the manager-resolved
+grace window, after which the customer recovers escrow via
+`withdrawRemainingEscrow` but operators are not paid for the
+period(s) already due.
+
+The dev share is funded from the customer's payment, so the BSM
+attacker burns their own slice of revenue to grief; this caps the
+incentive but does not eliminate it (the attack is free for the
+manager owner if the original developer share is small relative to
+the harm).
+
+**Impact** MEDIUM. Liveness loss on every payment path through
+`_distributeBill` for one blueprint. No funds lost (revert is atomic),
+but a manager-upgrade scenario can persistently brick payment for the
+operators on that blueprint.
+
+**Reproducer (sketch)**
+1. Deploy a blueprint with an upgradeable BSM.
+2. Operate normally until the blueprint has services + escrow.
+3. Upgrade the BSM to one whose `queryDeveloperPaymentAddress` returns
+   `address(rejecter)` where `rejecter.receive()` always reverts.
+4. Every subsequent `submitResult`, RFQ execute, quote-accept,
+   activation, or subscription bill reverts at the developer-transfer
+   step.
+
+**Fix**
+Wrap the developer push in try/catch the same way `_forwardStakerShare`
+already isolates the staker pool. On failure, refund the
+griefed share to the service escrow (subscription) or fold it into the
+operator pool (one-shot), and emit a marker event. The
+`_refundStakerShareToEscrow` helper is already the right shape — apply
+the same pattern at line 209.
+
+### M-2: `withdrawRemainingEscrow` has no admin / customer fallback when the escrow token is broken
+
+**Where** `src/core/PaymentsEscrow.sol:46`
+
+**What**
+`withdrawRemainingEscrow` zeros `escrow.balance` and bumps
+`totalReleased`, then calls `PaymentLib.transferPayment` which reverts
+on failure. If the escrow token becomes globally broken (e.g. a
+centrally-administered token is paused, the customer is blocklisted,
+or the token's `transfer` developers a bug post-deposit) the customer's
+funded escrow is permanently stuck. There is no admin rescue path in
+the payments subsystem (the staking module has `rescueTokens` but only
+for non-registered assets — escrow tokens are not staking-registered).
+
+Symmetric to `claimRewardsAll`'s griefing channel that PR #136 closed
+for operator rewards.
+
+**Impact** MEDIUM. Loss of access to funds (not loss of funds — the
+balance remains in the contract). Recovery requires a UUPS upgrade to
+add a force-rescue path.
+
+**Reproducer (sketch)**
+1. Customer funds a service with `BadToken` (centrally paused / can
+   blocklist).
+2. Service terminates normally.
+3. Token issuer pauses transfers (or blocklists the service owner).
+4. `withdrawRemainingEscrow` reverts forever.
+
+**Fix**
+Either:
+- Add a per-service admin-rescue path (`onlyRole(ADMIN_ROLE)`) that
+  forwards stuck escrow to the service owner via the same
+  permissionless path, isolated by try/catch and with a marker event,
+  OR
+- Allow the service owner to designate an alternate recipient for the
+  refund (parameterize `withdrawRemainingEscrow(uint64 serviceId,
+  address payable to)` with owner-only auth on `to`), so a blocklisted
+  owner can route to a fresh address.
+
+### M-3: `getNonPaymentTerminationPolicy` is invoked without a gas cap, letting a malicious BSM grief the livelock-escape path
+
+**Where** `src/core/ServicesLifecycle.sol:103`
+
+**What**
+`terminateServiceForNonPayment` is the documented livelock-escape for
+subscription billing: when an operator-side issue or BSM griefing
+freezes the schedule, anyone can terminate after a grace window
+resolved by the BSM's `getNonPaymentTerminationPolicy` hook. The
+resolver uses Solidity's `try/catch`, which does NOT impose a gas cap
+— Solidity forwards 63/64 of the available gas, and the 1/64 reserved
+gas may be insufficient to complete the post-call work
+(`_terminateService` loops over operators, decrements counters,
+deregisters from the heartbeat registry).
+
+A BSM whose `getNonPaymentTerminationPolicy` body burns through all
+forwarded gas turns the escape path into a gas-eating black hole.
+Off-chain keepers can compensate by sending more gas, but it raises
+the cost of the escape — and the protocol elsewhere bounds BSM hooks
+to 500k gas via `MANAGER_HOOK_GAS_LIMIT` and a raw staticcall
+(`_resolveBillAdjustmentBps` is the canonical pattern).
+
+Same hygiene gap applies to:
+- `querySlashingOrigin` at `Slashing.sol:59` (alternate authorization
+  path for `proposeSlash`; bounded blast radius because service-owner
+  / blueprint-owner are independent authorization paths).
+- `getHeartbeatInterval` / `getHeartbeatThreshold` at `Base.sol:613`
+  and `:622` (called during `_configureHeartbeat` from activation;
+  failure modes degrade to defaults but a BSM gas burn can still
+  delay activation).
+
+**Impact** MEDIUM for `getNonPaymentTerminationPolicy` because it sits
+on the only livelock escape; LOW for the heartbeat hooks; LOW for
+`querySlashingOrigin` because two other authorization paths exist.
+
+**Reproducer (sketch)**
+1. BSM implements `getNonPaymentTerminationPolicy(serviceId)` with a
+   `while (gasleft() > 1000) { sha256(...) }` body.
+2. Service stops being billed, grace elapses.
+3. Keeper calls `terminateServiceForNonPayment(serviceId)` with the
+   usual gas budget.
+4. The hook burns the budget; the catch block runs but the loop in
+   `_terminateService` runs out of gas.
+
+**Fix**
+Replace the `try / catch` invocations of view hooks with the
+gas-bounded raw-staticcall pattern already used by
+`_resolveBillAdjustmentBps` and `_resolveDeveloperPaymentAddress`.
+Capped to `MANAGER_HOOK_GAS_LIMIT` (500k), with revert / empty / wrong
+returndata falling back to the default. This is mechanical: every
+view-hook resolver should look like `manager.staticcall{ gas:
+MANAGER_HOOK_GAS_LIMIT }(...)` and `abi.decode` the return data only
+on the success path.
+
+### L-1: `_settleDisputeBond` strands the dispute bond when the treasury push fails after a slash executes
+
+**Where** `src/core/Slashing.sol:475` (`_settleDisputeBond`, in the
+`refund == false` branch)
+
+**What**
+On `executeSlash` / `executeSlashBatch`, the disputer's bond is
+forwarded to the treasury via `t.call{value: bond}("")`. On failure
+the function restores `proposal.disputeBond` and `proposal.disputer`,
+but by this point the proposal has already been `markExecuted`'d. No
+admin re-settle path reads `proposal.disputeBond` for executed
+proposals, so the bond is stuck on the proposal struct until a UUPS
+upgrade or a manual rescue.
+
+Realistic only if the treasury is misconfigured (contract without
+payable fallback, or a multisig whose receiver logic reverts). The
+`setTreasury` admin path lets ops correct the misconfiguration, but
+already-executed proposals remain unsettled.
+
+**Impact** LOW. Stuck native asset; recovery requires either an admin
+re-settle path or a UUPS upgrade.
+
+**Fix**
+Add an admin-callable re-settle helper that re-runs `_settleDisputeBond`
+for executed proposals whose `disputeBond > 0`. Alternatively, on push
+failure during execute, fall through to a `_pendingDisputeBondRefunds`
+pull credit for the treasury so the existing claim path drains it.
+
+### L-2: `_operatorActiveSlashProposals` cap check ordering is inverted in `proposeSlash`
+
+**Where** `src/core/Slashing.sol:93`
+
+**What**
+The pending-slash cap check (`_operatorActiveSlashProposals[operator]
+>= maxPendingSlashesPerOperator`) runs AFTER
+`SlashingLib.proposeSlash` has already allocated `slashId`, written
+the proposal struct, and emitted `SlashProposed`. The revert at line
+94 correctly rolls everything back, but the call burns gas unnecessarily
+and emits a misleading event-then-revert pattern that off-chain
+indexers may interpret as a successful propose followed by a separate
+cap event.
+
+**Impact** LOW. No state corruption — EVM revert rolls back all writes
+and emits. Cosmetic ordering issue; minor wasted gas.
+
+**Fix**
+Move the cap check (and the `_operatorActiveSlashProposals[operator]
++= 1` increment that pairs with it) above the `SlashingLib.proposeSlash`
+call so the cap fires before any other state mutation.
+
+### I-1: `_claimRewardsTokenSafe` self-call is correctly NOT `nonReentrant`, confirmed by trace
+
+**Where** `src/core/PaymentsRewards.sol:85`
+
+**What** (clarification, not a finding)
+`claimRewardsAll` holds the outer `nonReentrant` guard for the whole
+sweep. Per-token execution self-calls
+`this._claimRewardsTokenSafe(account, token)`, which goes external
+(diamond proxy receives, dispatches to the rewards facet via
+delegatecall). The inner function deliberately omits `nonReentrant`
+because the OpenZeppelin guard's storage slot is the ERC-7201 namespaced
+slot at `0x9b779b…5f00`, which is read/written under the proxy's
+delegatecall context and therefore SHARED across facets. The outer
+guard is `ENTERED` at the moment the self-call lands. If the inner
+function were `nonReentrant` it would revert on every token. If a
+token transfer inside the inner self-call attempted to re-enter
+`claimRewardsAll`, the outer guard would block it (defense-in-depth).
+
+This is correct and the audit confirms it. The same reasoning applies
+to `distributePayment`, `distributeBillWithKeeper`, `depositToEscrow`,
+and `initSubscriptionBaseline` — all self-call entry points
+intentionally omit `nonReentrant` and gate on `msg.sender ==
+address(this)` as the first check, before any state read.
+
+## Clean checks
+
+The following items were traced end-to-end and confirmed clean:
+
+- **All token-moving external entry points hold `nonReentrant`.**
+  Verified: `fundService`, `withdrawRemainingEscrow`,
+  `billSubscription`, `billSubscriptionBatch`, `claimRewards()`,
+  `claimRewards(address)`, `claimRewardsBatch`, `claimRewardsAll`,
+  `proposeSlash`, `disputeSlash`, `executeSlash`, `executeSlashBatch`,
+  `cancelSlash`, `claimDisputeBond`, `submitJob`, `submitResult`,
+  `submitResults`, all aggregation / RFQ / quote / quote-extension /
+  service-activation / join / exit entry points,
+  `registerOperator` (both variants), `unregisterOperator`,
+  `terminateService`, `terminateServiceForNonPayment`, `joinService`,
+  `joinServiceWithCommitments`, `scheduleExit`, `executeExit`,
+  `cancelExit`, `forceExit`, `leaveService`, `forceRemoveOperator`.
+
+- **Cross-facet self-call reentrancy posture.** The OpenZeppelin
+  `ReentrancyGuardUpgradeable` v5.1.0 stores its `_status` flag at the
+  ERC-7201 slot
+  `keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ReentrancyGuard"))
+  - 1)) & ~bytes32(uint256(0xff))` — a fixed,
+  inheritance-position-independent location. Every facet in the
+  diamond inherits `Base → ReentrancyGuardUpgradeable`, and all
+  delegatecalls from the diamond router operate on the proxy's
+  storage, so the guard is genuinely shared. Self-calls from one facet
+  to another go through `address(this).call(...)`, which lands at the
+  proxy's fallback and delegatecalls into the target facet under the
+  same storage context. Verified by reading the OZ implementation,
+  `FacetRouterBase._delegateTo`, and confirming `Base.__Base_init`
+  calls `__ReentrancyGuard_init()` exactly once at proxy
+  initialization.
+
+- **Self-call gates fire before any state read or external call.**
+  `distributePayment`, `depositToEscrow`, `initSubscriptionBaseline`,
+  `distributeBillWithKeeper`, `_claimRewardsTokenSafe`: each begins
+  with `if (msg.sender != address(this)) revert Errors.Unauthorized();`
+  as the very first statement.
+
+- **Operator payments are pull, not push.** `_distributeBill` credits
+  per-operator amounts to `_pendingRewards[operator][token]` via
+  `PaymentLib.addPendingReward` and tracks the token via
+  `_pendingRewardTokens[operator].add(token)`. Operators claim later
+  via `claimRewards*`. A contract-operator that reverts on receive
+  cannot force-fail the distribution. Confirmed by reading
+  `PaymentsDistribution._payOperatorPoolByWeight:283-294`.
+
+- **Keeper rebate is pull.** Same pattern at
+  `PaymentsDistribution._distributeBill:229-233`.
+
+- **CEI ordering in token-moving paths.**
+  - `withdrawRemainingEscrow`: zeros `escrow.balance`, bumps
+    `totalReleased`, THEN transfers (`PaymentsEscrow.sol:60-63`).
+  - `claimPendingReward`: reads amount, zeros pending entry, THEN
+    transfers (`PaymentLib.sol:351-364`).
+  - `claimDisputeBond`: reads amount, zeros pending entry, THEN
+    transfers; restores on transfer failure (`Slashing.sol:521-534`).
+  - `_settleDisputeBond` (refund branch): zeros
+    `proposal.disputeBond` and `proposal.disputer` BEFORE any
+    interaction (`Slashing.sol:481-483`).
+  - `executeSlash`: every state mutation
+    (`markExecuted`, `decrementPendingSlash`,
+    `_decrementOperatorPendingTracker`, `_recordSlash`) finalizes
+    before `_settleDisputeBond` does the push.
+
+- **`_forwardStakerShare` refund accounting is correct.** The function
+  pushes ERC20 to the distributor BEFORE the staking-distributor call
+  for ERC20 (so a revert leaves tokens at the distributor; the
+  `StakerShareRefundedToEscrow` event marks it for off-chain
+  resolution), and uses value-on-call for native (rolled back on
+  revert, refunded to escrow). The escrow refund path
+  (`_refundStakerShareToEscrow`) increments `escrow.balance += amount`
+  and decrements `escrow.totalReleased` saturating at zero. The
+  symmetry with `releaseFromEscrow` is exact when
+  `escrow.totalReleased >= amount`; the saturation case can only
+  happen when the staker share to refund exceeds the lifetime release
+  count, which is structurally impossible (the release is in the
+  same `_distributeBill` invocation that produced this refund branch,
+  so `totalReleased` is at least `d.amount > stakerShare`). Verified
+  at `PaymentsDistribution.sol:339-360`.
+
+- **Manager hook gas bounding (correct sites).**
+  `_resolveBillAdjustmentBps` (`PaymentsBilling.sol:381`),
+  `_resolveDeveloperPaymentAddress` (`PaymentsDistribution.sol:374`),
+  `_callManager` (`Base.sol:730`), `_tryCallManager` (`Base.sol:743`):
+  all use `manager.staticcall{ gas: MANAGER_HOOK_GAS_LIMIT }(...)` or
+  `manager.call{ gas: MANAGER_HOOK_GAS_LIMIT }(...)`. The
+  `_isPaymentAssetAllowedByManager` helper does NOT bound gas but is
+  read-only with a single boolean return and is invoked from
+  `try/catch`; failure denies the token. Acceptable. The hooks that
+  lack the bound are listed in M-3.
+
+- **`fundService` ingress validation.** Re-checks (a) service active,
+  (b) subscription pricing, (c) not TTL-expired, (d) manager still
+  whitelists token. `depositToEscrow → collectPayment` rejects
+  fee-on-transfer / rebasing tokens via the
+  `balanceAfter - balanceBefore` check, rejects native value with
+  ERC20 payments, and requires exact `msg.value` for native. CEI:
+  collect THEN credit. Verified at `PaymentsEscrow.sol:19-43` and
+  `PaymentLib.sol:211-249`.
+
+- **Slashing spam cap.** `_operatorActiveSlashProposals` is bounded by
+  `_slashState.config.maxPendingSlashesPerOperator` (default 32, never
+  zero per `initializeConfig` and `updateConfig` validation). Past 32,
+  `proposeSlash` reverts. Counter is decremented in `executeSlash`,
+  `executeSlashBatch`, and `cancelSlash` paths via
+  `_decrementOperatorPendingTracker`. Verified at
+  `Slashing.sol:541-544` and `SlashingLib.sol:155-185`. Ordering is
+  suboptimal (L-2) but correctness holds.
+
+- **Subscription billing livelock paths considered.** The bill schedule
+  advances `lastPaymentAt` by exactly one `interval` per processed
+  period. The cursor advances unconditionally on:
+  - Zero active operators (`PaymentsBilling.sol:116-120`,
+    `SubscriptionBillSkippedNoOperators`).
+  - Bill rounds to zero (`PaymentsBilling.sol:177-180`).
+  - Skip-on-dust below `minBillAmount` (`PaymentsBilling.sol:171-175`).
+  - Successful bill with manager QoS discount applied
+    (`PaymentsBilling.sol:147-154`).
+  The cursor does NOT advance on insufficient escrow
+  (`PaymentsBilling.sol:159-162`), so an underfunded service stays
+  stuck on the same period — recovery is either top-up
+  (`fundService`) or `terminateServiceForNonPayment` after grace.
+  Findings M-1 and M-3 are the only ways to permanently brick advance:
+  a malicious developer recipient (M-1) makes the distribute step
+  revert, which keeps the cursor un-committed; a malicious BSM
+  termination-policy hook (M-3) makes the escape itself griefable.
+  Both have mechanical fixes; neither corrupts state.
+
+- **No path calls `distributePayment` with a forged operators array.**
+  All eight call sites (`TangleJobsFacet` ×2, `TangleQuotesFacet`,
+  `TangleJobsRFQFacet`, `TangleJobsAggregationFacet` ×2,
+  `TangleQuotesExtensionFacet`, `TangleServicesFacet`) construct
+  `operators` from `_serviceOperatorSet[serviceId].values()` or
+  `_jobQuotedOperators[serviceId][callId].values()` or the
+  request-resolved selection. No path lets a caller smuggle a
+  fabricated address into the array.
+
+- **`_claimRewardsTokenSafe` is registered on the rewards facet.**
+  `TanglePaymentsRewardsFacet.selectors()` includes
+  `this._claimRewardsTokenSafe.selector` at index 13. Without this
+  registration the diamond fallback would revert with
+  "unknown selector" and `claimRewardsAll` would tip every token into
+  the catch block. Verified at
+  `TanglePaymentsRewardsFacet.sol:27`.
+
+## Method
+
+1. Read `Base.sol` to confirm every protocol contract inherits
+   `ReentrancyGuardUpgradeable` exactly once and `__ReentrancyGuard_init`
+   is called at initialization.
+2. Read the OpenZeppelin v5.1.0 `ReentrancyGuardUpgradeable.sol` source
+   to confirm the guard's storage location is ERC-7201 namespaced (not
+   inheritance-position dependent), and therefore shared across facets
+   in the diamond.
+3. Read `FacetRouterBase.sol` to confirm the diamond uses `delegatecall`
+   for all facet dispatch, preserving the proxy's storage context.
+4. Enumerate every external entry point under `src/core/` and
+   `src/facets/tangle/` that moves tokens, calls a BSM hook, or is
+   reachable from a path that does either. For each, verify
+   `nonReentrant`, CEI ordering, and authorization gating.
+5. Trace the self-call surfaces (`distributePayment`,
+   `distributeBillWithKeeper`, `depositToEscrow`,
+   `initSubscriptionBaseline`, `_claimRewardsTokenSafe`) end-to-end:
+   confirm the `msg.sender == address(this)` gate is the first
+   statement, confirm the outer caller holds `nonReentrant`, and
+   confirm the inner does NOT (so the legitimate self-call is not
+   blocked by the same-frame guard).
+6. Enumerate every `manager.call` / `manager.staticcall` /
+   `IBlueprintServiceManager(manager).<fn>` callsite. Confirm gas
+   bounding (`MANAGER_HOOK_GAS_LIMIT`) or document the gap.
+7. Trace the subscription billing flow: identify every cursor-advance
+   site and every revert site, enumerate the adversarial state
+   combinations that could pin `lastPaymentAt`, and confirm the
+   permissionless escape `terminateServiceForNonPayment` cleanly
+   exits.
+8. Audit operator and keeper payment patterns: confirm pull via
+   `_pendingRewards` is the only path used in `_distributeBill` and
+   that no path push-transfers value to operator addresses.

--- a/docs/audits/REDTEAM-STORAGE-UPGRADE-2026-05-16.md
+++ b/docs/audits/REDTEAM-STORAGE-UPGRADE-2026-05-16.md
@@ -1,0 +1,178 @@
+# Red-team audit: storage + UUPS — 2026-05-16
+
+Scope: PRs #132 (subscription billing rearchitecture), #133 (payments facet split + RFQ
+hardening + multi-asset bill weighting), #134 (O(1) operator stake aggregate + VPM
+share-pool slashing), #136 (claimRewardsAll griefing isolation), #137 (bindings regen),
+#138 (indexer events). Audit window: `8b2777b..HEAD` on `main`.
+
+## Summary
+
+| Severity | Count |
+| --- | --- |
+| CRITICAL | 0 |
+| HIGH | 0 |
+| MEDIUM | 0 |
+| LOW | 1 |
+| INFORMATIONAL | 3 |
+
+No upgrade-safety regressions detected. One LOW finding on divergent upgrade-authority
+role between `Base` and `MultiAssetDelegation`. Three informational notes on
+storage-layout reinterpretation and non-proxy "legacy slot preservation" framing.
+
+## Findings
+
+### L-1 — `MultiAssetDelegation._authorizeUpgrade` is gated by `ADMIN_ROLE`, not `UPGRADER_ROLE`
+
+- **Where:** `src/staking/MultiAssetDelegation.sol:116`
+- **What:** `_authorizeUpgrade(address) internal override onlyRole(ADMIN_ROLE) { }`.
+  The contract never defines or grants a separate `UPGRADER_ROLE`. By contrast,
+  `Base.sol:42,177,232` defines `UPGRADER_ROLE = keccak256("UPGRADER_ROLE")` and
+  uses it for `_authorizeUpgrade`. `MBSMRegistry`, `TangleMetrics`,
+  `ServiceFeeDistributor`, `RewardVaults`, `InflationPool`, and
+  `StreamingPaymentManager` all follow the `Base` pattern.
+- **Impact:** Whoever holds `ADMIN_ROLE` on MAD can both administer parameters
+  (commission, asset config, adapter migration, slasher role grants) AND upgrade
+  the implementation. There is no way to delegate upgrade authority to a separate
+  multisig/timelock without also granting day-to-day admin power, which collapses
+  the role-separation that `Base` is structured to enforce.
+- **Reproducer:** Read `_authorizeUpgrade` on the deployed `MultiAssetDelegation`
+  proxy and the role mask of `ADMIN_ROLE`. Compare to `Tangle.UPGRADER_ROLE`. Any
+  account with `ADMIN_ROLE` can call `upgradeToAndCall(maliciousImpl, "")` directly.
+- **Fix:** Mirror `Base`: declare `bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE")`;
+  grant it in `initialize`; switch `_authorizeUpgrade` to `onlyRole(UPGRADER_ROLE)`.
+  Storage-safe (no new slots; role data lives in
+  `AccessControlUpgradeable`'s ERC-7201 storage). Existing deployments need a
+  follow-up admin tx that grants `UPGRADER_ROLE` to the chosen upgrader before
+  any subsequent upgrade.
+
+### INFO-1 — Slot 77 in `TangleStorage` was retyped between #132 and #133 (`_twapCursorByOp` → `_twapCursorByOpAsset`)
+
+- **Where:** `src/TangleStorage.sol:423` (`_twapCursorByOpAsset`).
+- **What:** PR #132 introduced `mapping(uint64 => mapping(address => uint256)) _twapCursorByOp`
+  at slot 77. PR #133 replaced the declaration with
+  `mapping(uint64 => mapping(address => mapping(bytes32 => uint256))) _twapCursorByOpAsset`
+  at the same slot. Mapping root slot is reused; data lives at hashed addresses
+  so the value reads at any (svcId, op) key from the previous declaration are
+  now orphaned (never read by the new code path).
+- **Impact:** Production proxies that were already initialized under #132 and
+  carry attribution data at the old layout would lose that data on upgrade to
+  the #133 layout. Verified the only known live deployment manifest
+  (`deployments/base-sepolia/latest.json`) is from `19887b5` (Tangle v0.10.9),
+  which predates PR #132 — so no production proxy holds `_twapCursorByOp`
+  data. No on-chain impact. Calling out so future deployments do not assume
+  the slot's data type is stable.
+- **Fix (if any prior deployment is later discovered):** Migration script must
+  read the old slot and re-key the data via `_twapCursorByOpAsset[svcId][op][bondAssetHash]`
+  before the first `billSubscription` call.
+
+### INFO-2 — `ValidatorPodManager` "legacy slot preserved as placeholder" is defensive but inapplicable
+
+- **Where:** `src/beacon/ValidatorPodManager.sol:33,99,104,116,119`.
+- **What:** The contract is declared `contract ValidatorPodManager is IStaking, Ownable, ReentrancyGuard`
+  with a `constructor(address, uint256)` (line 275). It is deployed directly by
+  `script/DeployBeaconSlashing.s.sol:168` and `script/LocalTestnet.s.sol:972`
+  with `new ValidatorPodManager(...)` — no proxy, no UUPS, no upgrade path. The
+  comments labelling slots 12/13/15/16 as "legacy slot, retained for layout
+  compatibility" therefore protect against an upgrade vector that does not exist.
+- **Impact:** Zero. The placeholder slots cost one bytes32 each on every new
+  pod-manager deployment and are never read by the live code. Consider this
+  informational hygiene: either (a) document that VPM is intentionally
+  non-upgradeable and remove the preservation comments, or (b) move VPM to a
+  UUPS proxy if storage continuity across versions matters operationally.
+- **Verification of layout claim:** Despite the upgrade path being absent, the
+  layout *is* faithfully preserved: `forge inspect ValidatorPodManager storage-layout`
+  shows the legacy mappings at the same indices they occupied at `8b2777b`
+  (`delegations` → `_legacyDelegations` slot 12, `operatorDelegatedStake` →
+  `_legacyOperatorDelegatedStake` slot 13, `_operatorDelegators` slot 15,
+  `_isDelegator` slot 16). New share-pool state (`_operatorDelegationPools`,
+  `_delegationShares`) is appended at slots 25–26. Public ABI is preserved via
+  explicit `delegations(address,address)` and `operatorDelegatedStake(address)`
+  view functions at L377/L384 of the new file.
+
+### INFO-3 — `DelegationStorage` gap arithmetic verified
+
+- **Where:** `src/staking/DelegationStorage.sol:491,495`.
+- **What:** `_operatorDelegatedAggregate` was appended in PR #134 to back the
+  O(1) `_getOperatorDelegatedStakeForAsset` lookup. The gap was reduced from 44
+  to 43 to absorb the one-slot addition. Pre-existing TWAP cursor and
+  `lastUpdate` slots (`_cumStakeSeconds`, `_cumStakeSecondsLastUpdate`) keep
+  their indices. All other named slots above the gap retain their previous
+  positions.
+- **Impact:** Safe. Aggregate invariant
+  `_operatorDelegatedAggregate[op][h] == _rewardPools[op][h].totalAssets + Σ_bp _blueprintPools[op][bp][h].totalAssets`
+  is the only correctness contract that matters for upgrade — and it lives in
+  contract logic, not storage layout.
+
+## Clean checks
+
+- **TangleStorage slot ordering.** `forge inspect Tangle storage-layout` confirms
+  slot 0 (`_staking`) through slot 77 (`_twapCursorByOpAsset`) match the
+  declaration order in `src/TangleStorage.sol`, including all packed sub-slots
+  (`_treasury`+`_maxBlueprintsPerOperator` packed in slot 1;
+  `_rewardVaults`+`_defaultTntMinExposureBps`+`_deprecatedTntStakerFeeBps`+`_tntPaymentDiscountBps`
+  packed in slot 60; the four uint64 TTL fields packed in slot 66). Gap is
+  `uint256[40]` at slot 78. OZ-Upgradeable parents (`Initializable`,
+  `UUPSUpgradeable`, `PausableUpgradeable`, `ReentrancyGuardUpgradeable`,
+  `AccessControlUpgradeable`) all use ERC-7201 namespaced storage in OZ v5 and
+  therefore do not occupy contiguous slots — `_staking` correctly sits at slot 0.
+- **Payments facet split storage shared via `Base`/`TangleStorage`.** Audited every
+  new and modified mixin (`PaymentsCore`, `PaymentsEscrow`, `PaymentsBilling`,
+  `PaymentsDistribution`, `PaymentsRewards`, `PaymentsEffectiveExposure`,
+  `ServicesApprovalsViews`). None declares any state variable. Mixins that touch
+  protocol state inherit `Base` (which inherits `TangleStorage`), so reads/writes
+  resolve to the same shared slots used by the pre-split `Payments.sol`.
+  `PaymentsEffectiveExposure` is the lone mixin that does *not* inherit `Base`
+  (it only defines `internal virtual` hooks and `EXPOSURE_PRECISION`/`_BPS_DENOM`
+  constants) so it cannot collide.
+- **Facet storage sharing.** `TanglePaymentsFacet` inherits `PaymentsEscrow + PaymentsBilling`,
+  `TanglePaymentsDistributionFacet` inherits `PaymentsDistribution`,
+  `TanglePaymentsRewardsFacet` inherits `PaymentsRewards`,
+  `TangleServicesViewsFacet` inherits `ServicesApprovalsViews`. Each is intended
+  to be `delegatecall`-ed from `Tangle` via `FacetRouterBase._fallbackToFacet`,
+  so their storage view is the proxy's storage — i.e. `TangleStorage`. None
+  declares its own state; the only members are pure `selectors()` functions and
+  pure dispatchers to the parent. No collision risk.
+- **`_disableInitializers` + `initializer` modifier.** Verified across every
+  UUPS contract: `Base` (152), `MultiAssetDelegation` (31),
+  `MBSMRegistry` (90), `L2SlashingReceiver` (127), `TangleMetrics` (138),
+  `ServiceFeeDistributor` (156), `RewardVaults` (195), `InflationPool` (243),
+  `StreamingPaymentManager` (90), `TangleTimelock` (41), `TangleGovernor` (77),
+  `TangleToken` (66). All `initialize` functions carry the `initializer` modifier.
+  All constructors are tagged `@custom:oz-upgrades-unsafe-allow constructor`.
+- **`__gap` declarations.** Enumerated all 12 occurrences:
+  `TangleStorage` 40 (was 41 pre-#132, reduced by 1 for `_twapCursorByOp[Asset]`);
+  `DelegationStorage` 43 (was 44 pre-#134, reduced by 1 for `_operatorDelegatedAggregate`);
+  `MBSMRegistry` 50; rewards/ contracts all 50; cross-chain bridge namespaced
+  structs each carry an internal `uint256[50] __gap`. No bridge changed in the
+  audit window.
+- **External library statelessness.** `AttestationLib`, `ServiceValidationLib`,
+  `PaymentLib`, `SignatureLib`, `SlashingLib`, `SchemaLib` — all declared
+  `library X` with only `internal constant` declarations (no state, no
+  `external` functions on non-`internal` storage). Solc embeds calls to these
+  libraries inline; no `delegatecall` storage hazard exists.
+- **VPM legacy-slot preservation by inspection.** `forge inspect
+  ValidatorPodManager storage-layout` (run under `FOUNDRY_PROFILE=local_build`)
+  confirms slot 12 = `_legacyDelegations`, slot 13 = `_legacyOperatorDelegatedStake`,
+  slot 15 = `_legacyOperatorDelegators`, slot 16 = `_legacyIsDelegator`,
+  slot 25 = `_operatorDelegationPools`, slot 26 = `_delegationShares`. Matches
+  the comments in source.
+- **Upgrade authorization sweep.** Every `_authorizeUpgrade` in the tree gates
+  on `onlyRole(UPGRADER_ROLE)` except `MultiAssetDelegation` (L-1 above) and
+  `L2SlashingReceiver` (intentionally `onlyOwner` because it inherits
+  `OwnableUpgradeable`, not `AccessControl`).
+
+## Method
+
+- `git log --oneline 8b2777b..HEAD -- src/` to enumerate in-scope file changes.
+  Only `ValidatorPodManager.sol` (PR #134), `DelegationStorage.sol` (PR #134),
+  `TangleStorage.sol` (PR #133), `Payments.sol` → split (PR #133),
+  `core/Payments{Core,Escrow,Billing,Distribution,Rewards,EffectiveExposure}.sol`,
+  `core/ServicesApprovals{,Views}.sol` were touched in this window.
+- `grep -rn "uint256\[.*\] (private|internal) __gap" src/` to enumerate gaps.
+- `grep -rn "_authorizeUpgrade\|UPGRADER_ROLE" src/` to confirm gating.
+- `grep -rn "_disableInitializers" src/` to confirm constructor lock.
+- `forge inspect Tangle storage-layout` and `forge inspect ValidatorPodManager
+  storage-layout` (under `FOUNDRY_PROFILE=local_build`) to verify slot indices
+  match the declarations.
+- Cross-checked `deployments/base-sepolia/latest.json` to determine whether
+  any reinterpreted slot (INFO-1) could affect a live proxy.

--- a/script/StressGriefingSeed.s.sol
+++ b/script/StressGriefingSeed.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 whose `transfer` reverts. `transferFrom`/balance/approve still work so a
+///         service could in principle collect payment; the revert only fires when the
+///         diamond tries to flush operator rewards via the `_claimRewardsToken` path.
+contract RevertingTransferERC20 is ERC20 {
+    error TransferGriefed();
+
+    constructor() ERC20("Griefer", "GRF") { }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert TransferGriefed();
+    }
+}
+
+/// @title StressGriefingSeed
+/// @notice Deploys a `RevertingTransferERC20` whose address the bash harness uses for
+///         the per-token griefing storage seed (issued via `anvil_setStorageAt`).
+///         `vm.store` in a broadcast script only mutates simulation state — it is NOT
+///         propagated to anvil — so the seeding lives entirely in the harness's RPC
+///         calls. This script's only on-chain side effect is the ERC20 deployment.
+contract StressGriefingSeed is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_KEY");
+        vm.startBroadcast(deployerKey);
+        RevertingTransferERC20 grief = new RevertingTransferERC20();
+        vm.stopBroadcast();
+        // Print only this final line, parsed by the harness via `grep -oE`.
+        console2.log("GRIEF_TOKEN=", address(grief));
+    }
+}

--- a/scripts/local-env/STRESS-TEST.md
+++ b/scripts/local-env/STRESS-TEST.md
@@ -1,0 +1,181 @@
+# Local stress test harness
+
+`stress-test.sh` is a single executable that brings up the full local Tangle
+stack and walks 17 ordered economic checks against the merged-PR surface
+(PRs #132, #133, #134, #136). It is intended as a fast, scriptable smoke test —
+re-runnable locally and from CI — for the entire vertical slice.
+
+A full green run takes **~45–85 seconds** on a warm-cache checkout (cold first
+compile of `LocalTestnet.s.sol` adds another 4–6 minutes, one-time).
+
+## Prereqs
+
+Required on `PATH`:
+
+- `anvil`, `cast`, `forge` (Foundry — recent enough to support
+  `anvil_setStorageAt`, `anvil_setBalance`, `evm_increaseTime`)
+- `curl`, `jq`, `nc`, `awk`, `python3`
+
+Repository state:
+
+- `forge soldeer update` must have populated `dependencies/`. The harness checks
+  for `dependencies/forge-std-1.9.4` and exits early if missing.
+- `forge build` must succeed for the implementation contracts and for
+  `script/StressGriefingSeed.s.sol` (the helper that deploys the griefing
+  ERC20 used in step 16).
+
+Optional (only when the corresponding flag is passed):
+
+- `docker` + Docker daemon — required for `--with-indexer` (Postgres + Hasura).
+- `pnpm` — required for `--with-indexer` and `--with-dapp`.
+- A clone of `/home/drew/code/dapp` for `--with-dapp`.
+- A clone of `/home/drew/code/llm-inference-blueprint` with a `cargo build
+  --release --bin llm-operator` target for `--with-operator`.
+
+## How to run
+
+```bash
+# happy path — runs all 17 steps, indexer leg auto-skips (step 17 marked skip)
+./scripts/local-env/stress-test.sh
+
+# include the envio indexer + Hasura container; step 17 then asserts entities
+./scripts/local-env/stress-test.sh --with-indexer
+
+# also boot the dApp dev server (best-effort, never fails the harness)
+./scripts/local-env/stress-test.sh --with-indexer --with-dapp
+
+# also boot a blueprint operator binary
+./scripts/local-env/stress-test.sh --with-operator
+
+# skip the griefing-token step if the environment can't run anvil_setStorageAt
+./scripts/local-env/stress-test.sh --skip-griefing
+
+# skip step 17 explicitly even when the indexer is up
+./scripts/local-env/stress-test.sh --with-indexer --skip-indexer-checks
+```
+
+Output format (one line per step + a single result line):
+
+```
+[OK]   step 06: operator2 registered             (0.05s)
+[OK]   step 10: billSubscription #1              (0.32s, draw1=80909090909090909 wei)
+[FAIL] step 13: proposeSlash + executeSlash      (0.30s — see /tmp/stress-13.log)
+…
+RESULT: 16 / 17 OK in 84s (failed: 13:proposeSlash + executeSlash).
+```
+
+Exit code: `0` ⇔ all green, `1` otherwise.
+
+## What each step proves
+
+| # | Step | Validates |
+|---|---|---|
+| 01 | prerequisites | local tools present, soldeer deps installed |
+| 02 | idempotent cleanup | re-runs work — anvil killed, indexer docker volumes wiped, broadcast artifacts removed, state file deleted |
+| 03 | anvil + contracts deployed | fresh anvil on port 8545; `script/LocalTestnet.s.sol:LocalTestnetSetup` runs in subscription mode (0.1 ETH per 60s blueprint); broadcast file written |
+| 04 | resolve deployed addresses | the broadcast file at `broadcast/LocalTestnet.s.sol/31337/run-latest.json` parses to the Tangle proxy + staking proxy addresses every subsequent step depends on |
+| 05 | optional services launched | the three best-effort side-processes (`--with-indexer` / `--with-dapp` / `--with-operator`) start without throwing |
+| 06 | operator2 registered | `isOperatorRegistered(0, op2) == true` — confirms the blueprint registration path ran during setup (PR #132 setup baseline) |
+| 07 | subscription service Active | `isServiceActive(0) == true` — subscription-priced service activation completed cleanly, including `subscriptionBaselineStake` pin (PR #132 subscription rearchitecture) |
+| 08 | operator on service operator set | `isServiceOperator(0, op2) == true` — the `approveService` path emitted the right `ServiceOperator` record; ApprovalsViews split off cleanly (PR #133 facet split for EIP-170) |
+| 09 | escrow funded > 0 | `getServiceEscrow(0).balance > 0` — `fundService` (invoked by `requestService{value: 1 ether}`) credited escrow |
+| 10 | billSubscription #1 | first bill draws ≤ `subscriptionRate` from escrow; TWAP weighting across multi-asset operator delegations (TNT + native + USDC) executes without revert (PR #133 multi-asset bill weighting) |
+| 11 | second staker grows pool | `MultiAssetDelegation.depositAndDelegate{value: 5 ether}` to op2 succeeds; `getOperatorDelegatedStake(op2)` strictly increases — proves the O(1) `_operatorDelegatedAggregate` update path (PR #134) |
+| 12 | billSubscription #2 (post-stake) | second period draws again with the now-larger underlying pool — accounting stays consistent across delegations (PR #133 + #134 interplay) |
+| 13 | proposeSlash + executeSlash | dispute window respected (`evm_increaseTime` by `7 days + 20s` to clear `DEFAULT_DISPUTE_WINDOW + TIMESTAMP_BUFFER`); `executeSlash` returns non-zero `actualSlashed` and emits `SlashExecuted` (PR #134 share-pool slashing) |
+| 14 | operator stake reduced post-slash | `getOperatorDelegatedStake(op2)` post-slash < pre-slash baseline; share-pool slash dropped pool assets without per-delegator iteration (PR #134 win) |
+| 15 | claimRewardsAll (native) | native rewards accrued in steps 10/12 are sweepable; `pendingRewards(op2, address(0))` returns 0 after the call |
+| 16 | griefing token skipped | a deployed `RevertingTransferERC20` is seeded into op2's pending-reward bookkeeping via `anvil_setStorageAt` (`_pendingRewards[op2][grief] = 1e18` + `_pendingRewardTokens[op2].add(grief)`); `claimRewardsAll` iterates it but per-token try/catch isolates the revert and emits `RewardsClaimSkipped(op2, grief)`; the pending balance remains intact for retry (PR #136 win) |
+| 17 | indexer entities present | when `--with-indexer` is set, envio indexer has ≥1 row each in `Operator`, `Service`, `ServiceOperator`, `SubscriptionBilling`, `PaymentDistribution`, `RewardClaim`, `RewardsClaimSkip` (PR #138), `SlashProposal`, `OperatorPoolSlash` (PR #138). Skipped if `--with-indexer` is not passed |
+
+## Where logs land
+
+- `/tmp/stress-NN.log` — stdout+stderr of step `NN`. Any non-zero exit leaves a
+  log here for triage.
+- `/tmp/stress-NN.log.summary` — single-line headline metric a passing step
+  produces (e.g. `draw1=80909090909090909 wei` for step 10). The metric is
+  inlined into the step's `[OK]` print and the file is consumed at print time.
+- `/tmp/stress-11.stake-baseline` — pre-slash baseline written by step 11 so
+  step 14 can compare post-slash stake. Cleaned up by `idempotent_cleanup`.
+- `/tmp/stress-anvil.log`, `/tmp/stress-anvil.pid` — output and pid of the
+  anvil instance the harness booted.
+- `/tmp/stress-16-seed.log` — output of the `StressGriefingSeed` forge script
+  that deploys the reverting ERC20 used in step 16.
+- `/tmp/stress-dapp.log`, `/tmp/stress-operator.log` — outputs of the optional
+  side processes (only created when their flags are passed).
+
+## How to debug
+
+1. **Step 01 fails with "Soldeer deps missing"** — run `forge soldeer update`
+   in the repo root and retry.
+2. **Step 03 fails** — inspect `/tmp/stress-anvil.log` (anvil itself) and
+   `/tmp/stress-03.log` (the `LocalTestnet.s.sol` broadcast). Usually means a
+   deployment script reverted or a port collision; the cleanup in step 02
+   handles the latter on retry.
+3. **Step 04 fails ("no broadcast file")** — `script/LocalTestnet.s.sol`
+   produced no broadcast artifact. Re-run with the script's `-vvvv` (manual:
+   `forge script script/LocalTestnet.s.sol:LocalTestnetSetup --rpc-url
+   http://127.0.0.1:8545 --private-key … --broadcast --non-interactive -vvvv`)
+   to see the on-chain trace.
+4. **Step 13 fails with `SlashNotExecutable`** — the dispute window or the
+   `TIMESTAMP_BUFFER` changed. Read the current window via `cast call
+   $TANGLE_ADDR "getSlashConfig()"` and update the `bump_time` argument in
+   `step_13_propose_and_execute_slash`.
+5. **Step 16 reads `seeded == 0` or some weird number** — the storage slots
+   changed. Re-run `forge inspect Tangle storage-layout | rg
+   "_pendingRewards|_pendingRewardTokens"` and update the two slot constants
+   (`2c` and `40`) inside `step_16_griefing_sweep`. Note: `vm.store` from a
+   broadcast forge script does NOT propagate to anvil — only
+   `anvil_setStorageAt` does — which is why the harness drives the seeding via
+   `curl` rather than from `StressGriefingSeed.s.sol`.
+6. **Step 17 fails for a single entity** — bring up an interactive run with
+   `--with-indexer KEEP_RUNNING=true ./scripts/local-env/stress-test.sh` and
+   inspect Hasura at <http://localhost:8080/console>. Usual cause: an event
+   handler regressed when the contract changed selectors.
+
+## Known issues / flakes
+
+- **Indexer cold-start can take 60–120s.** The bring-up probe in
+  `setup_indexer_optional` waits up to 240s. On slow disks or first-run
+  `pnpm install`, raise to 360s if you see frequent timeouts.
+- **`pnpm-workspace.yaml` in `indexer/`** — earlier QA runs may have left a
+  stray `pnpm-workspace.yaml` file in `indexer/` with placeholder values that
+  cause `pnpm` to choke. The harness's `idempotent_cleanup` does NOT remove
+  this file (it's outside our scope to delete a tracked-by-someone file). If
+  `--with-indexer` is flaky for you, `rm indexer/pnpm-workspace.yaml` and
+  retry.
+- **`getOperatorDelegatedStake` granularity** — step 14's pre/post inequality
+  depends on the slashed share-pool dust being ≥1 wei. At 1500 bps on a
+  10-ETH-equivalent pool the drop is 1.5 ETH ≈ 1.5e18 wei, well above any
+  rounding floor. If you parameterize the slash bps lower than 100, the drop
+  may round to zero and step 14 will fail spuriously.
+
+## How to extend
+
+Each step is an independent shell function — `step_NN_<name>` — invoked
+through `run_step "NN" "<label>" step_NN_<name>`. To add an 18th step:
+
+```bash
+step_18_my_new_assertion() {
+    state                                 # reload TANGLE_ADDR / STAKING_ADDR
+    # ... cast call, assert, optionally write /tmp/stress-18.log.summary
+}
+# in main():
+run_step 18 "my new assertion" step_18_my_new_assertion
+TOTAL_STEPS=18                            # bump near the top of the script
+```
+
+Conventions:
+
+- Read state via `state` (sources `/tmp/stress-state.env`). Add new keys
+  there in `resolve_addresses` if you need a new address.
+- Stay revert-on-error inside each step body — `set -e` is enforced.
+- If a step measures a number worth surfacing in the OK line, write
+  `${LOG_DIR}/stress-NN.log.summary` (one line). The runner consumes it and
+  inlines the text into the `[OK]` print.
+- If a step needs to persist data across steps, write a separate file like
+  `${LOG_DIR}/stress-NN.<purpose>` (the `.summary` files are deleted after
+  being consumed by `run_step`). Add the path glob to `idempotent_cleanup`.
+- Group all indexer assertions into step 17 to keep the rest of the harness
+  fast — every individual GraphQL call has multi-second latency on a
+  cold-synced indexer.

--- a/scripts/local-env/stress-test.sh
+++ b/scripts/local-env/stress-test.sh
@@ -1,0 +1,686 @@
+#!/usr/bin/env bash
+#
+# stress-test.sh
+#
+# End-to-end local stress harness for tnt-core.
+#
+# Spins up anvil + tnt-core (and optionally the envio indexer / dApp / blueprint
+# operator) and exercises the merged-PR economic surface: subscription billing,
+# multi-asset delegation, slashing dispute window + execution, multi-token
+# reward sweeps including a custom griefing ERC20.
+#
+# Idempotent: re-running tears down previous state and starts fresh.
+#
+# Usage:
+#   ./stress-test.sh [--with-indexer] [--with-dapp] [--with-operator]
+#                    [--skip-griefing] [--skip-indexer-checks]
+#
+# Exit codes:
+#   0  all steps green
+#   1  at least one step failed (see /tmp/stress-*.log)
+#
+set -euo pipefail
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Configuration
+# ────────────────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INDEXER_DIR="${ROOT_DIR}/indexer"
+
+ANVIL_PORT="${ANVIL_PORT:-8545}"
+RPC_URL="${LOCAL_RPC_URL:-http://127.0.0.1:${ANVIL_PORT}}"
+HASURA_PORT="${HASURA_PORT:-8080}"
+GRAPHQL_URL="http://127.0.0.1:${HASURA_PORT}/v1/graphql"
+
+# Anvil default accounts (see LocalTestnet.s.sol for role mapping).
+DEPLOYER_KEY="${DEPLOYER_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+OPERATOR2_KEY="${OPERATOR2_KEY:-0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a}"
+DELEGATOR_KEY="${DELEGATOR_KEY:-0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6}"
+SECOND_STAKER_KEY="${SECOND_STAKER_KEY:-0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e}"
+
+OPERATOR1_ADDR="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+OPERATOR2_ADDR="0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+SECOND_STAKER_ADDR="$(cast wallet address --private-key "${SECOND_STAKER_KEY}" 2>/dev/null)"
+
+MULTICALL3_ADDRESS="0xcA11bde05977b3631167028862bE2a173976CA11"
+
+WITH_INDEXER=false
+WITH_DAPP=false
+WITH_OPERATOR=false
+SKIP_GRIEFING=false
+SKIP_INDEXER_CHECKS=false
+
+LOG_DIR="${LOG_DIR:-/tmp}"
+STATE_FILE="${LOG_DIR}/stress-state.env"
+
+WALL_START_TS=$(date +%s)
+TOTAL_STEPS=17
+OK_COUNT=0
+FAIL_COUNT=0
+FAIL_STEPS=()
+ANVIL_PID=""
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Argument parsing
+# ────────────────────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --with-indexer) WITH_INDEXER=true; shift ;;
+        --with-dapp) WITH_DAPP=true; shift ;;
+        --with-operator) WITH_OPERATOR=true; shift ;;
+        --skip-griefing) SKIP_GRIEFING=true; shift ;;
+        --skip-indexer-checks) SKIP_INDEXER_CHECKS=true; shift ;;
+        -h|--help)
+            sed -n '/^#$/,/^set/p' "$0" | sed 's/^# \{0,1\}//; s/^#$//' | head -30
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1"; exit 2 ;;
+    esac
+done
+
+# Without --with-indexer the indexer leg cannot run, so the entity-presence step is
+# automatically skipped to avoid a guaranteed failure.
+if [[ "${WITH_INDEXER}" != "true" ]]; then
+    SKIP_INDEXER_CHECKS=true
+fi
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Logging helpers
+# ────────────────────────────────────────────────────────────────────────────────
+
+format_secs() {
+    awk -v s="$1" 'BEGIN { printf "%.2fs", s }'
+}
+
+run_step() {
+    local step_id="$1"; local label="$2"; shift 2
+    local log_file="${LOG_DIR}/stress-${step_id}.log"
+    local t0
+    t0=$(date +%s%N)
+    if "$@" >"$log_file" 2>&1; then
+        local t1
+        t1=$(date +%s%N)
+        local secs
+        secs=$(awk -v a="$t1" -v b="$t0" 'BEGIN { print (a-b)/1e9 }')
+        local extra=""
+        if [[ -f "${log_file}.summary" ]]; then
+            extra=", $(cat "${log_file}.summary")"
+            rm -f "${log_file}.summary"
+        fi
+        printf '[OK]   step %s: %-32s (%s%s)\n' "$step_id" "$label" "$(format_secs "$secs")" "$extra"
+        OK_COUNT=$((OK_COUNT + 1))
+    else
+        local t1
+        t1=$(date +%s%N)
+        local secs
+        secs=$(awk -v a="$t1" -v b="$t0" 'BEGIN { print (a-b)/1e9 }')
+        printf '[FAIL] step %s: %-32s (%s — see %s)\n' "$step_id" "$label" "$(format_secs "$secs")" "$log_file"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAIL_STEPS+=("$step_id:$label")
+    fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Anvil RPC helpers
+# ────────────────────────────────────────────────────────────────────────────────
+
+rpc() {
+    local method="$1"; local params="$2"
+    curl -s --max-time 10 "${RPC_URL}" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"${method}\",\"params\":${params},\"id\":1}"
+}
+
+bump_time() {
+    local secs="$1"
+    rpc evm_increaseTime "[$secs]" >/dev/null
+    rpc evm_mine "[]" >/dev/null
+}
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Setup phase
+# ────────────────────────────────────────────────────────────────────────────────
+
+check_prereqs() {
+    local missing=()
+    for tool in anvil cast forge curl jq nc awk; do
+        command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+    done
+    if [[ "${WITH_INDEXER}" == "true" ]]; then
+        for tool in docker pnpm; do
+            command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+        done
+        docker info >/dev/null 2>&1 || missing+=("docker daemon")
+    fi
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Missing required tools: ${missing[*]}" >&2
+        return 1
+    fi
+    if [[ ! -d "${ROOT_DIR}/dependencies/forge-std-1.9.4" ]]; then
+        echo "Soldeer deps missing — run 'forge soldeer update' first." >&2
+        return 1
+    fi
+    return 0
+}
+
+idempotent_cleanup() {
+    pkill -9 -f "anvil.*--port.*${ANVIL_PORT}" 2>/dev/null || true
+    if [[ "${WITH_INDEXER}" == "true" ]] && [[ -d "${INDEXER_DIR}/generated" ]]; then
+        (cd "${INDEXER_DIR}/generated" && docker compose down -v 2>/dev/null) || true
+    fi
+    rm -f "${INDEXER_DIR}/generated/persisted_state.envio.json" 2>/dev/null || true
+    rm -rf "${ROOT_DIR}/broadcast/LocalTestnet.s.sol" 2>/dev/null || true
+    rm -f "${STATE_FILE}" "${LOG_DIR}"/stress-*.stake-baseline 2>/dev/null || true
+    pkill -f "envio start" 2>/dev/null || true
+    # Give the OS a beat to release ports.
+    sleep 1
+    return 0
+}
+
+start_anvil() {
+    if nc -z 127.0.0.1 "${ANVIL_PORT}" 2>/dev/null; then
+        echo "Anvil already up on port ${ANVIL_PORT}"
+        return 0
+    fi
+    anvil --chain-id 31337 --base-fee 0 --gas-limit 30000000 \
+        --disable-code-size-limit --silent --port "${ANVIL_PORT}" \
+        > "${LOG_DIR}/stress-anvil.log" 2>&1 &
+    ANVIL_PID=$!
+    echo "${ANVIL_PID}" > "${LOG_DIR}/stress-anvil.pid"
+    # Wait up to 30s for anvil to accept RPC.
+    local deadline=$(( $(date +%s) + 30 ))
+    while [[ $(date +%s) -lt $deadline ]]; do
+        if curl -s "${RPC_URL}" -X POST -H "Content-Type: application/json" \
+            --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+            2>/dev/null | grep -q '"result"'; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "Anvil did not start within 30s" >&2
+    return 1
+}
+
+inject_multicall3() {
+    # Multicall3 is only required by downstream tooling (viem multicall, indexer
+    # batch-RPC). The optional setup_indexer_optional path delegates to the
+    # canonical local-env helper which already injects multicall before booting
+    # the indexer. For the bare RPC surface the harness uses, multicall is
+    # unnecessary, so this is a no-op.
+    return 0
+}
+
+deploy_tnt_core() {
+    # Reuses LocalTestnet.s.sol in subscription mode so a billable service is
+    # active at activation time (with `subscriptionBaselineStake` pinned).
+    SUBSCRIPTION_MODE=true forge script \
+        script/LocalTestnet.s.sol:LocalTestnetSetup \
+        --rpc-url "${RPC_URL}" \
+        --private-key "${DEPLOYER_KEY}" \
+        --broadcast --non-interactive
+}
+
+setup_indexer_optional() {
+    if [[ "${WITH_INDEXER}" != "true" ]]; then return 0; fi
+    # Honor the existing helper for indexer bring-up. It runs docker compose + envio
+    # codegen + starts the indexer in the background.
+    local helper="${ROOT_DIR}/script/sh/local-env/start-local-dev.sh"
+    (cd "${ROOT_DIR}" && SKIP_DEPLOY=1 "${helper}" --subscription &) \
+        || echo "indexer helper failed; continuing"
+    # Wait up to 240s for the GraphQL endpoint.
+    local deadline=$(( $(date +%s) + 240 ))
+    while [[ $(date +%s) -lt $deadline ]]; do
+        if curl -s --max-time 3 "${GRAPHQL_URL}" \
+            -H "Content-Type: application/json" \
+            -d '{"query":"{ Operator(limit:1) { id } }"}' 2>/dev/null \
+            | grep -q '"Operator"'; then return 0; fi
+        sleep 4
+    done
+    echo "Indexer did not become healthy within 240s — step 17 will skip" >&2
+    SKIP_INDEXER_CHECKS=true
+    return 0
+}
+
+start_dapp_optional() {
+    if [[ "${WITH_DAPP}" != "true" ]]; then return 0; fi
+    local dapp_dir="/home/drew/code/dapp"
+    if [[ ! -d "${dapp_dir}" ]]; then
+        echo "dapp dir not present; skipping --with-dapp"
+        return 0
+    fi
+    (cd "${dapp_dir}" && nohup pnpm nx run tangle-dapp:serve >"${LOG_DIR}/stress-dapp.log" 2>&1 &) || true
+    echo "dApp started in background (logs: ${LOG_DIR}/stress-dapp.log)"
+}
+
+start_operator_optional() {
+    if [[ "${WITH_OPERATOR}" != "true" ]]; then return 0; fi
+    local op_dir="/home/drew/code/llm-inference-blueprint"
+    if [[ ! -d "${op_dir}/operator" ]]; then
+        echo "operator dir not present; skipping --with-operator"
+        return 0
+    fi
+    (cd "${op_dir}" && cargo build --release --bin llm-operator >"${LOG_DIR}/stress-operator-build.log" 2>&1) || {
+        echo "operator build failed; see ${LOG_DIR}/stress-operator-build.log"
+        return 0
+    }
+    (cd "${op_dir}" && nohup ./target/release/llm-operator >"${LOG_DIR}/stress-operator.log" 2>&1 &) || true
+    echo "operator binary started (logs: ${LOG_DIR}/stress-operator.log)"
+}
+
+step_03_bringup() {
+    start_anvil || return 1
+    # Multicall3 is only needed if downstream tooling (indexer / dApp) hits it.
+    if [[ "${WITH_INDEXER}" == "true" || "${WITH_DAPP}" == "true" ]]; then
+        inject_multicall3 || echo "Multicall3 inject failed; continuing without it"
+    fi
+    deploy_tnt_core
+}
+
+resolve_addresses() {
+    local broadcast_dir="${ROOT_DIR}/broadcast/LocalTestnet.s.sol/31337"
+    local latest
+    latest=$(ls -t "${broadcast_dir}"/run-*.json 2>/dev/null | head -1)
+    [[ -n "${latest}" ]] || { echo "no broadcast file"; return 1; }
+
+    local TANGLE_ADDR STAKING_ADDR
+    TANGLE_ADDR=$(jq -r '[.transactions[] | select(.contractName=="ERC1967Proxy") | .contractAddress] | .[1]' "${latest}")
+    STAKING_ADDR=$(jq -r '[.transactions[] | select(.contractName=="ERC1967Proxy") | .contractAddress] | .[0]' "${latest}")
+
+    [[ "${TANGLE_ADDR}" != "null" && -n "${TANGLE_ADDR}" ]] || { echo "Could not parse TANGLE_ADDR"; return 1; }
+    [[ "${STAKING_ADDR}" != "null" && -n "${STAKING_ADDR}" ]] || { echo "Could not parse STAKING_ADDR"; return 1; }
+
+    {
+        echo "TANGLE_ADDR=${TANGLE_ADDR}"
+        echo "STAKING_ADDR=${STAKING_ADDR}"
+    } >"${STATE_FILE}"
+}
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Step implementations
+# ────────────────────────────────────────────────────────────────────────────────
+
+state() {
+    # shellcheck disable=SC1090
+    source "${STATE_FILE}"
+}
+
+step_06_registered() {
+    state
+    local out
+    out=$(cast call "${TANGLE_ADDR}" "isOperatorRegistered(uint64,address)(bool)" 0 "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}")
+    [[ "${out}" == "true" ]] || { echo "operator2 not registered for blueprint 0: '${out}'"; return 1; }
+}
+
+step_07_service_active() {
+    state
+    local active
+    active=$(cast call "${TANGLE_ADDR}" "isServiceActive(uint64)(bool)" 0 --rpc-url "${RPC_URL}")
+    [[ "${active}" == "true" ]] || { echo "service 0 not Active (isServiceActive=${active})"; return 1; }
+}
+
+step_08_security_commitments() {
+    state
+    # Operator2 must be on service 0's operator list. `isServiceOperator` reads the
+    # ServiceOperator record that ServicesApprovals.approveService wrote, which
+    # carries the per-asset commitment slice from the multi-asset bill weighting
+    # path (PR #133 split into ApprovalsViews).
+    local out
+    out=$(cast call "${TANGLE_ADDR}" "isServiceOperator(uint64,address)(bool)" 0 "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}")
+    [[ "${out}" == "true" ]] || { echo "op2 not on service 0 operator set: '${out}'"; return 1; }
+}
+
+step_09_escrow_funded() {
+    state
+    local raw
+    raw=$(cast call "${TANGLE_ADDR}" "getServiceEscrow(uint64)" 0 --rpc-url "${RPC_URL}")
+    # `ServiceEscrow` is (address token, uint256 balance, uint256 subscriptionBaselineStake, ...).
+    # Decode the second word (offset 32) as the balance.
+    local balance_hex="${raw:66:64}"
+    local balance_dec
+    balance_dec=$(cast --to-dec "0x${balance_hex}")
+    [[ "${balance_dec}" -gt 0 ]] || { echo "escrow balance is 0 (raw=${raw})"; return 1; }
+    echo "escrow_balance=${balance_dec} wei" > "${LOG_DIR}/stress-09.log.summary"
+}
+
+bill_subscription_once() {
+    state
+    local raw_before
+    raw_before=$(cast call "${TANGLE_ADDR}" "getServiceEscrow(uint64)" 0 --rpc-url "${RPC_URL}")
+    local before
+    before=$(cast --to-dec "0x${raw_before:66:64}")
+
+    bump_time 65 >/dev/null
+    cast send "${TANGLE_ADDR}" "billSubscription(uint64)" 0 \
+        --private-key "${DEPLOYER_KEY}" --rpc-url "${RPC_URL}" >/dev/null
+
+    local raw_after
+    raw_after=$(cast call "${TANGLE_ADDR}" "getServiceEscrow(uint64)" 0 --rpc-url "${RPC_URL}")
+    local after
+    after=$(cast --to-dec "0x${raw_after:66:64}")
+
+    echo "before=${before} after=${after}"
+}
+
+step_10_bill_first() {
+    local out before after
+    out=$(bill_subscription_once)
+    eval "$out"
+    [[ "${before}" -gt "${after}" ]] || { echo "escrow did not decrease: before=${before} after=${after}"; return 1; }
+    local drawn=$((before - after))
+    echo "draw1=${drawn} wei" > "${LOG_DIR}/stress-10.log.summary"
+}
+
+step_11_second_staker() {
+    state
+    # Fund the second staker with 500 ETH so it can stake.
+    rpc anvil_setBalance "[\"${SECOND_STAKER_ADDR}\", \"0x1B1AE4D6E2EF500000\"]" >/dev/null
+
+    # Use getOperatorDelegatedStake (sum across ALL enabled assets) — this is the
+    # O(1) aggregate the PR landed. getOperatorStake() only reflects the bond asset.
+    local before
+    before=$(cast call "${STAKING_ADDR}" "getOperatorDelegatedStake(address)(uint256)" "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}" | awk '{print $1}')
+    [[ "${before}" =~ ^[0-9]+$ ]] || { echo "could not read pre-stake: ${before}"; return 1; }
+
+    cast send "${STAKING_ADDR}" "depositAndDelegate(address)" "${OPERATOR2_ADDR}" \
+        --value 5ether \
+        --private-key "${SECOND_STAKER_KEY}" --rpc-url "${RPC_URL}" >/dev/null
+
+    local after
+    after=$(cast call "${STAKING_ADDR}" "getOperatorDelegatedStake(address)(uint256)" "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}" | awk '{print $1}')
+    [[ "${after}" -gt "${before}" ]] || { echo "operator stake did not grow: before=${before} after=${after}"; return 1; }
+    echo "delegated_pre=${before} delegated_post=${after}" > "${LOG_DIR}/stress-11.log.summary"
+    # Persist a copy that survives run_step's .summary consumption, so step 14 can
+    # cross-reference the baseline.
+    echo "${after}" > "${LOG_DIR}/stress-11.stake-baseline"
+}
+
+step_12_bill_after_added_stake() {
+    local out before after
+    out=$(bill_subscription_once)
+    eval "$out"
+    [[ "${before}" -gt "${after}" ]] || { echo "second bill drew zero (before=${before} after=${after})"; return 1; }
+    local drawn=$((before - after))
+    echo "draw2=${drawn} wei" > "${LOG_DIR}/stress-12.log.summary"
+}
+
+step_13_propose_and_execute_slash() {
+    state
+    local evidence="0x5354524553533a20534c41206d6973736564000000000000000000000000000000"
+    local tx_propose
+    tx_propose=$(cast send "${TANGLE_ADDR}" \
+        "proposeSlash(uint64,address,uint16,bytes32)" 0 "${OPERATOR2_ADDR}" 1500 \
+        "${evidence:0:66}" \
+        --private-key "${DEPLOYER_KEY}" --rpc-url "${RPC_URL}" --json)
+    local slash_topic
+    slash_topic="$(cast keccak 'SlashProposed(uint64,uint64,address,address,uint16,uint16,bytes32,uint64)')"
+    local slash_id_hex
+    slash_id_hex=$(echo "${tx_propose}" | jq -r --arg t "${slash_topic}" \
+        '[.logs[] | select(.topics[0]==$t) | .topics[1]] | .[0] // empty')
+    [[ -n "${slash_id_hex}" ]] || { echo "no SlashProposed event found"; echo "${tx_propose}"; return 1; }
+    local slash_id
+    slash_id=$(cast --to-dec "${slash_id_hex}")
+
+    # Default dispute window is 7 days; advance past it AND past the TIMESTAMP_BUFFER
+    # (15s) the slashing lib uses to defang same-block sequencer/proposer games.
+    bump_time $((7 * 24 * 60 * 60 + 20))
+
+    local execute_out
+    execute_out=$(cast send "${TANGLE_ADDR}" "executeSlash(uint64)" "${slash_id}" \
+        --private-key "${DEPLOYER_KEY}" --rpc-url "${RPC_URL}" --json)
+    local slash_executed_topic
+    slash_executed_topic="$(cast keccak 'SlashExecuted(uint64,uint64,address,uint256)')"
+    local executed_data
+    executed_data=$(echo "${execute_out}" | jq -r --arg t "${slash_executed_topic}" \
+        '[.logs[] | select(.topics[0]==$t) | .data] | .[0] // empty')
+    [[ -n "${executed_data}" ]] || { echo "no SlashExecuted event"; echo "${execute_out}"; return 1; }
+    local actual_slashed
+    actual_slashed=$(cast --to-dec "${executed_data}")
+    [[ "${actual_slashed}" -gt 0 ]] || { echo "slash executed but actualSlashed=0"; return 1; }
+    echo "slashId=${slash_id} actualSlashed=${actual_slashed} wei" > "${LOG_DIR}/stress-13.log.summary"
+}
+
+step_14_post_slash_stake_reduced() {
+    state
+    local after
+    after=$(cast call "${STAKING_ADDR}" "getOperatorDelegatedStake(address)(uint256)" "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}" | awk '{print $1}')
+    local prev=""
+    [[ -f "${LOG_DIR}/stress-11.stake-baseline" ]] && prev=$(<"${LOG_DIR}/stress-11.stake-baseline")
+    [[ -n "${prev}" ]] || { echo "could not read step-11 baseline"; return 1; }
+    [[ "${after}" -lt "${prev}" ]] || { echo "operator stake did not drop: prev=${prev} after=${after}"; return 1; }
+    echo "stake_pre=${prev} stake_post=${after}" > "${LOG_DIR}/stress-14.log.summary"
+}
+
+step_15_claim_rewards_all() {
+    state
+    cast send "${TANGLE_ADDR}" "claimRewardsAll()" \
+        --private-key "${OPERATOR2_KEY}" --rpc-url "${RPC_URL}" >/dev/null
+    local pending
+    pending=$(cast call "${TANGLE_ADDR}" "pendingRewards(address,address)(uint256)" \
+        "${OPERATOR2_ADDR}" "0x0000000000000000000000000000000000000000" \
+        --rpc-url "${RPC_URL}" | awk '{print $1}')
+    [[ "${pending}" == "0" ]] || { echo "native pendingRewards still non-zero: ${pending}"; return 1; }
+}
+
+to_32hex() {
+    # Strip 0x, lowercase, left-pad to 64 hex chars (32 bytes). Input MUST already be hex.
+    local v="${1#0x}"
+    printf '%064s' "${v,,}" | tr ' ' '0'
+}
+
+dec_to_32hex() {
+    # Convert a decimal value to a 0x-prefixed 32-byte hex word.
+    python3 -c "print('0x' + hex(int('$1'))[2:].rjust(64, '0'))"
+}
+
+seed_storage() {
+    # seed_storage <contract> <slot-hex> <value> [--hex|--dec]
+    # Slot may or may not have 0x prefix. Value defaults to decimal interpretation.
+    local contract="$1"
+    local slot="$2"
+    local value="$3"
+    local mode="${4:---dec}"
+    [[ "${slot}" == 0x* ]] || slot="0x${slot}"
+    local val32
+    if [[ "${mode}" == "--hex" ]]; then
+        val32="0x$(to_32hex "${value}")"
+    else
+        val32=$(dec_to_32hex "${value}")
+    fi
+    curl -s "${RPC_URL}" -X POST -H "Content-Type: application/json" \
+        --data "{\"jsonrpc\":\"2.0\",\"method\":\"anvil_setStorageAt\",\"params\":[\"${contract}\",\"${slot}\",\"${val32}\"],\"id\":1}" \
+        | jq -e '.result' >/dev/null
+}
+
+step_16_griefing_sweep() {
+    if [[ "${SKIP_GRIEFING}" == "true" ]]; then
+        echo "skipped via --skip-griefing" > "${LOG_DIR}/stress-16.log.summary"
+        return 0
+    fi
+    state
+    # Deploy the reverting ERC20 via the forge script (only on-chain side effect).
+    DEPLOYER_KEY="${DEPLOYER_KEY}" \
+    forge script script/StressGriefingSeed.s.sol:StressGriefingSeed \
+        --rpc-url "${RPC_URL}" --broadcast --non-interactive -vv \
+        > "${LOG_DIR}/stress-16-seed.log" 2>&1
+    local grief_token
+    grief_token=$(grep -oE 'GRIEF_TOKEN=[[:space:]]*0x[a-fA-F0-9]+' "${LOG_DIR}/stress-16-seed.log" \
+        | tail -1 | grep -oE '0x[a-fA-F0-9]+')
+    [[ -n "${grief_token}" ]] || { echo "failed to deploy griefing token"; tail -30 "${LOG_DIR}/stress-16-seed.log"; return 1; }
+    local grief_lower="${grief_token,,}"
+    grief_lower="${grief_lower#0x}"
+
+    # Compute storage slots for the seed. Source of truth: `forge inspect Tangle storage-layout`.
+    #   _pendingRewards         at slot 44
+    #   _pendingRewardTokens    at slot 64  (mapping(address => EnumerableSet.AddressSet))
+    # `AddressSet` wraps `Set { bytes32[] _values; mapping(bytes32 => uint256) _positions; }`.
+    local op32; op32=$(to_32hex "${OPERATOR2_ADDR}")
+    local g32; g32=$(to_32hex "${grief_token}")
+    # _pendingRewards is at slot 44 (0x2c). Inner mapping slot first, then the per-token slot.
+    local slot_pending32; slot_pending32=$(to_32hex "2c")
+    local inner; inner=$(cast keccak "0x${op32}${slot_pending32}")
+    local inner_hex="${inner#0x}"
+    local pending_slot; pending_slot=$(cast keccak "0x${g32}${inner_hex}")
+
+    # _pendingRewardTokens at slot 64 (0x40) — mapping(address => AddressSet).
+    local slot_set32; slot_set32=$(to_32hex "40")
+    local set_struct; set_struct=$(cast keccak "0x${op32}${slot_set32}")
+    local set_struct_hex="${set_struct#0x}"
+    # _values length lives at set_struct itself (offset 0)
+    # _values[0] lives at keccak256(set_struct)
+    local values_data; values_data=$(cast keccak "${set_struct}")
+    # _positions[grief] lives at keccak256(grief . (set_struct + 1)). Use python for
+    # the 256-bit add so we don't pull in bc/dc-isms that vary by platform.
+    local positions_base
+    positions_base=$(python3 -c "print(hex(int('${set_struct_hex}', 16) + 1)[2:].rjust(64, '0'))")
+    local positions_slot; positions_slot=$(cast keccak "0x${g32}${positions_base}")
+
+    # Write the four storage cells via anvil_setStorageAt. Values come in two flavors:
+    #   --dec  : value is decimal, python converts to 32-byte hex.
+    #   --hex  : value is already hex, just padded to 32 bytes.
+    seed_storage "${TANGLE_ADDR}" "${pending_slot}"   "1000000000000000000" --dec || { echo "anvil_setStorageAt pending failed"; return 1; }
+    seed_storage "${TANGLE_ADDR}" "${set_struct}"     "1"                   --dec || { echo "anvil_setStorageAt set-length failed"; return 1; }
+    seed_storage "${TANGLE_ADDR}" "${values_data}"    "${grief_lower}"      --hex || { echo "anvil_setStorageAt values[0] failed"; return 1; }
+    seed_storage "${TANGLE_ADDR}" "${positions_slot}" "1"                   --dec || { echo "anvil_setStorageAt positions failed"; return 1; }
+
+    local seeded
+    seeded=$(cast call "${TANGLE_ADDR}" "pendingRewards(address,address)(uint256)" \
+        "${OPERATOR2_ADDR}" "${grief_token}" --rpc-url "${RPC_URL}" | awk '{print $1}')
+    [[ "${seeded}" == "1000000000000000000" ]] || { echo "seed did not land in storage (got ${seeded})"; return 1; }
+
+    local rewards_tokens
+    rewards_tokens=$(cast call "${TANGLE_ADDR}" "rewardTokens(address)(address[])" \
+        "${OPERATOR2_ADDR}" --rpc-url "${RPC_URL}")
+    local grief_lower="${grief_token,,}"
+    echo "${rewards_tokens,,}" | grep -qF "${grief_lower#0x}" || {
+        echo "griefing token not visible via rewardTokens(): ${rewards_tokens}"
+        return 1
+    }
+
+    local claim_out
+    claim_out=$(cast send "${TANGLE_ADDR}" "claimRewardsAll()" \
+        --private-key "${OPERATOR2_KEY}" --rpc-url "${RPC_URL}" --json)
+    local skip_topic
+    skip_topic="$(cast keccak 'RewardsClaimSkipped(address,address)')"
+    local skipped_found
+    skipped_found=$(echo "${claim_out}" | jq -r --arg t "${skip_topic}" \
+        '[.logs[] | select(.topics[0]==$t)] | length')
+    [[ "${skipped_found}" -ge 1 ]] || { echo "RewardsClaimSkipped not emitted (got ${skipped_found})"; echo "${claim_out}" | jq '.logs[].topics'; return 1; }
+
+    local still_pending
+    still_pending=$(cast call "${TANGLE_ADDR}" "pendingRewards(address,address)(uint256)" \
+        "${OPERATOR2_ADDR}" "${grief_token}" --rpc-url "${RPC_URL}" | awk '{print $1}')
+    [[ "${still_pending}" == "1000000000000000000" ]] || {
+        echo "skipped token's pending was zeroed (expected 1e18, got ${still_pending})"
+        return 1
+    }
+    echo "grief=${grief_token} skips=${skipped_found}" > "${LOG_DIR}/stress-16.log.summary"
+}
+
+graphql_count() {
+    local entity="$1"
+    local resp
+    resp=$(curl -s --max-time 5 "${GRAPHQL_URL}" \
+        -H "Content-Type: application/json" \
+        -d "{\"query\":\"{ ${entity}(limit: 50) { id } }\"}")
+    echo "${resp}" | jq -r ".data.${entity} | length" 2>/dev/null || echo 0
+}
+
+step_17_indexer_entities() {
+    if [[ "${SKIP_INDEXER_CHECKS}" == "true" ]]; then
+        echo "skipped (indexer not enabled — pass --with-indexer)" > "${LOG_DIR}/stress-17.log.summary"
+        return 0
+    fi
+    sleep 6
+    # Entities that should have at least one row after the 16 prior steps:
+    #  - Core protocol shapes (Operator, Service, ServiceOperator)
+    #  - Subscription billing (SubscriptionBilling, PaymentDistribution)
+    #  - Reward sweep (RewardClaim) + griefing isolation (RewardsClaimSkip)
+    #  - Slashing (SlashProposal, OperatorPoolSlash)
+    local entities=(
+        Operator Service ServiceOperator
+        SubscriptionBilling PaymentDistribution
+        RewardClaim RewardsClaimSkip
+        SlashProposal OperatorPoolSlash
+    )
+    local missing=()
+    local summary=""
+    for e in "${entities[@]}"; do
+        local c
+        c=$(graphql_count "${e}")
+        summary+="${e}=${c} "
+        if [[ "${c}" -lt 1 ]]; then
+            missing+=("${e}")
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "indexer missing rows for: ${missing[*]}"
+        echo "counts: ${summary}"
+        return 1
+    fi
+    echo "${summary% }" > "${LOG_DIR}/stress-17.log.summary"
+}
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Teardown
+# ────────────────────────────────────────────────────────────────────────────────
+
+teardown() {
+    if [[ "${KEEP_RUNNING:-false}" == "true" ]]; then return 0; fi
+    [[ -n "${ANVIL_PID}" ]] && kill "${ANVIL_PID}" 2>/dev/null || true
+    pkill -f "anvil.*--port.*${ANVIL_PORT}" 2>/dev/null || true
+    if [[ "${WITH_INDEXER}" == "true" ]] && [[ -d "${INDEXER_DIR}/generated" ]]; then
+        (cd "${INDEXER_DIR}/generated" && docker compose down -v 2>/dev/null) || true
+    fi
+    pkill -f "envio start" 2>/dev/null || true
+    if [[ "${WITH_DAPP}" == "true" ]]; then pkill -f "tangle-dapp:serve" 2>/dev/null || true; fi
+    if [[ "${WITH_OPERATOR}" == "true" ]]; then pkill -f "llm-operator" 2>/dev/null || true; fi
+}
+trap teardown EXIT
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Main
+# ────────────────────────────────────────────────────────────────────────────────
+
+main() {
+    cd "${ROOT_DIR}"
+
+    run_step 01 "prerequisites"               check_prereqs
+    run_step 02 "idempotent cleanup"          idempotent_cleanup
+    run_step 03 "anvil + contracts deployed"  step_03_bringup
+    run_step 04 "resolve deployed addresses"  resolve_addresses
+    # 05 bundles all optional services (indexer + dapp + operator); never fails the harness.
+    setup_indexer_optional || true
+    start_dapp_optional || true
+    start_operator_optional || true
+    run_step 05 "optional services launched"  true
+
+    run_step 06 "operator2 registered"               step_06_registered
+    run_step 07 "subscription service Active"        step_07_service_active
+    run_step 08 "operator on service operator set"   step_08_security_commitments
+    run_step 09 "escrow funded > 0"                  step_09_escrow_funded
+    run_step 10 "billSubscription #1"                step_10_bill_first
+    run_step 11 "second staker grows pool"           step_11_second_staker
+    run_step 12 "billSubscription #2 (post-stake)"   step_12_bill_after_added_stake
+    run_step 13 "proposeSlash + executeSlash"        step_13_propose_and_execute_slash
+    run_step 14 "operator stake reduced post-slash"  step_14_post_slash_stake_reduced
+    run_step 15 "claimRewardsAll (native)"           step_15_claim_rewards_all
+    run_step 16 "griefing token skipped"             step_16_griefing_sweep
+    run_step 17 "indexer entities present"           step_17_indexer_entities
+
+    local wall_end_ts elapsed
+    wall_end_ts=$(date +%s)
+    elapsed=$(( wall_end_ts - WALL_START_TS ))
+    if [[ ${FAIL_COUNT} -eq 0 ]]; then
+        printf '\nRESULT: %d / %d OK in %ds.\n' "${OK_COUNT}" "${TOTAL_STEPS}" "${elapsed}"
+        exit 0
+    else
+        printf '\nRESULT: %d / %d OK in %ds (failed: %s).\n' \
+            "${OK_COUNT}" "${TOTAL_STEPS}" "${elapsed}" "${FAIL_STEPS[*]}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/src/MBSMRegistry.sol
+++ b/src/MBSMRegistry.sol
@@ -304,7 +304,7 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         return _versions[revision - 1] != address(0);
     }
 
-    /// @notice M-8 FIX: Check if a revision is in the deprecation grace period
+    /// @notice Check if a revision is in the deprecation grace period
     /// @param revision The revision to check
     /// @return inGracePeriod True if revision is deprecated but still in grace period
     /// @return gracePeriodEnds Timestamp when grace period ends (0 if not in grace period)
@@ -317,7 +317,7 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         inGracePeriod = block.timestamp < gracePeriodEnds && _versions[revision - 1] != address(0);
     }
 
-    /// @notice M-8 FIX: Get deprecation timestamp for a revision
+    /// @notice Get deprecation timestamp for a revision
     /// @param revision The revision to check
     /// @return timestamp When deprecation was initiated (0 if not deprecated)
     function getDeprecationTimestamp(uint32 revision) external view returns (uint256 timestamp) {
@@ -326,12 +326,12 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
 
     /// @notice Get all registered MBSM addresses
     /// @return addresses Array of all MBSM addresses (may include address(0) for deprecated)
-    /// @dev M-13 FIX: For large registries, prefer using getVersionsPaginated to avoid gas issues
+    /// @dev For large registries, prefer using getVersionsPaginated to avoid gas issues
     function getAllVersions() external view returns (address[] memory addresses) {
         return _versions;
     }
 
-    /// @notice M-13 FIX: Get registered MBSM addresses with pagination
+    /// @notice Get registered MBSM addresses with pagination
     /// @param offset Starting index (0-based)
     /// @param limit Maximum number of versions to return
     /// @return addresses Array of MBSM addresses in the requested range
@@ -359,7 +359,7 @@ contract MBSMRegistry is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         }
     }
 
-    /// @notice M-13 FIX: Get only active (non-deprecated) versions with pagination
+    /// @notice Get only active (non-deprecated) versions with pagination
     /// @param offset Starting index in the active versions (0-based)
     /// @param limit Maximum number of versions to return
     /// @return addresses Array of active MBSM addresses

--- a/src/beacon/BeaconChainProofs.sol
+++ b/src/beacon/BeaconChainProofs.sol
@@ -66,7 +66,7 @@ library BeaconChainProofs {
     uint256 internal constant VALIDATORS_PER_BALANCE_LEAF = 4;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // CONSTANTS - PROOF AGE LIMITS (M-11 FIX)
+    // CONSTANTS - PROOF AGE LIMITS
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Maximum age for beacon chain proofs (8192 slots = ~1 day)
@@ -98,15 +98,15 @@ library BeaconChainProofs {
     error ProofVerificationFailed();
     error InvalidWithdrawalCredentials();
     error EmptyProof();
-    /// @notice M-11 FIX: Beacon block root is zero (invalid or genesis block)
+    /// @notice Beacon block root is zero (invalid or genesis block)
     error InvalidBeaconBlockRoot();
-    /// @notice M-11 FIX: State root is zero (invalid proof data)
+    /// @notice State root is zero (invalid proof data)
     error InvalidStateRoot();
-    /// @notice M-11 FIX: Proof timestamp is too old (exceeds MAX_PROOF_AGE)
+    /// @notice Proof timestamp is too old (exceeds MAX_PROOF_AGE)
     error ProofTooOld(uint64 proofTimestamp, uint64 currentTimestamp);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // PROOF AGE VALIDATION (M-11 FIX)
+    // PROOF AGE VALIDATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Validate that a proof timestamp is not too old
@@ -135,7 +135,7 @@ library BeaconChainProofs {
     /// @param beaconBlockRoot The beacon block root to verify against
     /// @param stateRootProof The proof containing state root and merkle proof
     /// @return True if verification succeeds
-    /// @dev M-11 FIX: Added validation for zero beacon block root (genesis block edge case)
+    /// @dev Added validation for zero beacon block root (genesis block edge case)
     ///      and zero state root to prevent invalid proof acceptance
     function verifyStateRoot(
         bytes32 beaconBlockRoot,
@@ -145,13 +145,13 @@ library BeaconChainProofs {
         pure
         returns (bool)
     {
-        // M-11 FIX: Reject zero beacon block root (could be genesis block or invalid root)
+        // Reject zero beacon block root (could be genesis block or invalid root)
         // EIP-4788 returns 0 for timestamps before the fork or invalid timestamps
         if (beaconBlockRoot == bytes32(0)) {
             revert InvalidBeaconBlockRoot();
         }
 
-        // M-11 FIX: Reject zero state root as it indicates invalid proof data
+        // Reject zero state root as it indicates invalid proof data
         if (stateRootProof.beaconStateRoot == bytes32(0)) {
             revert InvalidStateRoot();
         }
@@ -216,7 +216,7 @@ library BeaconChainProofs {
     /// @param beaconStateRoot The beacon state root (must be verified separately against block root)
     /// @param proof The balance container proof
     /// @return True if verification succeeds
-    /// @dev C-3 FIX: Now correctly verifies against state root, not block root
+    /// @dev Now correctly verifies against state root, not block root
     function verifyBalanceContainer(
         bytes32 beaconStateRoot,
         ValidatorTypes.BalanceContainerProof calldata proof

--- a/src/beacon/L2SlashingReceiver.sol
+++ b/src/beacon/L2SlashingReceiver.sol
@@ -73,7 +73,7 @@ contract L2SlashingReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     /// @notice Message type for beacon chain slashing
     bytes4 public constant SLASH_MESSAGE_TYPE = bytes4(keccak256("BEACON_SLASH"));
 
-    /// @notice H-4 FIX: Delay before new authorized senders become active
+    /// @notice Delay before new authorized senders become active
     uint256 public constant SENDER_ACTIVATION_DELAY = 2 days;
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -90,9 +90,9 @@ contract L2SlashingReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         address messenger;
         // Authorized senders per source chain
         mapping(uint256 => mapping(address => bool)) authorizedSenders;
-        // H-4 FIX: pending authorizations (chainId => sender => activation timestamp)
+        // pending authorizations (chainId => sender => activation timestamp)
         mapping(uint256 => mapping(address => uint256)) pendingAuthorizedSenders;
-        // C-2: timelocked admin swaps for messenger / slasher
+        // timelocked admin swaps for messenger / slasher
         address pendingMessenger;
         uint256 pendingMessengerAt;
         address pendingSlasher;
@@ -282,7 +282,7 @@ contract L2SlashingReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     // ADMIN
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice H-4 FIX: Schedule authorization of a sender (subject to timelock)
+    /// @notice Schedule authorization of a sender (subject to timelock)
     /// @dev For revoking authorization, takes effect immediately
     function setAuthorizedSender(uint256 chainId, address sender, bool authorized) external onlyOwner {
         ReceiverStorage storage $ = _getStorage();
@@ -299,7 +299,7 @@ contract L2SlashingReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         }
     }
 
-    /// @notice H-4 FIX: Activate a pending authorized sender after delay
+    /// @notice Activate a pending authorized sender after delay
     function activateAuthorizedSender(uint256 chainId, address sender) external onlyOwner {
         ReceiverStorage storage $ = _getStorage();
         uint256 activationTime = $.pendingAuthorizedSenders[chainId][sender];

--- a/src/beacon/ValidatorPod.sol
+++ b/src/beacon/ValidatorPod.sol
@@ -9,7 +9,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @title IValidatorPodManager
-/// @notice Interface for the pod manager (forward declaration). G-02 follow-up:
+/// @notice Interface for the pod manager (forward declaration).
 ///         splits the legacy signed-delta entry point into explicit
 ///         deposit-mints-shares and rebase-moves-assets methods so the call
 ///         site's intent is unambiguous in the ABI.
@@ -70,11 +70,11 @@ contract ValidatorPod is ReentrancyGuard {
     /// @notice ETH balance that has been withdrawn but not yet claimed
     uint256 public withdrawableRestakedExecutionLayerGwei;
 
-    /// @notice H-1 FIX: Total restaked balance across all active validators (in gwei)
+    /// @notice Total restaked balance across all active validators (in gwei)
     /// @dev Maintained as running total for gas efficiency
     uint64 public totalRestakedBalanceGwei;
 
-    /// @notice H-5 FIX: Maximum age for beacon roots (27 hours like EigenLayer)
+    /// @notice Maximum age for beacon roots (27 hours like EigenLayer)
     /// @dev EIP-4788 stores roots for 8191 slots (~27 hours)
     uint256 public constant MAX_BEACON_ROOT_AGE = 27 hours;
 
@@ -197,7 +197,7 @@ contract ValidatorPod is ReentrancyGuard {
         onlyPodOwner
         nonReentrant
     {
-        // H-5 FIX: Check beacon root is not stale
+        // Check beacon root is not stale
         if (block.timestamp > beaconTimestamp + MAX_BEACON_ROOT_AGE) {
             revert StaleProof();
         }
@@ -230,7 +230,7 @@ contract ValidatorPod is ReentrancyGuard {
         // Mint pod-pool shares for the newly verified principal. Distinct from
         // the rebase path below — credential verification adds principal, so we
         // call the explicit deposit entry point instead of the legacy signed
-        // delta. (G-02 follow-up: dropped the silent-semantics back-compat
+        // delta. (dropped the silent-semantics back-compat
         // shim; ValidatorPod now invokes the two explicit entry points.)
         if (totalRestakedGwei > 0) {
             podManager.recordBeaconChainDeposit(podOwner, uint256(totalRestakedGwei) * 1 gwei);
@@ -350,7 +350,7 @@ contract ValidatorPod is ReentrancyGuard {
 
         ValidatorTypes.Checkpoint memory checkpoint = currentCheckpoint;
 
-        // C-3 FIX: Two-step verification - first verify state root against block root
+        // Two-step verification - first verify state root against block root
         if (!BeaconChainProofs.verifyStateRoot(checkpoint.beaconBlockRoot, stateRootProof)) {
             revert ProofVerificationFailed();
         }
@@ -410,7 +410,7 @@ contract ValidatorPod is ReentrancyGuard {
         info.restakedBalanceGwei = currentBalance;
         info.lastCheckpointedAt = currentCheckpointTimestamp;
 
-        // H-1 FIX: Update total restaked balance tracking
+        // Update total restaked balance tracking
         if (currentBalance > previousBalance) {
             totalRestakedBalanceGwei += (currentBalance - previousBalance);
         } else if (previousBalance > currentBalance) {
@@ -604,7 +604,7 @@ contract ValidatorPod is ReentrancyGuard {
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Get total restaked gwei across all active validators
-    /// @dev H-1 FIX: Now returns the tracked running total instead of 0
+    /// @dev Now returns the tracked running total instead of 0
     function _getTotalRestakedGwei() internal view returns (uint64) {
         return totalRestakedBalanceGwei;
     }

--- a/src/beacon/ValidatorPodManager.sol
+++ b/src/beacon/ValidatorPodManager.sol
@@ -26,10 +26,10 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 ///      Virtual offsets (`VIRTUAL_SHARES = VIRTUAL_ASSETS = 1e3`) defend against
 ///      first-depositor inflation attacks on both pools.
 ///
-///      External ABI is preserved: `delegations(d,o)`, `operatorDelegatedStake(o)` and
-///      `getDelegation/getOperatorDelegatedStake` continue to return asset-denominated
-///      values. Post-slash, those values reflect the slashed amount automatically via
-///      the share-to-asset conversion.
+///      External ABI: `delegations(d,o)` and `operatorDelegatedStake(o)` return
+///      asset-denominated values derived from the per-operator share pool. Post-slash,
+///      those values reflect the slashed amount automatically via share-to-asset
+///      conversion.
 contract ValidatorPodManager is IStaking, Ownable, ReentrancyGuard {
     using Math for uint256;
 
@@ -92,31 +92,12 @@ contract ValidatorPodManager is IStaking, Ownable, ReentrancyGuard {
     /// @notice Operator self-stake
     mapping(address operator => uint256) public operatorStake;
 
-    /// @notice Legacy slot: was `mapping(address => mapping(address => uint256)) public delegations`.
-    /// @dev Retained as internal storage so the contract's storage layout is unchanged.
-    ///      External reads now go through the `delegations(address,address)` view function
-    ///      below which converts the delegator's pool shares back to assets.
-    mapping(address delegator => mapping(address operator => uint256)) internal _legacyDelegations;
-
-    /// @notice Legacy slot: was `mapping(address => uint256) public operatorDelegatedStake`.
-    /// @dev Retained as internal storage; the public view is now the operator pool's
-    ///      `totalAssets`. Storage slot is preserved to avoid relayout.
-    mapping(address operator => uint256) internal _legacyOperatorDelegatedStake;
-
     /// @notice Total amount delegated by a delegator (in asset units, deposit-accounted).
-    /// @dev This is a deposit/withdraw counter used for headroom checks and is NOT
-    ///      slash-adjusted. It overstates committed delegation after slashes, which is
-    ///      conservative -- it can only block new delegations, never permit over-delegation.
-    ///      Live per-(delegator, operator) asset value is available via `getDelegation`.
+    /// @dev Deposit/withdraw counter used for headroom checks; NOT slash-adjusted. It
+    ///      overstates committed delegation after slashes, which is conservative — it
+    ///      can only block new delegations, never permit over-delegation. Live
+    ///      per-(delegator, operator) asset value is available via `getDelegation`.
     mapping(address delegator => uint256) public delegatorTotalDelegated;
-
-    /// @notice Legacy slot: was `mapping(address => address[]) _operatorDelegators`.
-    /// @dev No longer written; kept as a storage placeholder so subsequent slots keep
-    ///      their positions. New deployments will leave this empty.
-    mapping(address operator => address[]) internal _legacyOperatorDelegators;
-
-    /// @notice Legacy slot: was `mapping(address => mapping(address => bool)) _isDelegator`.
-    mapping(address operator => mapping(address delegator => bool)) internal _legacyIsDelegator;
 
     /// @notice Authorized slashers
     mapping(address => bool) internal _slashers;

--- a/src/beacon/bridges/ArbitrumCrossChainMessenger.sol
+++ b/src/beacon/bridges/ArbitrumCrossChainMessenger.sol
@@ -58,10 +58,10 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
     /// @notice Default L2 gas price (can be overridden)
     uint256 public l2MaxFeePerGas = 0.1 gwei;
 
-    /// @notice M-12 FIX: Minimum gas limit for L2 execution (prevents insufficient gas)
+    /// @notice Minimum gas limit for L2 execution (prevents insufficient gas)
     uint256 public minGasLimit = 100_000;
 
-    /// @notice M-12 FIX: Gas buffer percentage (in basis points, 10000 = 100%)
+    /// @notice Gas buffer percentage (in basis points, 10000 = 100%)
     /// @dev Adds safety margin to requested gas limit
     uint256 public gasBufferBps = 1000; // 10% buffer by default
 
@@ -79,7 +79,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
     /// @notice Owner for configuration
     address public owner;
 
-    /// @notice M-12 FIX: Events for gas configuration changes
+    /// @notice Events for gas configuration changes
     event MinGasLimitUpdated(uint256 oldLimit, uint256 newLimit);
     event GasBufferUpdated(uint256 oldBuffer, uint256 newBuffer);
     event L2RefundAddressUpdated(address indexed oldAddress, address indexed newAddress);
@@ -101,7 +101,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Gas limit is now enforced to be at least minGasLimit and includes buffer
+    /// @dev Gas limit is now enforced to be at least minGasLimit and includes buffer
     function sendMessage(
         uint256 destinationChainId,
         address target,
@@ -117,7 +117,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
             "Unsupported chain"
         );
 
-        // M-12 FIX: Apply minimum gas limit and add safety buffer
+        // Apply minimum gas limit and add safety buffer
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode the cross-chain call
@@ -151,7 +151,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Fee estimation now includes gas buffer for accurate cost
+    /// @dev Fee estimation now includes gas buffer for accurate cost
     function estimateFee(
         uint256, // destinationChainId
         bytes calldata payload,
@@ -161,7 +161,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
         view
         returns (uint256 fee)
     {
-        // M-12 FIX: Apply minimum gas limit and buffer for accurate estimation
+        // Apply minimum gas limit and buffer for accurate estimation
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode call to estimate size
@@ -187,7 +187,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
         l2MaxFeePerGas = _l2MaxFeePerGas;
     }
 
-    /// @notice M-12 FIX: Set minimum gas limit for L2 execution
+    /// @notice Set minimum gas limit for L2 execution
     /// @param _minGasLimit New minimum gas limit
     function setMinGasLimit(uint256 _minGasLimit) external onlyOwner {
         uint256 oldLimit = minGasLimit;
@@ -195,7 +195,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
         emit MinGasLimitUpdated(oldLimit, _minGasLimit);
     }
 
-    /// @notice M-12 FIX: Set gas buffer percentage
+    /// @notice Set gas buffer percentage
     /// @param _gasBufferBps New buffer in basis points (10000 = 100%)
     function setGasBuffer(uint256 _gasBufferBps) external onlyOwner {
         require(_gasBufferBps <= 10_000, "Buffer too high"); // Max 100% buffer
@@ -217,7 +217,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
         emit L2RefundAddressUpdated(old, newAddress);
     }
 
-    /// @notice M-12 FIX: Apply minimum gas limit and safety buffer
+    /// @notice Apply minimum gas limit and safety buffer
     /// @param gasLimit Requested gas limit
     /// @return Effective gas limit with buffer applied
     function _applyGasLimitWithBuffer(uint256 gasLimit) internal view returns (uint256) {
@@ -238,7 +238,7 @@ contract ArbitrumCrossChainMessenger is ICrossChainMessenger {
 /// @title ArbitrumL2Receiver
 /// @notice Adapter for receiving messages on Arbitrum L2 from L1
 /// @dev Validates sender is the aliased L1 contract
-///      M-12 FIX: Added message replay protection
+///      Added message replay protection
 ///      C-3 (Round 4): Converted to UUPS upgradeable. Deploy behind ERC1967Proxy
 ///      and call `initialize(...)`.
 contract ArbitrumL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
@@ -268,10 +268,10 @@ contract ArbitrumL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         }
     }
 
-    /// @notice M-12 FIX: Event emitted when a message is processed
+    /// @notice Event emitted when a message is processed
     event MessageProcessed(bytes32 indexed messageId, address indexed sender, uint256 nonce);
 
-    /// @notice M-12 FIX: Error for replayed messages
+    /// @notice Error for replayed messages
     error MessageAlreadyProcessed(bytes32 messageId);
     error ZeroAddress();
 
@@ -327,7 +327,7 @@ contract ArbitrumL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     }
 
     /// @notice Relay message from L1 (called via retryable ticket)
-    /// @dev M-12 FIX: Added message ID validation to prevent replay attacks
+    /// @dev Added message ID validation to prevent replay attacks
     function relayMessage(bytes calldata payload) external {
         ArbitrumL2ReceiverStorage storage $ = _getStorage();
         address sender_ = $.l1Sender;
@@ -338,12 +338,12 @@ contract ArbitrumL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         // Deduplicate identical bridged payload deliveries from the same L1 sender.
         bytes32 messageId = keccak256(abi.encode(block.chainid, sender_, payload));
 
-        // M-12 FIX: Check for replay attack
+        // Check for replay attack
         if ($.processedMessages[messageId]) {
             revert MessageAlreadyProcessed(messageId);
         }
 
-        // M-12 FIX: Mark message as processed before external call (CEI pattern)
+        // Mark message as processed before external call (CEI pattern)
         $.processedMessages[messageId] = true;
         uint256 currentNonce = $.messageNonce++;
 
@@ -352,7 +352,7 @@ contract ArbitrumL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         $.receiver.receiveMessage($.sourceChainId, sender_, payload);
     }
 
-    /// @notice M-12 FIX: Check if a message ID has been processed
+    /// @notice Check if a message ID has been processed
     /// @param messageId The message ID to check
     /// @return True if the message has been processed
     function isMessageProcessed(bytes32 messageId) external view returns (bool) {

--- a/src/beacon/bridges/BaseCrossChainMessenger.sol
+++ b/src/beacon/bridges/BaseCrossChainMessenger.sol
@@ -24,16 +24,16 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
     uint256 public constant BASE_CHAIN_ID = 8453;
     uint256 public constant BASE_SEPOLIA_CHAIN_ID = 84_532;
 
-    /// @notice M-12 FIX: Owner for configuration
+    /// @notice Owner for configuration
     address public owner;
 
-    /// @notice M-12 FIX: Minimum gas limit for L2 execution
+    /// @notice Minimum gas limit for L2 execution
     uint256 public minGasLimit = 100_000;
 
-    /// @notice M-12 FIX: Gas buffer percentage (in basis points, 10000 = 100%)
+    /// @notice Gas buffer percentage (in basis points, 10000 = 100%)
     uint256 public gasBufferBps = 1000; // 10% buffer by default
 
-    /// @notice M-12 FIX: Events for gas configuration changes
+    /// @notice Events for gas configuration changes
     event MinGasLimitUpdated(uint256 oldLimit, uint256 newLimit);
     event GasBufferUpdated(uint256 oldBuffer, uint256 newBuffer);
 
@@ -50,7 +50,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Gas limit is now enforced to be at least minGasLimit and includes buffer
+    /// @dev Gas limit is now enforced to be at least minGasLimit and includes buffer
     function sendMessage(
         uint256 destinationChainId,
         address target,
@@ -63,7 +63,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
     {
         require(destinationChainId == BASE_CHAIN_ID || destinationChainId == BASE_SEPOLIA_CHAIN_ID, "Unsupported chain");
 
-        // M-12 FIX: Apply minimum gas limit and add safety buffer
+        // Apply minimum gas limit and add safety buffer
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Base native messaging
@@ -99,7 +99,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
         return chainId == BASE_CHAIN_ID || chainId == BASE_SEPOLIA_CHAIN_ID;
     }
 
-    /// @notice M-12 FIX: Set minimum gas limit for L2 execution
+    /// @notice Set minimum gas limit for L2 execution
     /// @param _minGasLimit New minimum gas limit
     function setMinGasLimit(uint256 _minGasLimit) external onlyOwner {
         uint256 oldLimit = minGasLimit;
@@ -107,7 +107,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
         emit MinGasLimitUpdated(oldLimit, _minGasLimit);
     }
 
-    /// @notice M-12 FIX: Set gas buffer percentage
+    /// @notice Set gas buffer percentage
     /// @param _gasBufferBps New buffer in basis points (10000 = 100%)
     function setGasBuffer(uint256 _gasBufferBps) external onlyOwner {
         require(_gasBufferBps <= 10_000, "Buffer too high"); // Max 100% buffer
@@ -116,7 +116,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
         emit GasBufferUpdated(oldBuffer, _gasBufferBps);
     }
 
-    /// @notice M-12 FIX: Apply minimum gas limit and safety buffer
+    /// @notice Apply minimum gas limit and safety buffer
     /// @param gasLimit Requested gas limit
     /// @return Effective gas limit with buffer applied
     function _applyGasLimitWithBuffer(uint256 gasLimit) internal view returns (uint256) {
@@ -136,7 +136,7 @@ contract BaseCrossChainMessenger is ICrossChainMessenger {
 
 /// @title BaseL2Receiver
 /// @notice Adapter for receiving messages on Base L2
-/// @dev M-12 FIX: Added message replay protection
+/// @dev Added message replay protection
 ///      C-3 (Round 4): Converted to UUPS upgradeable. Deploy behind ERC1967Proxy
 ///      and call `initialize(...)`.
 contract BaseL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
@@ -164,10 +164,10 @@ contract BaseL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         }
     }
 
-    /// @notice M-12 FIX: Event emitted when a message is processed
+    /// @notice Event emitted when a message is processed
     event MessageProcessed(bytes32 indexed messageId, address indexed sender, uint256 nonce);
 
-    /// @notice M-12 FIX: Error for replayed messages
+    /// @notice Error for replayed messages
     error MessageAlreadyProcessed(bytes32 messageId);
     error ZeroAddress();
 
@@ -219,7 +219,7 @@ contract BaseL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     }
 
     /// @notice Relay message from L1
-    /// @dev M-12 FIX: Added message ID validation to prevent replay attacks
+    /// @dev Added message ID validation to prevent replay attacks
     function relayMessage(bytes calldata payload) external {
         BaseL2ReceiverStorage storage $ = _getStorage();
         IBaseCrossDomainMessenger msgr = $.l2Messenger;
@@ -231,12 +231,12 @@ contract BaseL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         // Deduplicate identical bridged payload deliveries from the same L1 sender.
         bytes32 messageId = keccak256(abi.encode(block.chainid, sender_, payload));
 
-        // M-12 FIX: Check for replay attack
+        // Check for replay attack
         if ($.processedMessages[messageId]) {
             revert MessageAlreadyProcessed(messageId);
         }
 
-        // M-12 FIX: Mark message as processed before external call (CEI pattern)
+        // Mark message as processed before external call (CEI pattern)
         $.processedMessages[messageId] = true;
         uint256 currentNonce = $.messageNonce++;
 
@@ -245,7 +245,7 @@ contract BaseL2Receiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         $.receiver.receiveMessage($.sourceChainId, sender_, payload);
     }
 
-    /// @notice M-12 FIX: Check if a message ID has been processed
+    /// @notice Check if a message ID has been processed
     function isMessageProcessed(bytes32 messageId) external view returns (bool) {
         return _getStorage().processedMessages[messageId];
     }

--- a/src/beacon/bridges/HyperlaneCrossChainMessenger.sol
+++ b/src/beacon/bridges/HyperlaneCrossChainMessenger.sol
@@ -74,10 +74,10 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
     /// @notice Mapping from Hyperlane domain ID to EVM chainId
     mapping(uint32 => uint256) public domainToChainId;
 
-    /// @notice M-12 FIX: Minimum gas limit for destination chain execution
+    /// @notice Minimum gas limit for destination chain execution
     uint256 public minGasLimit = 100_000;
 
-    /// @notice M-12 FIX: Gas buffer percentage (in basis points, 10000 = 100%)
+    /// @notice Gas buffer percentage (in basis points, 10000 = 100%)
     uint256 public gasBufferBps = 1000; // 10% buffer by default
 
     /// @notice Events
@@ -121,7 +121,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Gas limit is now enforced to be at least minGasLimit and includes buffer
+    /// @dev Gas limit is now enforced to be at least minGasLimit and includes buffer
     function sendMessage(
         uint256 destinationChainId,
         address target,
@@ -135,7 +135,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
         uint32 destDomain = chainIdToDomain[destinationChainId];
         require(destDomain != 0, "Unsupported chain");
 
-        // M-12 FIX: Apply minimum gas limit and add safety buffer
+        // Apply minimum gas limit and add safety buffer
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode message with sender info for the receiver
@@ -168,7 +168,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Fee estimation now includes gas buffer for accurate cost
+    /// @dev Fee estimation now includes gas buffer for accurate cost
     function estimateFee(
         uint256 destinationChainId,
         bytes calldata payload,
@@ -181,7 +181,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
         uint32 destDomain = chainIdToDomain[destinationChainId];
         if (destDomain == 0) return 0;
 
-        // M-12 FIX: Apply minimum gas limit and buffer for accurate estimation
+        // Apply minimum gas limit and buffer for accurate estimation
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode message
@@ -222,7 +222,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
         owner = newOwner;
     }
 
-    /// @notice M-12 FIX: Set minimum gas limit for destination chain execution
+    /// @notice Set minimum gas limit for destination chain execution
     /// @param _minGasLimit New minimum gas limit
     function setMinGasLimit(uint256 _minGasLimit) external onlyOwner {
         uint256 oldLimit = minGasLimit;
@@ -230,7 +230,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
         emit MinGasLimitUpdated(oldLimit, _minGasLimit);
     }
 
-    /// @notice M-12 FIX: Set gas buffer percentage
+    /// @notice Set gas buffer percentage
     /// @param _gasBufferBps New buffer in basis points (10000 = 100%)
     function setGasBuffer(uint256 _gasBufferBps) external onlyOwner {
         require(_gasBufferBps <= 10_000, "Buffer too high"); // Max 100% buffer
@@ -239,7 +239,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
         emit GasBufferUpdated(oldBuffer, _gasBufferBps);
     }
 
-    /// @notice M-12 FIX: Apply minimum gas limit and safety buffer
+    /// @notice Apply minimum gas limit and safety buffer
     /// @param gasLimit Requested gas limit
     /// @return Effective gas limit with buffer applied
     function _applyGasLimitWithBuffer(uint256 gasLimit) internal view returns (uint256) {
@@ -264,7 +264,7 @@ contract HyperlaneCrossChainMessenger is ICrossChainMessenger {
 /// @title HyperlaneReceiver
 /// @notice Hyperlane MessageRecipient for receiving cross-chain messages
 /// @dev Implements handle() to process incoming messages
-///      M-12 FIX: Added message replay protection
+///      Added message replay protection
 ///      C-3 (Round 4): Converted to UUPS upgradeable. Deploy behind ERC1967Proxy
 ///      and call `initialize(...)`.
 contract HyperlaneReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
@@ -297,10 +297,10 @@ contract HyperlaneReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
     /// @notice Events
     event MessageHandled(uint32 indexed origin, bytes32 sender, uint256 sourceChainId);
     event TrustedSenderSet(uint32 domain, bytes32 sender, bool trusted);
-    /// @notice M-12 FIX: Event emitted when a message is processed
+    /// @notice Event emitted when a message is processed
     event MessageProcessed(bytes32 indexed messageId, uint32 indexed origin, bytes32 sender);
 
-    /// @notice M-12 FIX: Error for replayed messages
+    /// @notice Error for replayed messages
     error MessageAlreadyProcessed(bytes32 messageId);
     error ZeroAddress();
 
@@ -365,22 +365,22 @@ contract HyperlaneReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
     /// @param _origin Origin domain ID
     /// @param _sender Sender address as bytes32
     /// @param _message Message body
-    /// @dev M-12 FIX: Added message ID validation to prevent replay attacks
+    /// @dev Added message ID validation to prevent replay attacks
     function handle(uint32 _origin, bytes32 _sender, bytes calldata _message) external payable onlyMailbox {
         HyperlaneReceiverStorage storage $ = _getStorage();
 
         // Verify trusted sender
         require($.trustedSenders[_origin][_sender], "Untrusted sender");
 
-        // M-12 FIX: Generate unique message ID from origin, sender, and message content
+        // Generate unique message ID from origin, sender, and message content
         bytes32 messageId = keccak256(abi.encode(_origin, _sender, keccak256(_message)));
 
-        // M-12 FIX: Check for replay attack
+        // Check for replay attack
         if ($.processedMessages[messageId]) {
             revert MessageAlreadyProcessed(messageId);
         }
 
-        // M-12 FIX: Mark message as processed before external call (CEI pattern)
+        // Mark message as processed before external call (CEI pattern)
         $.processedMessages[messageId] = true;
 
         // Decode message
@@ -409,7 +409,7 @@ contract HyperlaneReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
         _getStorage().domainToChainId[domain] = chainId;
     }
 
-    /// @notice M-12 FIX: Check if a message ID has been processed
+    /// @notice Check if a message ID has been processed
     function isMessageProcessed(bytes32 messageId) external view returns (bool) {
         return _getStorage().processedMessages[messageId];
     }

--- a/src/beacon/bridges/LayerZeroCrossChainMessenger.sol
+++ b/src/beacon/bridges/LayerZeroCrossChainMessenger.sol
@@ -91,10 +91,10 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
     /// @notice Trusted peers on each chain (eid => peer address as bytes32)
     mapping(uint32 => bytes32) public peers;
 
-    /// @notice M-12 FIX: Minimum gas limit for destination chain execution
+    /// @notice Minimum gas limit for destination chain execution
     uint256 public minGasLimit = 100_000;
 
-    /// @notice M-12 FIX: Gas buffer percentage (in basis points, 10000 = 100%)
+    /// @notice Gas buffer percentage (in basis points, 10000 = 100%)
     uint256 public gasBufferBps = 1000; // 10% buffer by default
 
     /// @notice Events
@@ -140,7 +140,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Gas limit is now enforced to be at least minGasLimit and includes buffer
+    /// @dev Gas limit is now enforced to be at least minGasLimit and includes buffer
     function sendMessage(
         uint256 destinationChainId,
         address target,
@@ -154,7 +154,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
         uint32 dstEid = chainIdToEid[destinationChainId];
         require(dstEid != 0, "Unsupported chain");
 
-        // M-12 FIX: Apply minimum gas limit and add safety buffer
+        // Apply minimum gas limit and add safety buffer
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode full message with sender info
@@ -178,7 +178,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
     }
 
     /// @inheritdoc ICrossChainMessenger
-    /// @dev M-12 FIX: Fee estimation now includes gas buffer for accurate cost
+    /// @dev Fee estimation now includes gas buffer for accurate cost
     function estimateFee(
         uint256 destinationChainId,
         bytes calldata payload,
@@ -191,7 +191,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
         uint32 dstEid = chainIdToEid[destinationChainId];
         if (dstEid == 0) return 0;
 
-        // M-12 FIX: Apply minimum gas limit and buffer for accurate estimation
+        // Apply minimum gas limit and buffer for accurate estimation
         uint256 effectiveGasLimit = _applyGasLimitWithBuffer(gasLimit);
 
         // Encode message
@@ -234,7 +234,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
         owner = newOwner;
     }
 
-    /// @notice M-12 FIX: Set minimum gas limit for destination chain execution
+    /// @notice Set minimum gas limit for destination chain execution
     /// @param _minGasLimit New minimum gas limit
     function setMinGasLimit(uint256 _minGasLimit) external onlyOwner {
         uint256 oldLimit = minGasLimit;
@@ -242,7 +242,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
         emit MinGasLimitUpdated(oldLimit, _minGasLimit);
     }
 
-    /// @notice M-12 FIX: Set gas buffer percentage
+    /// @notice Set gas buffer percentage
     /// @param _gasBufferBps New buffer in basis points (10000 = 100%)
     function setGasBuffer(uint256 _gasBufferBps) external onlyOwner {
         require(_gasBufferBps <= 10_000, "Buffer too high"); // Max 100% buffer
@@ -251,7 +251,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
         emit GasBufferUpdated(oldBuffer, _gasBufferBps);
     }
 
-    /// @notice M-12 FIX: Apply minimum gas limit and safety buffer
+    /// @notice Apply minimum gas limit and safety buffer
     /// @param gasLimit Requested gas limit
     /// @return Effective gas limit with buffer applied
     function _applyGasLimitWithBuffer(uint256 gasLimit) internal view returns (uint256) {
@@ -270,7 +270,7 @@ contract LayerZeroCrossChainMessenger is ICrossChainMessenger {
 /// @title LayerZeroReceiver
 /// @notice OApp-compatible receiver for LayerZero V2 messages
 /// @dev Implements lzReceive to process incoming cross-chain messages
-///      M-12 FIX: Added message replay protection using GUID
+///      Added message replay protection using GUID
 ///      C-3 (Round 4): Converted to UUPS upgradeable. Deploy behind ERC1967Proxy
 ///      and call `initialize(...)`.
 contract LayerZeroReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable {
@@ -302,10 +302,10 @@ contract LayerZeroReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
 
     /// @notice Events
     event MessageReceived(uint32 indexed srcEid, bytes32 sender, uint256 sourceChainId, address originalSender);
-    /// @notice M-12 FIX: Event emitted when a message is processed
+    /// @notice Event emitted when a message is processed
     event MessageProcessed(bytes32 indexed guid, uint32 indexed srcEid, bytes32 sender);
 
-    /// @notice M-12 FIX: Error for replayed messages
+    /// @notice Error for replayed messages
     error MessageAlreadyProcessed(bytes32 guid);
     error ZeroAddress();
 
@@ -354,7 +354,7 @@ contract LayerZeroReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
 
     /// @notice LayerZero V2 receive function
     /// @dev Called by the endpoint when a message arrives
-    ///      M-12 FIX: Added GUID validation to prevent replay attacks
+    ///      Added GUID validation to prevent replay attacks
     function lzReceive(
         Origin calldata _origin,
         bytes32 _guid,
@@ -371,12 +371,12 @@ contract LayerZeroReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
         // Verify sender is trusted peer
         require($.peers[_origin.srcEid] == _origin.sender, "Untrusted peer");
 
-        // M-12 FIX: Check for replay attack using LayerZero's unique GUID
+        // Check for replay attack using LayerZero's unique GUID
         if ($.processedMessages[_guid]) {
             revert MessageAlreadyProcessed(_guid);
         }
 
-        // M-12 FIX: Mark message as processed before external call (CEI pattern)
+        // Mark message as processed before external call (CEI pattern)
         $.processedMessages[_guid] = true;
 
         // Decode message
@@ -403,7 +403,7 @@ contract LayerZeroReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeable
         _getStorage().eidToChainId[eid] = chainId;
     }
 
-    /// @notice M-12 FIX: Check if a message GUID has been processed
+    /// @notice Check if a message GUID has been processed
     function isMessageProcessed(bytes32 guid) external view returns (bool) {
         return _getStorage().processedMessages[guid];
     }

--- a/src/core/Base.sol
+++ b/src/core/Base.sol
@@ -18,6 +18,7 @@ import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager
 import { IMetricsRecorder } from "../interfaces/IMetricsRecorder.sol";
 import { IMBSMRegistry } from "../interfaces/IMBSMRegistry.sol";
 import { IOperatorStatusRegistry } from "../staking/OperatorStatusRegistry.sol";
+import { IPriceOracle } from "../oracles/interfaces/IPriceOracle.sol";
 import { ProtocolConfig } from "../config/ProtocolConfig.sol";
 
 /// @title Base
@@ -66,6 +67,11 @@ abstract contract Base is
     ///         the capped gas stipend. Observable so off-chain monitors can detect a
     ///         misbehaving BSM without halting the protocol path.
     event ManagerHookFailed(address indexed manager, bytes4 indexed selector, bytes returnData);
+
+    /// @notice Emitted when a price-oracle query reverted on the billing hot path and
+    ///         the protocol fell back to raw token-second weighting. The bill still
+    ///         completes; off-chain monitors should investigate the oracle health.
+    event PriceOracleFallback(address indexed oracle, address indexed token, bytes returnData);
 
     /// @notice Emitted when the metrics recorder is updated
     /// @param recorder The new recorder address (or zero to disable)
@@ -382,7 +388,7 @@ abstract contract Base is
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // SERVICE REQUEST TTL CONFIGURATION (M-1 fix)
+    // SERVICE REQUEST TTL CONFIGURATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Configure minimum TTL for service requests (0 = use protocol default)
@@ -609,26 +615,25 @@ abstract contract Base is
         uint8 maxMissed = 0; // 0 means use registry default
 
         if (manager != address(0)) {
-            // Try to get custom heartbeat interval
-            try IBlueprintServiceManager(manager).getHeartbeatInterval(serviceId) returns (
-                bool useDefault, uint64 customInterval
-            ) {
-                if (!useDefault && customInterval > 0) {
-                    interval = customInterval;
-                }
-            } catch { }
+            (bool okInt, bytes memory retInt) = _tryStaticcallManager(
+                manager, abi.encodeWithSelector(IBlueprintServiceManager.getHeartbeatInterval.selector, serviceId), 64
+            );
+            if (okInt) {
+                (bool useDefault, uint64 customInterval) = abi.decode(retInt, (bool, uint64));
+                if (!useDefault && customInterval > 0) interval = customInterval;
+            }
 
-            // Try to get custom heartbeat threshold (max missed before offline)
-            try IBlueprintServiceManager(manager).getHeartbeatThreshold(serviceId) returns (
-                bool useDefault, uint8 threshold
-            ) {
+            (bool okThr, bytes memory retThr) = _tryStaticcallManager(
+                manager, abi.encodeWithSelector(IBlueprintServiceManager.getHeartbeatThreshold.selector, serviceId), 64
+            );
+            if (okThr) {
+                (bool useDefault, uint8 threshold) = abi.decode(retThr, (bool, uint8));
                 if (!useDefault && threshold > 0) {
-                    // threshold is percentage, we interpret high values as max missed beats
-                    // Lower threshold = stricter = fewer missed allowed
-                    // e.g., 90% threshold ≈ allow 1 missed, 50% ≈ allow 3 missed
+                    // threshold is a percentage; mapped to max-missed beats inversely
+                    // (90% ≈ 1 missed, 50% ≈ 3 missed).
                     maxMissed = threshold > 80 ? 1 : (threshold > 50 ? 2 : 3);
                 }
-            } catch { }
+            }
         }
 
         // Register service owner and configure heartbeat
@@ -711,11 +716,13 @@ abstract contract Base is
         view
         returns (bool hasResult, bool allowed)
     {
-        try IBlueprintServiceManager(manager).queryIsPaymentAssetAllowed(contextId, asset) returns (bool isAllowed) {
-            return (true, isAllowed);
-        } catch {
-            return (false, false);
-        }
+        (bool ok, bytes memory ret) = _tryStaticcallManager(
+            manager,
+            abi.encodeWithSelector(IBlueprintServiceManager.queryIsPaymentAssetAllowed.selector, contextId, asset),
+            32
+        );
+        if (!ok) return (false, false);
+        return (true, abi.decode(ret, (bool)));
     }
 
     /// @notice Maximum gas forwarded to a blueprint manager hook.
@@ -745,6 +752,63 @@ abstract contract Base is
         if (!success) {
             emit ManagerHookFailed(manager, bytes4(data), returnData);
         }
+    }
+
+    /// @notice Best-effort gas-capped staticcall to a manager view hook.
+    /// @dev Returns `(false, "")` on revert, on a manager set to `address(0)`, on calls
+    ///      that consumed more than `MANAGER_HOOK_GAS_LIMIT` gas, or on returndata
+    ///      shorter than `minReturnLen`. Callers MUST treat the failure case as
+    ///      "no answer" and fall back to a safe default; never trust an `ok=false`
+    ///      branch to surface a structured error.
+    function _tryStaticcallManager(
+        address manager,
+        bytes memory data,
+        uint256 minReturnLen
+    )
+        internal
+        view
+        returns (bool ok, bytes memory ret)
+    {
+        if (manager == address(0)) return (false, "");
+        (ok, ret) = manager.staticcall{ gas: MANAGER_HOOK_GAS_LIMIT }(data);
+        if (!ok || ret.length < minReturnLen) return (false, "");
+    }
+
+    /// @notice Maximum gas forwarded to the price-oracle adapter per query.
+    /// @dev Same cap pattern as `MANAGER_HOOK_GAS_LIMIT`: bounds the cost of a buggy
+    ///      or adversarial oracle adapter on the billing hot path so the keeper's
+    ///      gas budget cannot be drained.
+    uint256 internal constant ORACLE_QUERY_GAS_LIMIT = 250_000;
+
+    /// @notice Best-effort `toUSD` query with a gas cap and revert isolation.
+    /// @dev Returns the raw `amount` on revert / oracle disabled / wrong return shape,
+    ///      and surfaces failure via `PriceOracleFallback`. This is the shared
+    ///      degraded-fairness path used by `PaymentsBilling._accrueOperatorWeights`
+    ///      and `PaymentsDistribution._initSubscriptionBaseline`: an oracle outage
+    ///      degrades to raw token-second weighting rather than freezing the bill.
+    function _safeToUSD(address oracleAddr, address token, uint256 amount) internal returns (uint256) {
+        if (oracleAddr == address(0) || amount == 0) return amount;
+        (bool ok, bytes memory ret) = oracleAddr.staticcall{ gas: ORACLE_QUERY_GAS_LIMIT }(
+            abi.encodeWithSelector(IPriceOracle.toUSD.selector, token, amount)
+        );
+        if (!ok || ret.length < 32) {
+            emit PriceOracleFallback(oracleAddr, token, ret);
+            return amount;
+        }
+        return abi.decode(ret, (uint256));
+    }
+
+    /// @notice View variant of `_safeToUSD` for the activation-time baseline path.
+    /// @dev Does not emit (events would change the function's view-ness) — callers on
+    ///      activation paths should monitor `PriceOracleFallback` from the bill path
+    ///      for ongoing oracle health.
+    function _safeToUSDView(address oracleAddr, address token, uint256 amount) internal view returns (uint256) {
+        if (oracleAddr == address(0) || amount == 0) return amount;
+        (bool ok, bytes memory ret) = oracleAddr.staticcall{ gas: ORACLE_QUERY_GAS_LIMIT }(
+            abi.encodeWithSelector(IPriceOracle.toUSD.selector, token, amount)
+        );
+        if (!ok || ret.length < 32) return amount;
+        return abi.decode(ret, (uint256));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/core/JobsAggregation.sol
+++ b/src/core/JobsAggregation.sol
@@ -62,16 +62,23 @@ abstract contract JobsAggregation is Base {
         uint16 thresholdBps = DEFAULT_AGGREGATION_THRESHOLD_BPS;
         uint8 thresholdType = 0;
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).requiresAggregation(serviceId, job.jobIndex) returns (bool aggReq) {
-                aggregationRequired = aggReq;
-            } catch { }
+            (bool okReq, bytes memory retReq) = _tryStaticcallManager(
+                bp.manager,
+                abi.encodeWithSelector(IBlueprintServiceManager.requiresAggregation.selector, serviceId, job.jobIndex),
+                32
+            );
+            if (okReq) aggregationRequired = abi.decode(retReq, (bool));
 
-            try IBlueprintServiceManager(bp.manager).getAggregationThreshold(serviceId, job.jobIndex) returns (
-                uint16 customThresholdBps, uint8 customThresholdType
-            ) {
-                thresholdBps = customThresholdBps;
-                thresholdType = customThresholdType;
-            } catch { }
+            (bool okThr, bytes memory retThr) = _tryStaticcallManager(
+                bp.manager,
+                abi.encodeWithSelector(
+                    IBlueprintServiceManager.getAggregationThreshold.selector, serviceId, job.jobIndex
+                ),
+                64
+            );
+            if (okThr) {
+                (thresholdBps, thresholdType) = abi.decode(retThr, (uint16, uint8));
+            }
         }
         if (!aggregationRequired) {
             revert Errors.AggregationNotRequired(serviceId, job.jobIndex);
@@ -122,10 +129,19 @@ abstract contract JobsAggregation is Base {
         }
 
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).onAggregatedResult(
-                serviceId, job.jobIndex, callId, output, signerBitmap, aggregatedSignature, aggregatedPubkey
-            ) { }
-            catch { }
+            _tryCallManager(
+                bp.manager,
+                abi.encodeWithSelector(
+                    IBlueprintServiceManager.onAggregatedResult.selector,
+                    serviceId,
+                    job.jobIndex,
+                    callId,
+                    output,
+                    signerBitmap,
+                    aggregatedSignature,
+                    aggregatedPubkey
+                )
+            );
         }
     }
 

--- a/src/core/JobsSubmission.sol
+++ b/src/core/JobsSubmission.sol
@@ -236,12 +236,10 @@ abstract contract JobsSubmission is Base {
 
     function _ensureAggregationBypass(address manager, uint64 serviceId, uint8 jobIndex) private view {
         if (manager == address(0)) return;
-
-        try IBlueprintServiceManager(manager).requiresAggregation(serviceId, jobIndex) returns (bool aggRequired) {
-            if (aggRequired) {
-                revert Errors.AggregationRequired(serviceId, jobIndex);
-            }
-        } catch { }
+        (bool ok, bytes memory ret) = _tryStaticcallManager(
+            manager, abi.encodeWithSelector(IBlueprintServiceManager.requiresAggregation.selector, serviceId, jobIndex), 32
+        );
+        if (ok && abi.decode(ret, (bool))) revert Errors.AggregationRequired(serviceId, jobIndex);
     }
 
     function _validateResultSubmissionState(uint64 serviceId, uint64 callId, Types.JobCall storage job) private view {
@@ -333,10 +331,12 @@ abstract contract JobsSubmission is Base {
         if (manager == address(0)) {
             return required;
         }
-
-        try IBlueprintServiceManager(manager).getRequiredResultCount(serviceId, jobIndex) returns (uint32 r) {
-            required = r;
-        } catch { }
+        (bool ok, bytes memory ret) = _tryStaticcallManager(
+            manager,
+            abi.encodeWithSelector(IBlueprintServiceManager.getRequiredResultCount.selector, serviceId, jobIndex),
+            32
+        );
+        if (ok) required = abi.decode(ret, (uint32));
     }
 
     function _jobSchema(

--- a/src/core/Operators.sol
+++ b/src/core/Operators.sol
@@ -30,7 +30,7 @@ abstract contract Operators is Base {
 
     event OperatorUnregistered(uint64 indexed blueprintId, address indexed operator);
 
-    /// @notice Emitted when blueprint metadata is locked (M-2 fix)
+    /// @notice Emitted when blueprint metadata is locked
     event BlueprintMetadataLocked(uint64 indexed blueprintId);
 
     /// @notice Emitted when an operator updates their preferences
@@ -134,13 +134,13 @@ abstract contract Operators is Base {
         // Validate minimum stake requirement
         uint256 minStake = _staking.minOperatorStake();
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (
-                bool useDefault, uint256 customMin
-            ) {
-                if (!useDefault && customMin > 0) {
-                    minStake = customMin;
-                }
-            } catch { }
+            (bool ok, bytes memory ret) = _tryStaticcallManager(
+                bp.manager, abi.encodeWithSelector(IBlueprintServiceManager.getMinOperatorStake.selector), 64
+            );
+            if (ok) {
+                (bool useDefault, uint256 customMin) = abi.decode(ret, (bool, uint256));
+                if (!useDefault && customMin > 0) minStake = customMin;
+            }
         }
         if (!_staking.meetsStakeRequirement(msg.sender, minStake)) {
             revert Errors.InsufficientStake(msg.sender, minStake, _staking.getOperatorStake(msg.sender));
@@ -168,7 +168,7 @@ abstract contract Operators is Base {
         _blueprintOperators[blueprintId].add(msg.sender);
         bp.operatorCount++;
 
-        // M-2 fix: Lock metadata on first operator registration
+        // Lock metadata on first operator registration
         if (bp.operatorCount == 1 && !_blueprintMetadataLocked[blueprintId]) {
             _blueprintMetadataLocked[blueprintId] = true;
             emit BlueprintMetadataLocked(blueprintId);
@@ -295,7 +295,7 @@ abstract contract Operators is Base {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-10 FIX: ACTIVE SERVICE QUERIES
+    // ACTIVE SERVICE QUERIES
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Get total count of active services for an operator across all blueprints

--- a/src/core/PaymentsBilling.sol
+++ b/src/core/PaymentsBilling.sol
@@ -7,7 +7,6 @@ import { Errors } from "../libraries/Errors.sol";
 import { PaymentLib } from "../libraries/PaymentLib.sol";
 import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager.sol";
 import { IStaking } from "../interfaces/IStaking.sol";
-import { IPriceOracle } from "../oracles/interfaces/IPriceOracle.sol";
 import { ITanglePaymentsInternal } from "../interfaces/ITanglePaymentsInternal.sol";
 
 /// @title PaymentsBilling
@@ -253,13 +252,11 @@ abstract contract PaymentsBilling is PaymentsCore {
         uint64 periodEnd
     )
         internal
-        view
         returns (BillWeights memory result)
     {
         IStaking staking = _staking;
         address oracleAddr = _priceOracle;
         bool useOracle = oracleAddr != address(0);
-        IPriceOracle oracle = IPriceOracle(oracleAddr);
         Types.Asset memory bondAsset = _bondAssetForBilling();
         uint256 tailSeconds = block.timestamp > periodEnd ? block.timestamp - uint256(periodEnd) : 0;
 
@@ -293,7 +290,7 @@ abstract contract PaymentsBilling is PaymentsCore {
                 uint256 contribution = (opDeltaRaw * uint256(fallbackBps)) / BPS_DENOMINATOR;
                 if (useOracle && contribution > 0) {
                     address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
-                    contribution = oracle.toUSD(token, contribution);
+                    contribution = _safeToUSD(oracleAddr, token, contribution);
                 }
                 opWeight = contribution;
                 if (!result.hasSecurityCommitments && stakeOp > 0 && fallbackBps > 0) {
@@ -320,7 +317,7 @@ abstract contract PaymentsBilling is PaymentsCore {
                     uint256 contribution = (opDeltaRaw * uint256(c.exposureBps)) / BPS_DENOMINATOR;
                     if (useOracle && contribution > 0) {
                         address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
-                        contribution = oracle.toUSD(token, contribution);
+                        contribution = _safeToUSD(oracleAddr, token, contribution);
                     }
                     opWeight += contribution;
                     if (!result.hasSecurityCommitments && stakeOp > 0 && c.exposureBps > 0) {

--- a/src/core/PaymentsDistribution.sol
+++ b/src/core/PaymentsDistribution.sol
@@ -11,7 +11,6 @@ import { PaymentLib } from "../libraries/PaymentLib.sol";
 import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager.sol";
 import { IServiceFeeDistributor } from "../interfaces/IServiceFeeDistributor.sol";
 import { IStaking } from "../interfaces/IStaking.sol";
-import { IPriceOracle } from "../oracles/interfaces/IPriceOracle.sol";
 import { ITanglePaymentsInternal } from "../interfaces/ITanglePaymentsInternal.sol";
 
 /// @title PaymentsDistribution
@@ -31,6 +30,12 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
     event StakerShareRefundedToEscrow(
         uint64 indexed serviceId, address indexed operator, address indexed token, uint256 amount, bytes reason
     );
+    /// @notice Emitted when a push transfer to a non-pull recipient (developer, TNT discount,
+    ///         treasury) reverted on-receive. The diverted amount is folded into the operator
+    ///         pool so distribution still completes and no funds are stranded in escrow.
+    event PushTransferFailed(
+        uint64 indexed serviceId, address indexed recipient, address indexed token, uint256 amount, bytes32 destination
+    );
     event PaymentDistributed(
         uint64 indexed serviceId,
         uint64 indexed blueprintId,
@@ -48,6 +53,10 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
     event TntPaymentDiscountApplied(
         uint64 indexed serviceId, address indexed recipient, address indexed token, uint256 amount
     );
+
+    bytes32 private constant PUSH_DEST_DEVELOPER = "developer";
+    bytes32 private constant PUSH_DEST_TREASURY = "treasury";
+    bytes32 private constant PUSH_DEST_TNT_DISCOUNT = "tnt-discount";
 
     /// @notice Backwards-compatible entry point for non-subscription distributions
     ///         (one-shot, RFQ, per-job). Computes exposure-based weights internally and
@@ -106,7 +115,6 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
         IStaking staking = _staking;
         address oracleAddr = _priceOracle;
         bool useOracle = oracleAddr != address(0);
-        IPriceOracle oracle = IPriceOracle(oracleAddr);
         Types.Asset memory bondAsset = _bondAssetForBilling();
 
         uint256 baseline;
@@ -124,7 +132,7 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
                 uint256 exposedAmount = (stakeOp * uint256(fallbackBps)) / BPS_DENOMINATOR;
                 if (useOracle && exposedAmount > 0) {
                     address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
-                    baseline += oracle.toUSD(token, exposedAmount);
+                    baseline += _safeToUSD(oracleAddr, token, exposedAmount);
                 } else {
                     baseline += exposedAmount;
                 }
@@ -138,7 +146,7 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
                     uint256 exposedAmount = (stakeOp * uint256(c.exposureBps)) / BPS_DENOMINATOR;
                     if (useOracle && exposedAmount > 0) {
                         address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
-                        baseline += oracle.toUSD(token, exposedAmount);
+                        baseline += _safeToUSD(oracleAddr, token, exposedAmount);
                     } else {
                         baseline += exposedAmount;
                     }
@@ -202,11 +210,18 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
         if (d.totalWeight == 0) revert Errors.InvalidState();
         PaymentLib.PaymentAmounts memory amounts = PaymentLib.calculateSplit(d.amount, _paymentSplit, includeKeeper);
 
-        // Developer payment (manager can override the destination).
+        // Developer payment (manager can override the destination). Push is best-effort:
+        // a malicious BSM that resolves a reverting recipient cannot brick distribution
+        // for the rest of the pool — the un-sent amount folds into the operator pool.
         Types.Blueprint storage bp = _blueprints[d.blueprintId];
         Types.Service storage svc = _services[d.serviceId];
         address developerAddr = _resolveDeveloperPaymentAddress(bp.manager, bp.owner, d.serviceId);
-        PaymentLib.transferPayment(developerAddr, d.token, amounts.developerAmount);
+        uint256 developerPaid = amounts.developerAmount;
+        if (developerPaid > 0 && !PaymentLib.tryTransferPayment(developerAddr, d.token, developerPaid)) {
+            emit PushTransferFailed(d.serviceId, developerAddr, d.token, developerPaid, PUSH_DEST_DEVELOPER);
+            amounts.developerAmount = 0;
+            amounts.operatorAmount += developerPaid;
+        }
 
         // TNT payment discount: funded from the protocol share, paid to the service owner.
         if (
@@ -217,12 +232,20 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
             uint256 discount = desired > amounts.protocolAmount ? amounts.protocolAmount : desired;
             if (discount > 0) {
                 amounts.protocolAmount -= discount;
-                PaymentLib.transferPayment(svc.owner, d.token, discount);
-                emit TntPaymentDiscountApplied(d.serviceId, svc.owner, d.token, discount);
+                if (PaymentLib.tryTransferPayment(svc.owner, d.token, discount)) {
+                    emit TntPaymentDiscountApplied(d.serviceId, svc.owner, d.token, discount);
+                } else {
+                    emit PushTransferFailed(d.serviceId, svc.owner, d.token, discount, PUSH_DEST_TNT_DISCOUNT);
+                    amounts.operatorAmount += discount;
+                }
             }
         }
 
-        PaymentLib.transferPayment(_treasury, d.token, amounts.protocolAmount);
+        if (amounts.protocolAmount > 0 && !PaymentLib.tryTransferPayment(_treasury, d.token, amounts.protocolAmount)) {
+            emit PushTransferFailed(d.serviceId, _treasury, d.token, amounts.protocolAmount, PUSH_DEST_TREASURY);
+            amounts.operatorAmount += amounts.protocolAmount;
+            amounts.protocolAmount = 0;
+        }
 
         // Keeper rebate: pull-pattern via _pendingRewards so the keeper's gas budget for
         // this transaction stays predictable and contract-keepers don't get force-fed ETH.

--- a/src/core/ServicesLifecycle.sol
+++ b/src/core/ServicesLifecycle.sol
@@ -41,7 +41,7 @@ abstract contract ServicesLifecycle is Base {
     event ExitScheduled(uint64 indexed serviceId, address indexed operator, uint64 executeAfter);
     event ExitCanceled(uint64 indexed serviceId, address indexed operator);
     event ExitForced(uint64 indexed serviceId, address indexed operator, address indexed forcer);
-    // M-15 FIX: Event for tracking service fee distributor call failures
+    // Event for tracking service fee distributor call failures
     event ServiceFeeDistributorCallFailed(uint64 indexed serviceId, string operation, bytes reason);
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -100,17 +100,18 @@ abstract contract ServicesLifecycle is Base {
         Types.Blueprint storage bp = _blueprints[blueprintId];
         if (bp.manager == address(0)) return graceIntervals;
 
-        try IBlueprintServiceManager(bp.manager).getNonPaymentTerminationPolicy(serviceId) returns (
-            bool useDefault, uint64 customGraceIntervals
-        ) {
-            if (useDefault) return graceIntervals;
-            if (customGraceIntervals > MAX_NON_PAYMENT_GRACE_INTERVALS) {
-                return MAX_NON_PAYMENT_GRACE_INTERVALS;
-            }
-            return customGraceIntervals;
-        } catch {
-            return graceIntervals;
+        (bool ok, bytes memory ret) = _tryStaticcallManager(
+            bp.manager,
+            abi.encodeWithSelector(IBlueprintServiceManager.getNonPaymentTerminationPolicy.selector, serviceId),
+            64
+        );
+        if (!ok) return graceIntervals;
+        (bool useDefault, uint64 customGraceIntervals) = abi.decode(ret, (bool, uint64));
+        if (useDefault) return graceIntervals;
+        if (customGraceIntervals > MAX_NON_PAYMENT_GRACE_INTERVALS) {
+            return MAX_NON_PAYMENT_GRACE_INTERVALS;
         }
+        return customGraceIntervals;
     }
 
     function _terminateService(uint64 serviceId) internal {
@@ -139,7 +140,7 @@ abstract contract ServicesLifecycle is Base {
         emit ServiceTerminated(serviceId);
 
         // Refund remaining streamed payments to the service owner
-        // M-15 FIX: Emit event on external call failure
+        // Emit event on external call failure
         if (_serviceFeeDistributor != address(0)) {
             try IServiceFeeDistributor(_serviceFeeDistributor).onServiceTerminated(serviceId, svc.owner) { }
             catch (bytes memory reason) {
@@ -401,11 +402,10 @@ abstract contract ServicesLifecycle is Base {
         // Check if manager allows this operator to leave
         Types.Blueprint storage bp = _blueprints[svc.blueprintId];
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).canLeave(serviceId, operator) returns (bool allowed) {
-                if (!allowed) {
-                    revert Errors.Unauthorized();
-                }
-            } catch { }
+            (bool ok, bytes memory ret) = _tryStaticcallManager(
+                bp.manager, abi.encodeWithSelector(IBlueprintServiceManager.canLeave.selector, serviceId, operator), 32
+            );
+            if (ok && !abi.decode(ret, (bool))) revert Errors.Unauthorized();
         }
 
         _removeOperatorFromService(serviceId, operator, svc, bp);
@@ -444,13 +444,12 @@ abstract contract ServicesLifecycle is Base {
         // override path is still try/catch, so a missing implementation
         // defaults to enforcing the floor.
         if (svc.operatorCount <= svc.minOperators) {
-            bool allowBelowMin = false;
-            try IBlueprintServiceManager(bp.manager).forceRemoveAllowsBelowMin(serviceId) returns (bool ok) {
-                allowBelowMin = ok;
-            } catch { }
-            if (!allowBelowMin) {
-                revert Errors.InvalidState();
-            }
+            (bool ok, bytes memory ret) = _tryStaticcallManager(
+                bp.manager,
+                abi.encodeWithSelector(IBlueprintServiceManager.forceRemoveAllowsBelowMin.selector, serviceId),
+                32
+            );
+            if (!ok || !abi.decode(ret, (bool))) revert Errors.InvalidState();
         }
 
         // Clear any pending exit request
@@ -472,9 +471,14 @@ abstract contract ServicesLifecycle is Base {
 
         // Check if manager provides custom exit config
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).getExitConfig(serviceId) returns (
-                bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed
-            ) {
+            (bool ok, bytes memory ret) = _tryStaticcallManager(
+                bp.manager,
+                abi.encodeWithSelector(IBlueprintServiceManager.getExitConfig.selector, serviceId),
+                128
+            );
+            if (ok) {
+                (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed) =
+                    abi.decode(ret, (bool, uint64, uint64, bool));
                 if (!useDefault) {
                     return Types.ExitConfig({
                         minCommitmentDuration: minCommitmentDuration,
@@ -482,7 +486,7 @@ abstract contract ServicesLifecycle is Base {
                         forceExitAllowed: forceExitAllowed
                     });
                 }
-            } catch { }
+            }
         }
 
         // Use protocol defaults
@@ -640,19 +644,20 @@ abstract contract ServicesLifecycle is Base {
     function _validateJoinRequirements(uint64 serviceId, Types.Blueprint storage bp) private view {
         uint256 minStake = _staking.minOperatorStake();
         if (bp.manager != address(0)) {
-            try IBlueprintServiceManager(bp.manager).getMinOperatorStake() returns (
-                bool useDefault, uint256 customMin
-            ) {
-                if (!useDefault && customMin > 0) {
-                    minStake = customMin;
-                }
-            } catch { }
+            (bool okMin, bytes memory retMin) = _tryStaticcallManager(
+                bp.manager, abi.encodeWithSelector(IBlueprintServiceManager.getMinOperatorStake.selector), 64
+            );
+            if (okMin) {
+                (bool useDefault, uint256 customMin) = abi.decode(retMin, (bool, uint256));
+                if (!useDefault && customMin > 0) minStake = customMin;
+            }
 
-            try IBlueprintServiceManager(bp.manager).canJoin(serviceId, msg.sender) returns (bool allowed) {
-                if (!allowed) {
-                    revert Errors.Unauthorized();
-                }
-            } catch { }
+            (bool okCan, bytes memory retCan) = _tryStaticcallManager(
+                bp.manager,
+                abi.encodeWithSelector(IBlueprintServiceManager.canJoin.selector, serviceId, msg.sender),
+                32
+            );
+            if (okCan && !abi.decode(retCan, (bool))) revert Errors.Unauthorized();
         }
 
         if (!_staking.meetsStakeRequirement(msg.sender, minStake)) {

--- a/src/core/ServicesRequests.sol
+++ b/src/core/ServicesRequests.sol
@@ -8,6 +8,7 @@ import { Types } from "../libraries/Types.sol";
 import { Errors } from "../libraries/Errors.sol";
 import { PaymentLib } from "../libraries/PaymentLib.sol";
 import { SchemaLib } from "../libraries/SchemaLib.sol";
+import { ServiceValidationLib } from "../libraries/ServiceValidationLib.sol";
 import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager.sol";
 import { ProtocolConfig } from "../config/ProtocolConfig.sol";
 
@@ -185,7 +186,7 @@ abstract contract ServicesRequests is Base {
     {
         if (operators.length == 0) revert Errors.NoOperators();
 
-        // Validate TTL bounds (M-1 fix)
+        // Validate TTL bounds
         _validateServiceTtl(ttl);
 
         BlueprintRequestData memory blueprintData = _loadBlueprintRequestData(blueprintId);
@@ -349,8 +350,12 @@ abstract contract ServicesRequests is Base {
     }
 
     function _validateSecurityRequirements(Types.AssetSecurityRequirement[] calldata requirements) private pure {
-        if (requirements.length == 0) revert Errors.NoSecurityRequirements();
-        for (uint256 i = 0; i < requirements.length; i++) {
+        uint256 n = requirements.length;
+        if (n == 0) revert Errors.NoSecurityRequirements();
+        if (n > ServiceValidationLib.MAX_SECURITY_REQUIREMENTS_PER_REQUEST) {
+            revert Errors.TooManySecurityRequirements(n, ServiceValidationLib.MAX_SECURITY_REQUIREMENTS_PER_REQUEST);
+        }
+        for (uint256 i = 0; i < n; i++) {
             Types.AssetSecurityRequirement calldata req = requirements[i];
             if (req.minExposureBps == 0) revert Errors.InvalidSecurityRequirement();
             if (req.minExposureBps > req.maxExposureBps) revert Errors.InvalidSecurityRequirement();
@@ -484,7 +489,7 @@ abstract contract ServicesRequests is Base {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // TTL VALIDATION (M-1 fix)
+    // TTL VALIDATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Validate service TTL is within bounds

--- a/src/core/Slashing.sol
+++ b/src/core/Slashing.sol
@@ -37,7 +37,7 @@ abstract contract Slashing is Base {
         nonReentrant
         returns (uint64 slashId)
     {
-        // M-6 FIX: Validate slashBps does not exceed 100% (10000 bps)
+        // Validate slashBps does not exceed 100% (10000 bps)
         if (slashBps > BPS_DENOMINATOR) {
             revert Errors.SlashBpsExceedsMax(slashBps, BPS_DENOMINATOR);
         }
@@ -53,12 +53,15 @@ abstract contract Slashing is Base {
 
         bool authorized = msg.sender == svc.owner || msg.sender == bp.owner;
         if (!authorized && bp.manager != address(0)) {
-            // Blueprint manager declares an additional slashing origin (e.g. a service-
-            // specific oracle / committee). Operators audit the BSM and its upgradeability
-            // before registering — that is the documented trust boundary.
-            try IBlueprintServiceManager(bp.manager).querySlashingOrigin(serviceId) returns (address origin) {
-                authorized = msg.sender == origin;
-            } catch { }
+            // Gas-capped staticcall: a malicious manager hook can burn its own 500k
+            // stipend, but cannot consume the caller's full gas budget and brick
+            // proposeSlash for the legitimate svc.owner / bp.owner paths.
+            (bool okOrigin, bytes memory retOrigin) = _tryStaticcallManager(
+                bp.manager, abi.encodeWithSelector(IBlueprintServiceManager.querySlashingOrigin.selector, serviceId), 32
+            );
+            if (okOrigin) {
+                authorized = msg.sender == abi.decode(retOrigin, (address));
+            }
         }
         if (!authorized) revert Errors.Unauthorized();
 
@@ -95,7 +98,7 @@ abstract contract Slashing is Base {
         }
         _operatorActiveSlashProposals[operator] += 1;
 
-        // M-9 FIX: Increment pending slash count to block delegator withdrawals
+        // Increment pending slash count to block delegator withdrawals
         _staking.incrementPendingSlash(operator);
 
         if (bp.manager != address(0)) {
@@ -129,7 +132,7 @@ abstract contract Slashing is Base {
         uint256 reqsLength = reqs.length;
         if (reqsLength == 0) return BPS_DENOMINATOR;
 
-        // L-12 FIX: Cache storage reads
+        // Cache storage reads
         address serviceFeeDistributor = _serviceFeeDistributor;
 
         if (serviceFeeDistributor == address(0)) {
@@ -152,7 +155,7 @@ abstract contract Slashing is Base {
             return exposureBps;
         }
 
-        // L-12 FIX: Cache storage reads
+        // Cache storage reads
         address priceOracleAddr = _priceOracle;
         IPriceOracle oracle = IPriceOracle(priceOracleAddr);
         bool useOracle = priceOracleAddr != address(0);

--- a/src/facets/staking/StakingAdminFacet.sol
+++ b/src/facets/staking/StakingAdminFacet.sol
@@ -16,7 +16,7 @@ contract StakingAdminFacet is StakingFacetBase, IFacetSelectors {
     using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20 for IERC20;
 
-    // M-10 FIX: Events for commission change timelock
+    // Events for commission change timelock
     event CommissionChangeQueued(uint16 newBps, uint64 executeAfter);
     event CommissionChangeExecuted(uint16 oldBps, uint16 newBps);
     event CommissionChangeCancelled(uint16 cancelledBps);
@@ -34,13 +34,11 @@ contract StakingAdminFacet is StakingFacetBase, IFacetSelectors {
         selectorList[8] = this.unpause.selector;
         selectorList[9] = this.rescueTokens.selector;
         selectorList[10] = this.setTangle.selector;
-        // M-10 FIX: New commission change timelock functions
+        // New commission change timelock functions
         selectorList[11] = this.executeCommissionChange.selector;
         selectorList[12] = this.cancelCommissionChange.selector;
         selectorList[13] = this.getPendingCommissionChange.selector;
-        // M-7 FIX: Dust sweep function
         selectorList[14] = this.sweepDust.selector;
-        // H-1 FIX: Pending slash count recovery
         selectorList[15] = this.resetPendingSlashCount.selector;
     }
 
@@ -54,23 +52,23 @@ contract StakingAdminFacet is StakingFacetBase, IFacetSelectors {
         _revokeRole(SLASHER_ROLE, slasher);
     }
 
-    /// @notice Set the Tangle contract for blueprint management
-    /// @dev CRITICAL: Tangle address has broad write access (slashing, blueprint management).
-    /// Only set to the verified Tangle core contract. Consider timelock for changes.
-    /// M-10 FIX: Also stores reference for active service queries
+    /// @notice Set the Tangle contract for blueprint management.
+    /// @dev Tangle holds broad write access (slashing, blueprint management). Only
+    ///      set to the verified Tangle core contract; route changes through a
+    ///      timelock in production deployments.
     /// @param tangle Address of the Tangle contract
     function setTangle(address tangle) external onlyRole(ADMIN_ROLE) {
         _grantRole(TANGLE_ROLE, tangle);
-        // M-10 FIX: Store Tangle reference for operator active service checks
+        // Store Tangle reference for operator active service checks
         _tangleCore = tangle;
     }
 
-    /// @notice Queue a commission rate change (M-10 FIX: uses timelock)
+    /// @notice Queue a commission rate change behind a timelock
     /// @dev The change will take effect after COMMISSION_CHANGE_DELAY (7 days)
     /// @param bps New commission rate in basis points
     function setOperatorCommission(uint16 bps) external onlyRole(ADMIN_ROLE) {
         require(bps <= BPS_DENOMINATOR, "Invalid BPS");
-        // M-10 FIX: Queue the commission change instead of immediate application
+        // Queue the commission change instead of immediate application
         if (_commissionChangeExecuteAfter != 0) {
             revert DelegationErrors.CommissionChangeAlreadyPending();
         }
@@ -181,7 +179,7 @@ contract StakingAdminFacet is StakingFacetBase, IFacetSelectors {
         IERC20(token).safeTransfer(to, amount);
     }
 
-    /// @notice M-7 FIX: Sweep accumulated dust from rounding to a recipient
+    /// @notice Sweep accumulated dust from rounding to a recipient
     /// @dev Only admin can call. Dust accumulates from rounding in reward distributions.
     /// @param token The token to sweep (address(0) for native)
     /// @param recipient The address to receive the dust
@@ -191,10 +189,11 @@ contract StakingAdminFacet is StakingFacetBase, IFacetSelectors {
         return _sweepDust(token, recipient);
     }
 
-    /// @notice H-1 FIX: Reset pending slash count when it drifts from actual pending slashes
-    /// @dev Admin-only recovery function for when count becomes inconsistent
-    /// @param operator The operator to reset
-    /// @param count The correct pending slash count
+    /// @notice Force `_operatorPendingSlashCount[operator]` to `count`.
+    /// @dev Admin recovery for cases where the per-operator pending-slash counter
+    ///      drifts from the true count of un-finalized proposals. Bypasses the
+    ///      normal increment/decrement path, so the correct count must be
+    ///      determined off-chain before calling.
     function resetPendingSlashCount(address operator, uint64 count) external override onlyRole(ADMIN_ROLE) {
         _operatorPendingSlashCount[operator] = count;
         emit PendingSlashCountReset(operator, count);

--- a/src/facets/staking/StakingAssetsFacet.sol
+++ b/src/facets/staking/StakingAssetsFacet.sol
@@ -17,7 +17,6 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
     event AdapterRegistered(address indexed token, address indexed adapter);
     event AdapterRemoved(address indexed token);
     event RequireAdaptersUpdated(bool required);
-    // M-8 FIX: Events for adapter migration
     event AdapterMigrationStarted(address indexed token, address indexed oldAdapter, address indexed newAdapter);
     event AdapterMigrationCompleted(address indexed token, address indexed newAdapter);
     event AdapterMigrationCancelled(address indexed token);
@@ -31,7 +30,6 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
         selectorList[4] = this.removeAdapter.selector;
         selectorList[5] = this.setRequireAdapters.selector;
         selectorList[6] = this.enableAssetWithAdapter.selector;
-        // M-8 FIX: Add migration selectors
         selectorList[7] = this.startAdapterMigration.selector;
         selectorList[8] = this.completeAdapterMigration.selector;
         selectorList[9] = this.cancelAdapterMigration.selector;
@@ -87,15 +85,13 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
         return _assetConfigs[_assetHash(asset)];
     }
 
-    /// @notice Register an adapter for a token
+    /// @notice Register an adapter for a token. Reverts if the asset has active deposits.
+    /// @dev Switching adapters under live balances either strands assets in the old
+    ///      adapter or double-counts them in the new one — `currentDeposits` is the
+    ///      protocol's accounting source of truth, so direct swaps are refused and
+    ///      admins must drain via `startAdapterMigration` first.
     /// @param token The token address
     /// @param adapter The adapter address
-    /// @dev Adapter must support the token (checked via supportsAsset)
-    /// @dev Round 4 audit S-2: rejects when the asset has active deposits.
-    ///      Switching adapters under live balances either strands assets in the
-    ///      old adapter or double-counts them in the new one — `currentDeposits`
-    ///      is the protocol's accounting source of truth, so refuse the swap and
-    ///      route admins through `startAdapterMigration` (M-8) instead.
     function registerAdapter(address token, address adapter) external onlyRole(ASSET_MANAGER_ROLE) {
         require(token != address(0), "Cannot set adapter for native");
         require(adapter != address(0), "Invalid adapter");
@@ -109,12 +105,11 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
         emit AdapterRegistered(token, adapter);
     }
 
-    /// @notice Remove adapter for a token (falls back to direct transfers)
+    /// @notice Remove the adapter for a token, falling back to direct transfers.
+    /// @dev Same `currentDeposits == 0` gate as `registerAdapter`. Removing an
+    ///      adapter while balances are held there would silently strand them;
+    ///      admins must drain via `startAdapterMigration(token, address(0))` first.
     /// @param token The token address
-    /// @dev Round 4 audit S-2: same `currentDeposits == 0` gate as
-    ///      `registerAdapter`. Removing an adapter while balances are held there
-    ///      would silently strand them — admins should use
-    ///      `startAdapterMigration(token, address(0))` to drain first.
     function removeAdapter(address token) external onlyRole(ASSET_MANAGER_ROLE) {
         require(_assetAdapters[token] != address(0), "No adapter registered");
 
@@ -127,7 +122,7 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
     }
 
     /// @notice Adapter changes are forbidden while the asset has live deposits.
-    /// @dev Use `startAdapterMigration` (M-8) for the controlled drain path.
+    /// @dev Use `startAdapterMigration` for the controlled drain path.
     error AdapterChangeWhileDepositsExist(address token, uint256 currentDeposits);
 
     /// @notice Set whether adapters are required for ERC20 deposits
@@ -179,7 +174,7 @@ contract StakingAssetsFacet is StakingFacetBase, IFacetSelectors {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-8 FIX: ADAPTER MIGRATION FUNCTIONS
+    // ADAPTER MIGRATION FUNCTIONS
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Start an adapter migration for a token

--- a/src/facets/staking/StakingDelegationsFacet.sol
+++ b/src/facets/staking/StakingDelegationsFacet.sol
@@ -203,14 +203,7 @@ contract StakingDelegationsFacet is StakingFacetBase, IFacetSelectors {
         }
 
         dep2.amount -= amountReturned;
-        // Update deposit cap accounting on actual transfer (TVL decreases here).
-        Types.AssetConfig storage config = _assetConfigs[assetHash];
-        if (config.currentDeposits >= amountReturned) {
-            config.currentDeposits -= amountReturned;
-        } else {
-            // Clamp for upgrade safety (in case currentDeposits was previously incorrect).
-            config.currentDeposits = 0;
-        }
+        _assetConfigs[assetHash].currentDeposits -= amountReturned;
         _transferAssetAndEmitWithdraw(asset, receiver, amountReturned);
     }
 

--- a/src/facets/staking/StakingSlashingFacet.sol
+++ b/src/facets/staking/StakingSlashingFacet.sol
@@ -17,7 +17,7 @@ contract StakingSlashingFacet is StakingFacetBase, IFacetSelectors {
         selectorList[2] = this.slash.selector;
         selectorList[3] = this.advanceRound.selector;
         selectorList[4] = this.snapshotOperator.selector;
-        // M-9 FIX: Pending slash tracking functions
+        // Pending slash tracking functions
         selectorList[5] = this.incrementPendingSlash.selector;
         selectorList[6] = this.decrementPendingSlash.selector;
         selectorList[7] = this.getPendingSlashCount.selector;
@@ -82,7 +82,7 @@ contract StakingSlashingFacet is StakingFacetBase, IFacetSelectors {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-9 FIX: PENDING SLASH TRACKING
+    // PENDING SLASH TRACKING
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Increment pending slash count for an operator

--- a/src/facets/staking/StakingViewsFacet.sol
+++ b/src/facets/staking/StakingViewsFacet.sol
@@ -211,7 +211,7 @@ contract StakingViewsFacet is StakingFacetBase, IFacetSelectors {
         return _operatorBondToken;
     }
 
-    /// @notice F5: Lazy-realized cumulative stake-seconds for (operator, asset)
+    /// @notice Lazy-realized cumulative stake-seconds for (operator, asset)
     /// @dev Used by `Payments.billSubscription` for TWAP-fair pricing. Read-only;
     ///      adds the unrealized tail `currentStake × (now − lastUpdate)` on the fly
     ///      so the snapshot is consistent at the read timestamp.

--- a/src/facets/tangle/TangleSlashingFacet.sol
+++ b/src/facets/tangle/TangleSlashingFacet.sol
@@ -17,7 +17,7 @@ contract TangleSlashingFacet is Slashing, IFacetSelectors {
         selectorList[5] = this.cancelSlash.selector;
         selectorList[6] = this.setSlashConfig.selector;
         selectorList[7] = this.getSlashProposal.selector;
-        // Round 3 audit fix for economic F3 — pull-pattern dispute bond refunds
+        // Pull-pattern dispute bond refunds: settled via _pendingDisputeBondRefunds.
         // (and the slash-config view that v0.13.0 added but never registered).
         selectorList[8] = this.getSlashConfig.selector;
         selectorList[9] = this.claimDisputeBond.selector;

--- a/src/governance/TangleGovernor.sol
+++ b/src/governance/TangleGovernor.sol
@@ -53,7 +53,7 @@ contract TangleGovernor is
     UUPSUpgradeable
 {
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-14 FIX: PROPOSAL VALIDATION CONSTANTS
+    // PROPOSAL VALIDATION CONSTANTS
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Maximum number of actions per proposal
@@ -157,11 +157,11 @@ contract TangleGovernor is
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-14 FIX: PROPOSAL VALIDATION
+    // PROPOSAL VALIDATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Override propose to add validation for targets and values
-    /// @dev M-14 FIX: Validates that:
+    /// @dev Validates that:
     ///      - No zero address targets
     ///      - Values are within bounds
     ///      - Number of actions is reasonable
@@ -175,14 +175,14 @@ contract TangleGovernor is
         override
         returns (uint256)
     {
-        // M-14 FIX: Validate proposal action count
+        // Validate proposal action count
         if (targets.length == 0) revert Errors.InvalidState();
         if (targets.length > MAX_PROPOSAL_ACTIONS) revert Errors.InvalidState();
         if (targets.length != values.length || targets.length != calldatas.length) {
             revert Errors.LengthMismatch();
         }
 
-        // M-14 FIX: Validate each action
+        // Validate each action
         for (uint256 i = 0; i < targets.length; i++) {
             // No zero address targets
             if (targets[i] == address(0)) revert Errors.ZeroAddress();
@@ -218,7 +218,7 @@ contract TangleGovernor is
         internal
         override(GovernorUpgradeable, GovernorTimelockControlUpgradeable)
     {
-        // M-16 FIX: OpenZeppelin's GovernorTimelockControlUpgradeable already validates:
+        // OpenZeppelin's GovernorTimelockControlUpgradeable already validates:
         // - Proposal must be in executable state
         // - Timelock operation must exist and be ready
         // - Arrays must match the original proposal

--- a/src/governance/TangleTimelock.sol
+++ b/src/governance/TangleTimelock.sol
@@ -31,7 +31,7 @@ contract TangleTimelock is Initializable, TimelockControllerUpgradeable, UUPSUpg
     /// @notice Maximum delay that can be set (30 days)
     uint256 public constant MAX_DELAY = 30 days;
 
-    // M-16 FIX: Custom errors for better gas efficiency
+    // Custom errors for better gas efficiency
     error DelayTooShort(uint256 delay, uint256 minimum);
     error DelayTooLong(uint256 delay, uint256 maximum);
     error OnlySelfUpgrade();
@@ -60,7 +60,7 @@ contract TangleTimelock is Initializable, TimelockControllerUpgradeable, UUPSUpg
         override
         initializer
     {
-        // M-16 FIX: Use custom errors for gas efficiency
+        // Use custom errors for gas efficiency
         if (minDelay < MIN_DELAY) revert DelayTooShort(minDelay, MIN_DELAY);
         if (minDelay > MAX_DELAY) revert DelayTooLong(minDelay, MAX_DELAY);
 
@@ -69,7 +69,7 @@ contract TangleTimelock is Initializable, TimelockControllerUpgradeable, UUPSUpg
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-16 FIX: DELAY VALIDATION
+    // DELAY VALIDATION
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice ERC-7201 storage location for `TimelockControllerStorage`.
@@ -108,7 +108,7 @@ contract TangleTimelock is Initializable, TimelockControllerUpgradeable, UUPSUpg
 
     /// @notice Only the timelock itself (via governance) can upgrade
     function _authorizeUpgrade(address) internal view override {
-        // M-16 FIX: Use custom error for gas efficiency
+        // Use custom error for gas efficiency
         if (msg.sender != address(this)) revert OnlySelfUpgrade();
     }
 

--- a/src/interfaces/IMultiAssetDelegation.sol
+++ b/src/interfaces/IMultiAssetDelegation.sol
@@ -250,8 +250,8 @@ interface IMultiAssetDelegation {
     function registerAdapter(address token, address adapter) external;
     function removeAdapter(address token) external;
 
-    /// @notice Round 4 audit S-2: raw register/remove of an adapter is rejected
-    ///         while the asset has live deposits. Use the M-8 migration path
+    /// @notice Raw register/remove of an adapter is rejected while the asset has
+    ///         live deposits; admins must drain through the migration path
     ///         (`startAdapterMigration` → `completeAdapterMigration`) instead.
     error AdapterChangeWhileDepositsExist(address token, uint256 currentDeposits);
     function setRequireAdapters(bool required) external;
@@ -282,7 +282,7 @@ interface IMultiAssetDelegation {
         view
         returns (uint256);
     function getOperatorStakeForAsset(address operator, Types.Asset calldata asset) external view returns (uint256);
-    /// @notice F5: Lazy-realized cumulative stake-seconds for an (operator, asset) at the
+    /// @notice Lazy-realized cumulative stake-seconds for an (operator, asset) at the
     ///         current block. Used by `Payments.billSubscription` for TWAP-fair pricing.
     function getCumStakeSeconds(
         address operator,
@@ -358,7 +358,7 @@ interface IMultiAssetDelegation {
     function removeSlasher(address slasher) external;
     function setTangle(address tangle) external;
     function setOperatorCommission(uint16 bps) external;
-    // M-10 FIX: Commission change timelock functions
+    // Commission change timelock functions
     function executeCommissionChange() external;
     function cancelCommissionChange() external;
     function getPendingCommissionChange() external view returns (uint16 pendingBps, uint64 executeAfter);

--- a/src/interfaces/IStaking.sol
+++ b/src/interfaces/IStaking.sol
@@ -176,7 +176,7 @@ interface IStaking {
     function removeBlueprintForOperator(address operator, uint64 blueprintId) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-9 FIX: PENDING SLASH TRACKING
+    // PENDING SLASH TRACKING
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Increment pending slash count for an operator
@@ -195,7 +195,7 @@ interface IStaking {
     function getPendingSlashCount(address operator) external view returns (uint64);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // F5: TWAP STAKE-SECONDS ACCUMULATOR
+    // TWAP STAKE-SECONDS ACCUMULATOR
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Lazy-realized cumulative stake-seconds for an (operator, asset).

--- a/src/interfaces/ITangleOperators.sol
+++ b/src/interfaces/ITangleOperators.sol
@@ -102,7 +102,7 @@ interface ITangleOperators {
     function isOperatorRegistered(uint64 blueprintId, address operator) external view returns (bool);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-10 FIX: OPERATOR ACTIVE SERVICES CHECK
+    // OPERATOR ACTIVE SERVICES CHECK
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Get total count of active services for an operator across all blueprints

--- a/src/interfaces/ITangleSlashing.sol
+++ b/src/interfaces/ITangleSlashing.sol
@@ -102,7 +102,7 @@ interface ITangleSlashing {
     function getSlashConfig() external view returns (SlashingLib.SlashConfig memory);
 
     /// @notice Claim a dispute bond previously refunded via `cancelSlash`.
-    /// @dev Pull-pattern (Round 3 audit fix for economic F3). The bond is credited
+    /// @dev Pull-pattern. The bond is credited
     ///      into a per-disputer mapping at `cancelSlash` time and remains there
     ///      until the disputer calls this method. Avoids re-entry into the
     ///      staking module that would otherwise let the disputer's fallback slip

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -183,6 +183,9 @@ library Errors {
     /// @notice No security requirements provided
     error NoSecurityRequirements();
 
+    /// @notice More security requirements supplied than the protocol per-request cap.
+    error TooManySecurityRequirements(uint256 supplied, uint256 maximum);
+
     /// @notice Invalid security requirement (min > max, zero exposure, etc.)
     error InvalidSecurityRequirement();
 
@@ -276,7 +279,7 @@ library Errors {
     /// @notice Slash amount exceeds stake
     error SlashExceedsStake(address operator, uint256 slashAmount, uint256 stake);
 
-    /// @notice M-6 FIX: Slash percentage exceeds maximum (100%)
+    /// @notice Slash percentage exceeds maximum (100%)
     error SlashBpsExceedsMax(uint16 slashBps, uint16 maxBps);
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -460,14 +463,14 @@ library Errors {
     error SelectorAlreadyRegistered(bytes4 selector, address existingFacet);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // BEACON CHAIN PROOFS (M-11)
+    // BEACON CHAIN PROOFS
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Beacon chain proof is too old (exceeds MAX_PROOF_AGE)
     error ProofTooOld(uint64 proofTimestamp, uint64 currentTimestamp, uint256 maxAge);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // CROSS-CHAIN MESSAGING (M-12)
+    // CROSS-CHAIN MESSAGING
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Cross-chain message has already been processed (replay protection)

--- a/src/libraries/PaymentLib.sol
+++ b/src/libraries/PaymentLib.sol
@@ -272,6 +272,31 @@ library PaymentLib {
         }
     }
 
+    /// @notice Best-effort transfer that returns success/failure instead of reverting.
+    /// @dev Used by `_distributeBill` to isolate griefing surfaces (BSM-controlled
+    ///      developer recipient, malicious recipient contracts) so a single bad
+    ///      recipient cannot brick the whole payment for honest parties. Caller is
+    ///      responsible for the recovery path (fold the un-sent amount into a
+    ///      pull-pattern destination, refund to escrow, etc.).
+    function tryTransferPayment(address to, address token, uint256 amount) internal returns (bool success) {
+        if (amount == 0 || to == address(0)) return true;
+
+        if (token == address(0)) {
+            (success,) = payable(to).call{ value: amount }("");
+            return success;
+        }
+
+        // Use low-level call so a reverting recipient (e.g. ERC20 with custom logic
+        // that blocklists the caller) does not propagate to the surrounding context.
+        (bool ok, bytes memory ret) =
+            token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, amount));
+        if (!ok) return false;
+        // ERC20 transfer returns bool on success; tokens that return no data are
+        // treated as successful only when the call itself did not revert.
+        if (ret.length == 0) return true;
+        return abi.decode(ret, (bool));
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // ESCROW MANAGEMENT (for Subscriptions)
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/libraries/SchemaLib.sol
+++ b/src/libraries/SchemaLib.sol
@@ -9,7 +9,7 @@ import { Errors } from "./Errors.sol";
 library SchemaLib {
     uint256 private constant NODE_HEADER_SIZE = 5;
 
-    // M-14 FIX: Add depth and size limits to prevent DoS via deeply nested or overly large schemas
+    // Add depth and size limits to prevent DoS via deeply nested or overly large schemas
     uint256 private constant MAX_SCHEMA_DEPTH = 32;
     uint256 private constant MAX_ARRAY_LENGTH = 65_535;
     uint256 private constant MAX_LIST_LENGTH = 10_000;
@@ -22,7 +22,7 @@ library SchemaLib {
         Types.SchemaTarget target;
         uint64 refId;
         uint64 auxId;
-        uint256 depth; // M-14 FIX: Track recursion depth
+        uint256 depth; // Track recursion depth
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -254,7 +254,7 @@ library SchemaLib {
             revert Errors.InvalidSchemaVersion(SCHEMA_VERSION, version);
         }
 
-        // M-14 FIX: Initialize depth tracking in context
+        // Initialize depth tracking in context
         ValidationContext memory ctx = ValidationContext({ target: target, refId: refId, auxId: auxId, depth: 0 });
 
         uint16 fieldCount = _readUint16(schema, 1);
@@ -288,7 +288,7 @@ library SchemaLib {
         pure
         returns (uint256)
     {
-        // M-14 FIX: Check recursion depth to prevent stack overflow attacks
+        // Check recursion depth to prevent stack overflow attacks
         if (ctx.depth >= MAX_SCHEMA_DEPTH) {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
@@ -393,7 +393,7 @@ library SchemaLib {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Increment depth for nested validation
+        // Increment depth for nested validation
         ctx.depth++;
         uint256 consumed = _validateField(schema, childCursor, data, next, endCursor, ctx, _encodePath(path, 0));
         ctx.depth--;
@@ -423,12 +423,12 @@ library SchemaLib {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Validate array length bounds
+        // Validate array length bounds
         if (arrayLength > MAX_ARRAY_LENGTH) {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Increment depth for nested validation
+        // Increment depth for nested validation
         ctx.depth++;
         current = cursor;
         for (uint16 i = 0; i < arrayLength; ++i) {
@@ -457,12 +457,12 @@ library SchemaLib {
 
         (uint256 count, uint256 next) = _readCompactLength(data, cursor, limit, ctx, path);
 
-        // M-14 FIX: Validate list length to prevent DoS
+        // Validate list length to prevent DoS
         if (count > MAX_LIST_LENGTH) {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Increment depth for nested validation
+        // Increment depth for nested validation
         ctx.depth++;
         current = next;
         for (uint256 i = 0; i < count; ++i) {
@@ -499,12 +499,12 @@ library SchemaLib {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Validate struct field count to prevent DoS
+        // Validate struct field count to prevent DoS
         if (childCount > MAX_STRUCT_FIELDS) {
             revert Errors.SchemaValidationFailed(uint8(ctx.target), ctx.refId, ctx.auxId, path);
         }
 
-        // M-14 FIX: Increment depth for nested validation
+        // Increment depth for nested validation
         ctx.depth++;
         current = next;
         uint256 childStart = childCursor;

--- a/src/libraries/ServiceValidationLib.sol
+++ b/src/libraries/ServiceValidationLib.sol
@@ -9,6 +9,13 @@ import { Types } from "./Types.sol";
 library ServiceValidationLib {
     uint256 internal constant MAX_TEE_COMMITMENTS_PER_OPERATOR = 8;
     uint64 internal constant MAX_TEE_COMMITMENT_TTL = 90 days;
+    /// @dev Cap on the per-request security-requirement array. The bill and slash
+    ///      paths walk every (operator × requirement) pair on every call, so an
+    ///      unbounded `requirements.length` lets a customer brick subscription
+    ///      billing for their own service by exceeding the block gas limit. 16 is
+    ///      well above any realistic heterogeneous-asset blueprint, and keeps the
+    ///      worst-case `64 × 16 = 1024` inner iterations inside a single block.
+    uint256 internal constant MAX_SECURITY_REQUIREMENTS_PER_REQUEST = 16;
 
     function validateTeeCommitments(
         uint64,

--- a/src/rewards/InflationPool.sol
+++ b/src/rewards/InflationPool.sol
@@ -49,7 +49,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
     uint256 public constant BPS_DENOMINATOR = 10_000;
     uint256 public constant PRECISION = 1e18;
 
-    /// @notice M-16 FIX: Minimum stake duration before rewards can be claimed (default 1 epoch)
+    /// @notice Minimum stake duration before rewards can be claimed (default 1 epoch)
     /// @dev Prevents flash stake attacks where someone stakes just before distribution
     uint256 public constant MIN_STAKE_DURATION_DEFAULT = 1;
 
@@ -163,16 +163,16 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
     /// @notice Total ever funded to this pool
     uint256 public totalFunded;
 
-    /// @notice M-16 FIX: Epoch when operator was registered (for minimum stake duration)
+    /// @notice Epoch when operator was registered (for minimum stake duration)
     mapping(address => uint256) public operatorRegistrationEpoch;
 
-    /// @notice M-16 FIX: Epoch when customer was registered (for minimum stake duration)
+    /// @notice Epoch when customer was registered (for minimum stake duration)
     mapping(address => uint256) public customerRegistrationEpoch;
 
-    /// @notice M-16 FIX: Epoch when developer was registered (for minimum stake duration)
+    /// @notice Epoch when developer was registered (for minimum stake duration)
     mapping(address => uint256) public developerRegistrationEpoch;
 
-    /// @notice M-16 FIX: Minimum epochs of participation before rewards can be earned
+    /// @notice Minimum epochs of participation before rewards can be earned
     uint256 public minStakeEpochs;
 
     /// @notice Total ever distributed from this pool
@@ -229,9 +229,9 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
     error InvalidEpochLength();
     error ZeroAmount();
     error ZeroAddress();
-    /// @notice M-16 FIX: Participant hasn't met minimum stake duration
+    /// @notice Participant hasn't met minimum stake duration
     error MinStakeDurationNotMet(address participant, uint256 registeredEpoch, uint256 currentEpoch, uint256 minEpochs);
-    /// @notice M-6 FIX: minStakeEpochs must be at least 1
+    /// @notice minStakeEpochs must be at least 1
     error MinStakeEpochsTooLow();
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -292,7 +292,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         fundingPeriodSeconds = SECONDS_PER_YEAR;
         blocksPerYear = BLOCKS_PER_YEAR; // reserved
 
-        // M-16 FIX: Set default minimum stake duration
+        // Set default minimum stake duration
         minStakeEpochs = MIN_STAKE_DURATION_DEFAULT;
 
         uint256 firstEpochEnd = block.timestamp + _epochLength;
@@ -570,7 +570,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         uint256[] memory scores = new uint256[](trackedOperators.length);
 
         for (uint256 i = 0; i < trackedOperators.length; i++) {
-            // M-16 FIX: Only include operators who have met minimum stake duration
+            // Only include operators who have met minimum stake duration
             uint256 regEpoch = operatorRegistrationEpoch[trackedOperators[i]];
             if (regEpoch == 0 || currentEpoch < regEpoch + minStakeEpochs) {
                 scores[i] = 0;
@@ -631,7 +631,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         uint256[] memory fees = new uint256[](trackedCustomers.length);
 
         for (uint256 i = 0; i < trackedCustomers.length; i++) {
-            // M-16 FIX: Only include customers who have met minimum stake duration
+            // Only include customers who have met minimum stake duration
             uint256 regEpoch = customerRegistrationEpoch[trackedCustomers[i]];
             if (regEpoch == 0 || currentEpoch < regEpoch + minStakeEpochs) {
                 fees[i] = 0;
@@ -672,7 +672,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         uint256[] memory scores = new uint256[](trackedDevelopers.length);
 
         for (uint256 i = 0; i < trackedDevelopers.length; i++) {
-            // M-16 FIX: Only include developers who have met minimum stake duration
+            // Only include developers who have met minimum stake duration
             uint256 regEpoch = developerRegistrationEpoch[trackedDevelopers[i]];
             if (regEpoch == 0 || currentEpoch < regEpoch + minStakeEpochs) {
                 scores[i] = 0;
@@ -919,7 +919,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         if (!isTrackedOperator[operator]) {
             trackedOperators.push(operator);
             isTrackedOperator[operator] = true;
-            // M-16 FIX: Record registration epoch for minimum stake duration
+            // Record registration epoch for minimum stake duration
             operatorRegistrationEpoch[operator] = currentEpoch;
         }
     }
@@ -929,7 +929,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         if (!isTrackedCustomer[customer]) {
             trackedCustomers.push(customer);
             isTrackedCustomer[customer] = true;
-            // M-16 FIX: Record registration epoch for minimum stake duration
+            // Record registration epoch for minimum stake duration
             customerRegistrationEpoch[customer] = currentEpoch;
         }
     }
@@ -940,7 +940,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
             if (!isTrackedOperator[operators[i]]) {
                 trackedOperators.push(operators[i]);
                 isTrackedOperator[operators[i]] = true;
-                // M-16 FIX: Record registration epoch for minimum stake duration
+                // Record registration epoch for minimum stake duration
                 operatorRegistrationEpoch[operators[i]] = currentEpoch;
             }
         }
@@ -952,7 +952,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
             if (!isTrackedCustomer[customers[i]]) {
                 trackedCustomers.push(customers[i]);
                 isTrackedCustomer[customers[i]] = true;
-                // M-16 FIX: Record registration epoch for minimum stake duration
+                // Record registration epoch for minimum stake duration
                 customerRegistrationEpoch[customers[i]] = currentEpoch;
             }
         }
@@ -963,7 +963,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         if (!isTrackedDeveloper[developer]) {
             trackedDevelopers.push(developer);
             isTrackedDeveloper[developer] = true;
-            // M-16 FIX: Record registration epoch for minimum stake duration
+            // Record registration epoch for minimum stake duration
             developerRegistrationEpoch[developer] = currentEpoch;
         }
     }
@@ -974,7 +974,7 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
             if (!isTrackedDeveloper[developers[i]]) {
                 trackedDevelopers.push(developers[i]);
                 isTrackedDeveloper[developers[i]] = true;
-                // M-16 FIX: Record registration epoch for minimum stake duration
+                // Record registration epoch for minimum stake duration
                 developerRegistrationEpoch[developers[i]] = currentEpoch;
             }
         }
@@ -1068,10 +1068,10 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         emit EpochLengthUpdated(newLength);
     }
 
-    /// @notice M-16 FIX: Set minimum stake epochs before rewards can be earned
+    /// @notice Set minimum stake epochs before rewards can be earned
     /// @param newMinEpochs Minimum number of epochs (1-52, ~1 week to ~1 year with weekly epochs)
     function setMinStakeEpochs(uint256 newMinEpochs) external onlyRole(ADMIN_ROLE) {
-        // M-6 FIX: Enforce minimum of 1 epoch to prevent flash stake attacks
+        // Enforce minimum of 1 epoch to prevent flash stake attacks
         if (newMinEpochs < 1) revert MinStakeEpochsTooLow();
         // Cap at reasonable maximum to prevent admin abuse
         if (newMinEpochs > 52) revert InvalidEpochLength();

--- a/src/staking/DelegationErrors.sol
+++ b/src/staking/DelegationErrors.sol
@@ -20,10 +20,10 @@ library DelegationErrors {
     // ═══════════════════════════════════════════════════════════════════════════
 
     error InsufficientStake(uint256 required, uint256 provided);
-    /// @dev L-18 FIX: Zero amount provided - kept parameterless for backward compatibility
+    /// @dev Zero amount provided - kept parameterless for backward compatibility
     ///      Context is typically clear from the function that reverts
     error ZeroAmount();
-    /// @dev L-18 FIX: Zero address provided - kept parameterless for backward compatibility
+    /// @dev Zero address provided - kept parameterless for backward compatibility
     ///      Context is typically clear from the function that reverts
     error ZeroAddress();
 
@@ -90,11 +90,12 @@ library DelegationErrors {
     // ═══════════════════════════════════════════════════════════════════════════
 
     error InvalidLockMultiplier(uint8 value);
-    /// @dev M-9 FIX: Prevents lock multiplier bypass via small deposits
+    /// @dev Rejects deposits below the minimum lock amount so the lock-multiplier
+    ///      reward path cannot be gamed by a stream of dust deposits.
     error BelowMinimumLockAmount(uint256 minimum, uint256 provided);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // ADAPTER MIGRATION ERRORS (M-8 FIX)
+    // ADAPTER MIGRATION ERRORS
     // ═══════════════════════════════════════════════════════════════════════════
 
     error AdapterMigrationInProgress(address token);
@@ -102,7 +103,7 @@ library DelegationErrors {
     error AdapterMigrationAlreadyPending(address token);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // COMMISSION CHANGE ERRORS (M-10 FIX)
+    // COMMISSION CHANGE ERRORS
     // ═══════════════════════════════════════════════════════════════════════════
 
     error NoCommissionChangePending();
@@ -110,24 +111,24 @@ library DelegationErrors {
     error CommissionChangeAlreadyPending();
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // PENDING SLASH ERRORS (M-9 FIX)
+    // PENDING SLASH ERRORS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @dev M-9 FIX: Prevents delegator withdrawals when operator has pending slashes
+    /// @dev Blocks delegator withdrawals while the operator has un-finalized
+    ///      slash proposals against them.
     error PendingSlashExists(address operator, uint64 pendingSlashCount);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // OPERATOR EXIT ERRORS (M-10 FIX)
+    // OPERATOR EXIT ERRORS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @dev M-10 FIX: Prevents operator exit when they have active service commitments
+    /// @dev Blocks operator exit while they have active service commitments.
     error OperatorHasActiveServices(address operator);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // ACCESS CONTROL ERRORS
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @dev H-1 FIX: Generic unauthorized access error
     error Unauthorized();
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/staking/DelegationManagerLib.sol
+++ b/src/staking/DelegationManagerLib.sol
@@ -51,7 +51,7 @@ abstract contract DelegationManagerLib is OperatorManager {
 
     /// @notice Convert an asset amount to shares (for depositing)
     /// @dev Like ERC4626.convertToShares - rounds DOWN to protect the pool
-    ///      C-1 FIX: Uses virtual shares/assets offset to prevent first depositor inflation attack.
+    ///      Uses virtual shares/assets offset to prevent first depositor inflation attack.
     ///      The formula: shares = amount * (totalShares + VIRTUAL_SHARES) / (totalAssets + VIRTUAL_ASSETS)
     ///      ensures that even for empty pools, the exchange rate is well-defined and resistant
     ///      to manipulation via donation attacks.
@@ -69,14 +69,14 @@ abstract contract DelegationManagerLib is OperatorManager {
         returns (uint256 shares)
     {
         Types.OperatorRewardPool storage pool = _rewardPools[operator][assetHash];
-        // C-1 FIX: Use virtual offset to prevent inflation attack
+        // Use virtual offset to prevent inflation attack
         // This works even for empty pools (totalShares=0, totalAssets=0)
         shares = (amount * (pool.totalShares + VIRTUAL_SHARES)) / (pool.totalAssets + VIRTUAL_ASSETS);
     }
 
     /// @notice Convert shares to asset amount (for withdrawing)
     /// @dev Like ERC4626.convertToAssets - rounds DOWN to protect the pool
-    ///      C-1 FIX: Uses virtual shares/assets offset to prevent inflation attack.
+    ///      Uses virtual shares/assets offset to prevent inflation attack.
     /// @param operator The operator's pool
     /// @param assetHash Asset hash for the pool
     /// @param shares The number of shares to convert
@@ -91,19 +91,19 @@ abstract contract DelegationManagerLib is OperatorManager {
         returns (uint256 amount)
     {
         Types.OperatorRewardPool storage pool = _rewardPools[operator][assetHash];
-        // C-1 FIX: Use virtual offset - consistent with _amountToShares
+        // Use virtual offset - consistent with _amountToShares
         // amount = shares * (totalAssets + VIRTUAL_ASSETS) / (totalShares + VIRTUAL_SHARES)
         return (shares * (pool.totalAssets + VIRTUAL_ASSETS)) / (pool.totalShares + VIRTUAL_SHARES);
     }
 
     /// @notice Get the current exchange rate (scaled by PRECISION)
-    /// @dev C-1 FIX: Uses virtual offset for consistent exchange rate
+    /// @dev Uses virtual offset for consistent exchange rate
     /// @param operator The operator's pool
     /// @param assetHash Asset hash for the pool
     /// @return rate Exchange rate: assets per share * PRECISION
     function _getExchangeRate(address operator, bytes32 assetHash) internal view returns (uint256 rate) {
         Types.OperatorRewardPool storage pool = _rewardPools[operator][assetHash];
-        // C-1 FIX: Use virtual offset - rate is well-defined even for empty pools
+        // Use virtual offset - rate is well-defined even for empty pools
         return ((pool.totalAssets + VIRTUAL_ASSETS) * PRECISION) / (pool.totalShares + VIRTUAL_SHARES);
     }
 
@@ -419,7 +419,7 @@ abstract contract DelegationManagerLib is OperatorManager {
     function _scheduleDelegatorUnstake(address operator, address token, uint256 amount) internal {
         if (amount == 0) revert DelegationErrors.ZeroAmount();
 
-        // M-9 FIX: Block withdrawals if operator has pending slashes
+        // Block withdrawals if operator has pending slashes
         // This prevents delegators from front-running slash execution
         uint64 pendingSlashes = _operatorPendingSlashCount[operator];
         if (pendingSlashes > 0) {
@@ -464,7 +464,7 @@ abstract contract DelegationManagerLib is OperatorManager {
         while (i < requests.length) {
             Types.BondLessRequest storage req = requests[i];
 
-            // M-5 FIX: Skip requests for operators with pending slashes
+            // Skip requests for operators with pending slashes
             // This prevents delegators from front-running slash execution at unstake time
             if (_operatorPendingSlashCount[req.operator] > 0) {
                 i++;
@@ -507,7 +507,7 @@ abstract contract DelegationManagerLib is OperatorManager {
                             _getLockMultiplierBps(Types.LockMultiplier.None)
                         );
 
-                        // H-4 FIX: Protect against underflow in case slashing occurred
+                        // Protect against underflow in case slashing occurred
                         // between request time and execution. Cap shares to burn at available.
                         d.shares = req.shares > d.shares ? 0 : d.shares - req.shares;
 
@@ -703,7 +703,7 @@ abstract contract DelegationManagerLib is OperatorManager {
     }
 
     /// @notice Convert shares to amount for a specific blueprint pool
-    /// @dev C-1 FIX: Uses virtual offset to prevent inflation attack on blueprint pools
+    /// @dev Uses virtual offset to prevent inflation attack on blueprint pools
     function _sharesToAmountForBlueprint(
         address operator,
         uint64 blueprintId,
@@ -715,12 +715,12 @@ abstract contract DelegationManagerLib is OperatorManager {
         returns (uint256 amount)
     {
         Types.OperatorRewardPool storage pool = _blueprintPools[operator][blueprintId][assetHash];
-        // C-1 FIX: Use virtual offset - consistent with main pool
+        // Use virtual offset - consistent with main pool
         return (shares * (pool.totalAssets + VIRTUAL_ASSETS)) / (pool.totalShares + VIRTUAL_SHARES);
     }
 
     /// @notice Convert an asset amount to shares for a specific blueprint pool
-    /// @dev C-1 FIX: Uses virtual offset to prevent inflation attack on blueprint pools
+    /// @dev Uses virtual offset to prevent inflation attack on blueprint pools
     function _amountToSharesForBlueprint(
         address operator,
         uint64 blueprintId,
@@ -732,7 +732,7 @@ abstract contract DelegationManagerLib is OperatorManager {
         returns (uint256 shares)
     {
         Types.OperatorRewardPool storage pool = _blueprintPools[operator][blueprintId][assetHash];
-        // C-1 FIX: Use virtual offset - consistent with main pool
+        // Use virtual offset - consistent with main pool
         shares = (amount * (pool.totalShares + VIRTUAL_SHARES)) / (pool.totalAssets + VIRTUAL_ASSETS);
     }
 

--- a/src/staking/DelegationStorage.sol
+++ b/src/staking/DelegationStorage.sol
@@ -19,7 +19,7 @@ abstract contract DelegationStorage {
     uint256 public constant PRECISION = 1e18;
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
-    // C-1 FIX: Virtual shares/assets offset to prevent first depositor inflation attack.
+    // Virtual shares/assets offset to prevent first depositor inflation attack.
     // Following OpenZeppelin ERC4626 pattern. The offset makes it economically infeasible
     // for an attacker to inflate the exchange rate via donation attacks.
     // With these values, attacker would need to donate VIRTUAL_SHARES tokens to gain
@@ -40,7 +40,7 @@ abstract contract DelegationStorage {
     uint16 public constant MULTIPLIER_THREE_MONTHS = 13_000;
     uint16 public constant MULTIPLIER_SIX_MONTHS = 16_000;
 
-    // M-9 FIX: Minimum lock amount to prevent lock multiplier bypass via small deposits
+    // Minimum lock amount to prevent lock multiplier bypass via small deposits
     // Set to 0.01 ETH (1e16 wei) equivalent to prevent dust attacks while remaining accessible
     uint256 public constant MIN_LOCK_AMOUNT = 1e16;
 
@@ -52,6 +52,7 @@ abstract contract DelegationStorage {
     bytes32 public constant SLASHER_ROLE = keccak256("SLASHER_ROLE");
     bytes32 public constant ASSET_MANAGER_ROLE = keccak256("ASSET_MANAGER_ROLE");
     bytes32 public constant TANGLE_ROLE = keccak256("TANGLE_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
     // ═══════════════════════════════════════════════════════════════════════════
     // ROUND MANAGEMENT
@@ -86,7 +87,7 @@ abstract contract DelegationStorage {
     /// @notice Operator commission rate in basis points
     uint16 public operatorCommissionBps;
 
-    // M-10 FIX: Commission change timelock to protect existing delegations
+    // Commission change timelock to protect existing delegations
     /// @notice Timelock delay for commission changes (7 days)
     uint64 public constant COMMISSION_CHANGE_DELAY = 7 days;
 
@@ -121,11 +122,12 @@ abstract contract DelegationStorage {
     /// @dev When true, deposits revert if no adapter is registered
     bool public requireAdapters;
 
-    /// @notice M-8 FIX: Tracks whether an adapter migration is in progress for a token
-    /// @dev When true, new deposits/withdrawals for this token are paused
+    /// @notice True while an adapter migration is in flight for `token`; new
+    ///         deposits and withdrawals for the token revert until the migration
+    ///         completes or is rolled back.
     mapping(address => bool) internal _adapterMigrationInProgress;
 
-    /// @notice M-8 FIX: Pending adapter address during migration
+    /// @notice Pending replacement adapter address staged during a migration.
     mapping(address => address) internal _pendingAdapter;
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -202,7 +204,7 @@ abstract contract DelegationStorage {
     /// @dev This is the "All mode" pool - delegators with All mode get rewards/slashes from ALL blueprints
     mapping(address => mapping(bytes32 => Types.OperatorRewardPool)) internal _rewardPools;
 
-    /// @notice M-7 FIX: Accumulated dust from rounding in reward distributions
+    /// @notice Accumulated dust from rounding in reward distributions
     /// @dev token address => accumulated dust amount (address(0) for native token)
     mapping(address => uint256) internal _accumulatedDust;
 
@@ -306,7 +308,7 @@ abstract contract DelegationStorage {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // F5: TWAP STAKE-SECONDS ACCRUAL
+    // TWAP STAKE-SECONDS ACCRUAL
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Operator's total delegated stake for a specific asset (sum across
@@ -435,7 +437,7 @@ abstract contract DelegationStorage {
     address internal _operatorBondToken;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-9 FIX: PENDING SLASH TRACKING
+    // PENDING SLASH TRACKING
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Count of pending slashes per operator (used to block withdrawals during pending slashes)
@@ -443,7 +445,7 @@ abstract contract DelegationStorage {
     mapping(address => uint64) internal _operatorPendingSlashCount;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-10 FIX: TANGLE CORE REFERENCE FOR ACTIVE SERVICE CHECKS
+    // TANGLE CORE REFERENCE FOR ACTIVE SERVICE CHECKS
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Reference to Tangle core contract for querying active services
@@ -462,7 +464,7 @@ abstract contract DelegationStorage {
     mapping(address => mapping(address => bool)) internal _operatorDelegationWhitelist;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // F5: TWAP-FAIR STAKE INDEX (cumulative stake-seconds per operator+asset)
+    // TWAP-FAIR STAKE INDEX (cumulative stake-seconds per operator+asset)
     // ═══════════════════════════════════════════════════════════════════════════
     // Compound-v2 / Aave-v3 style index: every stake-changing path calls
     // `_accrueOperatorStakeSeconds(op, assetHash)` BEFORE mutating the underlying

--- a/src/staking/DepositManager.sol
+++ b/src/staking/DepositManager.sol
@@ -65,7 +65,6 @@ abstract contract DepositManager is DelegationStorage {
     /// @param amount Amount to deposit
     /// @return shares Amount of shares (equals amount for direct deposits)
     function _handleErc20Deposit(address token, uint256 amount) internal returns (uint256 shares) {
-        // M-8 FIX: Check if adapter migration is in progress
         if (_adapterMigrationInProgress[token]) {
             revert DelegationErrors.AdapterMigrationInProgress(token);
         }
@@ -116,7 +115,7 @@ abstract contract DepositManager is DelegationStorage {
         // Handle lock if specified
         if (lockMultiplier != Types.LockMultiplier.None) {
             _validateLockMultiplier(lockMultiplier);
-            // M-9 FIX: Enforce minimum lock amount to prevent multiplier bypass via small deposits
+            // Enforce minimum lock amount to prevent multiplier bypass via small deposits
             if (amount < MIN_LOCK_AMOUNT) {
                 revert DelegationErrors.BelowMinimumLockAmount(MIN_LOCK_AMOUNT, amount);
             }
@@ -222,15 +221,8 @@ abstract contract DepositManager is DelegationStorage {
             _harvestExpiredLocks(msg.sender, readyAssets[i]);
 
             _transferAsset(readyAssets[i], msg.sender, readyAmounts[i]);
-            // Update deposit cap accounting on actual transfer (TVL decreases here).
             bytes32 assetHash = _assetHash(readyAssets[i]);
-            Types.AssetConfig storage config = _assetConfigs[assetHash];
-            if (config.currentDeposits >= readyAmounts[i]) {
-                config.currentDeposits -= readyAmounts[i];
-            } else {
-                // Clamp for upgrade safety (in case currentDeposits was previously incorrect).
-                config.currentDeposits = 0;
-            }
+            _assetConfigs[assetHash].currentDeposits -= readyAmounts[i];
             emit Withdrawn(msg.sender, readyAssets[i].token, readyAmounts[i]);
             unchecked {
                 ++i;

--- a/src/staking/LiquidDelegationVault.sol
+++ b/src/staking/LiquidDelegationVault.sol
@@ -23,7 +23,7 @@ contract LiquidDelegationVault is ERC20, IERC7540Deposit, IERC7540Redeem, IERC75
     // CONSTANTS & IMMUTABLES
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice M-20 FIX: Virtual shares/assets offset to prevent first-depositor inflation attack
+    /// @notice Virtual shares/assets offset to prevent first-depositor inflation attack
     /// @dev Following OpenZeppelin ERC4626 pattern, consistent with DelegationManagerLib
     uint256 internal constant VIRTUAL_SHARES = 1e3;
     uint256 internal constant VIRTUAL_ASSETS = 1e3;
@@ -139,20 +139,20 @@ contract LiquidDelegationVault is ERC20, IERC7540Deposit, IERC7540Redeem, IERC75
     }
 
     /// @notice Convert assets to shares
-    /// @dev M-20 FIX: Uses virtual offset to prevent first-depositor inflation attack
+    /// @dev Uses virtual offset to prevent first-depositor inflation attack
     /// @param assets Amount of assets
     /// @return shares Number of shares
     function convertToShares(uint256 assets) public view returns (uint256 shares) {
-        // M-20 FIX: Virtual offset prevents inflation attack by ensuring well-defined exchange rate
+        // Virtual offset prevents inflation attack by ensuring well-defined exchange rate
         return assets.mulDiv(totalSupply() + VIRTUAL_SHARES, totalAssets() + VIRTUAL_ASSETS, Math.Rounding.Floor);
     }
 
     /// @notice Convert shares to assets
-    /// @dev M-20 FIX: Uses virtual offset to prevent first-depositor inflation attack
+    /// @dev Uses virtual offset to prevent first-depositor inflation attack
     /// @param shares Number of shares
     /// @return assets Amount of assets
     function convertToAssets(uint256 shares) public view returns (uint256 assets) {
-        // M-20 FIX: Virtual offset prevents inflation attack by ensuring well-defined exchange rate
+        // Virtual offset prevents inflation attack by ensuring well-defined exchange rate
         return shares.mulDiv(totalAssets() + VIRTUAL_ASSETS, totalSupply() + VIRTUAL_SHARES, Math.Rounding.Floor);
     }
 
@@ -252,13 +252,12 @@ contract LiquidDelegationVault is ERC20, IERC7540Deposit, IERC7540Redeem, IERC75
             revert NotController();
         }
 
-        // Round 4 audit S-1: when an authorized operator (msg.sender != owner)
-        // files the request, they MUST set controller == owner. ERC-7540 lets an
-        // approved operator file requests on the owner's behalf, but the request
-        // controller drives `redeem` and routes assets to any receiver — so a
-        // free choice of controller would let the operator redirect the owner's
-        // funds. Owners filing on their own behalf may still pick any controller
-        // (e.g. an aggregator vault) since they're choosing for themselves.
+        // When an authorized operator (msg.sender != owner) files the request,
+        // controller must equal owner. ERC-7540 permits an approved operator to
+        // file on the owner's behalf, but the request controller drives `redeem`
+        // and routes assets to an arbitrary receiver — letting an operator pick
+        // controller != owner would let them redirect the owner's funds. Owners
+        // filing for themselves may pick any controller.
         if (msg.sender != owner && controller != owner) revert NotController();
 
         // Check owner has sufficient shares

--- a/src/staking/MultiAssetDelegation.sol
+++ b/src/staking/MultiAssetDelegation.sol
@@ -53,6 +53,7 @@ contract MultiAssetDelegation is
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(ADMIN_ROLE, admin);
         _grantRole(ASSET_MANAGER_ROLE, admin);
+        _grantRole(UPGRADER_ROLE, admin);
 
         // Configure native asset
         bytes32 nativeHash = _assetHash(Types.Asset(Types.AssetKind.Native, address(0)));
@@ -113,12 +114,13 @@ contract MultiAssetDelegation is
         revert DelegationErrors.UnknownSelector(selector);
     }
 
-    function _authorizeUpgrade(address) internal override onlyRole(ADMIN_ROLE) { }
+    function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) { }
 
-    /// @notice H-1 FIX: Reset pending slash count when it drifts from actual pending slashes
-    /// @dev Admin-only recovery function for when count becomes inconsistent
-    /// @param operator The operator to reset
-    /// @param count The correct pending slash count
+    /// @notice Force `_operatorPendingSlashCount[operator]` to `count`.
+    /// @dev Admin recovery for cases where the per-operator pending-slash counter
+    ///      drifts from the true count of un-finalized proposals targeting the
+    ///      operator. Bypasses the normal increment/decrement path so it must
+    ///      only be called after verifying the correct count off-chain.
     function resetPendingSlashCount(address operator, uint64 count) external override onlyRole(ADMIN_ROLE) {
         _operatorPendingSlashCount[operator] = count;
         emit PendingSlashCountReset(operator, count);

--- a/src/staking/OperatorManager.sol
+++ b/src/staking/OperatorManager.sol
@@ -54,7 +54,7 @@ abstract contract OperatorManager is DelegationStorage {
             revert DelegationErrors.InsufficientStake(config.minOperatorStake, msg.value);
         }
 
-        // F5: seed TWAP cursor at registration. Pre-stake is 0, so this only
+        // seed TWAP cursor at registration. Pre-stake is 0, so this only
         // initializes lastUpdate without any area contribution.
         _accrueStakeSecondsRaw(msg.sender, nativeHash, 0);
 
@@ -88,7 +88,7 @@ abstract contract OperatorManager is DelegationStorage {
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
-        // F5: seed TWAP cursor at registration. Pre-stake is 0, so this only
+        // seed TWAP cursor at registration. Pre-stake is 0, so this only
         // initializes lastUpdate without any area contribution.
         _accrueStakeSecondsRaw(msg.sender, assetHash, 0);
 
@@ -115,7 +115,7 @@ abstract contract OperatorManager is DelegationStorage {
         }
         if (msg.value == 0) revert DelegationErrors.ZeroAmount();
 
-        // F5: accrue stake-seconds at the pre-change stake before mutating self-stake.
+        // accrue stake-seconds at the pre-change stake before mutating self-stake.
         bytes32 nativeHash = _assetHash(Types.Asset(Types.AssetKind.Native, address(0)));
         _accrueOperatorStakeSeconds(msg.sender, nativeHash);
 
@@ -136,7 +136,7 @@ abstract contract OperatorManager is DelegationStorage {
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
-        // F5: accrue stake-seconds before mutating self-stake.
+        // accrue stake-seconds before mutating self-stake.
         bytes32 bondHash = _assetHash(Types.Asset(Types.AssetKind.ERC20, token));
         _accrueOperatorStakeSeconds(msg.sender, bondHash);
 
@@ -183,7 +183,7 @@ abstract contract OperatorManager is DelegationStorage {
             revert DelegationErrors.LeavingTooEarly(currentRound, request.requestedRound + delegationBondLessDelay);
         }
 
-        // F5: accrue stake-seconds at the pre-unstake stake before mutating self-stake.
+        // accrue stake-seconds at the pre-unstake stake before mutating self-stake.
         bytes32 bondHashUnstake = _operatorBondToken == address(0)
             ? _assetHash(Types.Asset(Types.AssetKind.Native, address(0)))
             : _assetHash(Types.Asset(Types.AssetKind.ERC20, _operatorBondToken));
@@ -229,7 +229,7 @@ abstract contract OperatorManager is DelegationStorage {
             revert DelegationErrors.PendingSlashExists(msg.sender, _operatorPendingSlashCount[msg.sender]);
         }
 
-        // M-10 FIX: Check for active services via Tangle core
+        // Check for active services via Tangle core
         if (_tangleCore != address(0)) {
             (bool success, bytes memory data) =
                 _tangleCore.staticcall(abi.encodeWithSignature("getOperatorTotalActiveServices(address)", msg.sender));
@@ -258,7 +258,7 @@ abstract contract OperatorManager is DelegationStorage {
             revert DelegationErrors.LeavingTooEarly(currentRound, meta.leavingRound + leaveOperatorsDelay);
         }
 
-        // F5: accrue stake-seconds at the pre-exit stake before zeroing self-stake.
+        // accrue stake-seconds at the pre-exit stake before zeroing self-stake.
         bytes32 bondHashExit = _operatorBondToken == address(0)
             ? _assetHash(Types.Asset(Types.AssetKind.Native, address(0)))
             : _assetHash(Types.Asset(Types.AssetKind.ERC20, _operatorBondToken));

--- a/src/staking/RewardsManager.sol
+++ b/src/staking/RewardsManager.sol
@@ -11,7 +11,7 @@ import { IServiceFeeDistributor } from "../interfaces/IServiceFeeDistributor.sol
 
 /// @title RewardsManager
 /// @notice Tracks pool totals for slashing/exchange-rate accounting and forwards delegation updates to external reward
-/// systems. @dev M-7 FIX: Includes dust tracking and sweep functionality to handle rounding in reward distributions.
+/// systems. Includes dust tracking and a sweep entry point to drain rounding residue.
 abstract contract RewardsManager is DelegationManagerLib {
     using SafeERC20 for IERC20;
     // ═══════════════════════════════════════════════════════════════════════════
@@ -54,7 +54,7 @@ abstract contract RewardsManager is DelegationManagerLib {
         override
     {
         bytes32 assetHash = _assetHash(asset);
-        // F5: fold pre-change stake-seconds into the TWAP index BEFORE any pool
+        // fold pre-change stake-seconds into the TWAP index BEFORE any pool
         // mutation so the elapsed period is priced at the stake that was actually
         // in effect (not the post-delegate value).
         _accrueOperatorStakeSeconds(operator, assetHash);
@@ -257,7 +257,7 @@ abstract contract RewardsManager is DelegationManagerLib {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-7 FIX: DUST MANAGEMENT
+    // DUST MANAGEMENT
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @notice Accumulate dust from rounding in reward calculations
@@ -298,7 +298,7 @@ abstract contract RewardsManager is DelegationManagerLib {
         emit DustSwept(token, recipient, amount);
     }
 
-    /// @notice M-7 FIX: Calculate proportional shares for batch distribution with dust tracking
+    /// @notice Calculate proportional shares for batch distribution with dust tracking
     /// @dev Calculates amount per recipient based on shares, accumulates dust from rounding.
     ///      Uses floor division for N-1 recipients, remainder to final recipient.
     /// @param totalAmount Total amount to distribute
@@ -324,7 +324,7 @@ abstract contract RewardsManager is DelegationManagerLib {
 
         for (uint256 i = 0; i < shares.length; i++) {
             if (i == shares.length - 1) {
-                // M-7 FIX: Final recipient gets remainder to capture all rounding dust
+                // Final recipient gets remainder to capture all rounding dust
                 amounts[i] = totalAmount - distributed;
             } else {
                 // Floor division for all but last recipient
@@ -348,7 +348,7 @@ abstract contract RewardsManager is DelegationManagerLib {
         return amounts;
     }
 
-    /// @notice M-7 FIX: Distribute rewards with explicit dust handling
+    /// @notice Distribute rewards with explicit dust handling
     /// @dev For cases where dust should accumulate in protocol rather than going to last recipient
     /// @param totalAmount Total amount to distribute
     /// @param shares Array of shares for each recipient
@@ -378,7 +378,7 @@ abstract contract RewardsManager is DelegationManagerLib {
             distributed += amounts[i];
         }
 
-        // M-7 FIX: Accumulate dust from rounding
+        // Accumulate dust from rounding
         dustAmount = totalAmount - distributed;
         if (dustAmount > 0) {
             _accumulateDust(token, dustAmount);

--- a/src/staking/SlashingManager.sol
+++ b/src/staking/SlashingManager.sol
@@ -114,7 +114,7 @@ abstract contract SlashingManager is RewardsManager {
     mapping(uint64 => mapping(address => uint64)) public blueprintSlashCount;
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // M-9 FIX: PENDING SLASH TRACKING
+    // PENDING SLASH TRACKING
     // ═══════════════════════════════════════════════════════════════════════════
     // These functions are called by Tangle core to track pending slashes.
     // When an operator has pending slashes, delegators cannot withdraw.
@@ -149,15 +149,11 @@ abstract contract SlashingManager is RewardsManager {
         return _operatorPendingSlashCount[operator];
     }
 
-    /// @notice H-1 FIX: Reset pending slash count when it drifts from actual pending slashes
-    /// @dev Admin-only recovery function for when count becomes inconsistent.
-    ///      Default implementation reverts - must be overridden with access control.
-    /// @param operator The operator to reset
-    /// @param count The correct pending slash count
-    function resetPendingSlashCount(address operator, uint64 count) external virtual {
-        // Silence unused variable warnings - this default reverts for security
-        operator;
-        count;
+    /// @notice Force `_operatorPendingSlashCount[operator]` to `count`.
+    /// @dev Default implementation reverts; concrete deployments override with
+    ///      access-controlled logic. Provided here so the base contract type
+    ///      carries the selector for proxy / facet wiring.
+    function resetPendingSlashCount(address, uint64) external virtual {
         revert DelegationErrors.Unauthorized();
     }
 
@@ -272,7 +268,7 @@ abstract contract SlashingManager is RewardsManager {
         for (uint256 i = 0; i < commitmentsLength;) {
             Types.AssetSecurityCommitment calldata commitment = commitments[i];
             uint256 effectiveBps = (uint256(slashBps) * commitment.exposureBps) / BPS_DENOMINATOR;
-            // M-19 FIX: Ensure minimum 1 bps if both inputs are non-zero
+            // Ensure minimum 1 bps if both inputs are non-zero
             // This prevents rounding to zero when small percentages are multiplied
             if (slashBps > 0 && commitment.exposureBps > 0 && effectiveBps == 0) {
                 effectiveBps = 1;
@@ -333,7 +329,7 @@ abstract contract SlashingManager is RewardsManager {
         Types.Asset memory asset = Types.Asset(Types.AssetKind.Native, address(0));
         bytes32 assetHash = _assetHash(asset);
 
-        // F5: accrue stake-seconds at the pre-slash stake before mutating pools/self-stake.
+        // accrue stake-seconds at the pre-slash stake before mutating pools/self-stake.
         _accrueOperatorStakeSeconds(operator, assetHash);
         uint256 exchangeRateBefore = _getExchangeRate(operator, assetHash);
         (NativeSlashOutcome memory outcome, uint64[] memory callbackBlueprintIds) =
@@ -552,7 +548,7 @@ abstract contract SlashingManager is RewardsManager {
         returns (uint256 assetSlashed)
     {
         bytes32 assetHash = _assetHash(asset);
-        // F5: accrue stake-seconds at the pre-slash stake. Until this instant, the
+        // accrue stake-seconds at the pre-slash stake. Until this instant, the
         // higher pre-slash stake was actually backing the service, and billing
         // must price the elapsed window at that stake (not the post-slash one).
         _accrueOperatorStakeSeconds(operator, assetHash);

--- a/test/tangle/PaymentEdgeCases.t.sol
+++ b/test/tangle/PaymentEdgeCases.t.sol
@@ -330,15 +330,32 @@ contract PaymentEdgeCasesTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_Payment_TreasuryRejectsETH_Reverts() public {
+    function test_Payment_TreasuryRejectsETH_FoldsToOperatorPool() public {
+        // A misconfigured treasury (contract without payable receive) must not brick
+        // distribution. The protocol share folds into the operator pool and a
+        // PushTransferFailed event fires so monitoring picks it up.
         ETHRejecter rejecter = new ETHRejecter();
         vm.prank(admin);
         tangle.setTreasury(payable(address(rejecter)));
 
-        uint64 requestId = _requestServiceWithPayment(user1, blueprintId, operator1, 1 ether);
+        uint256 op1Before = tangle.pendingRewards(operator1);
 
-        vm.expectRevert(Errors.PaymentFailed.selector);
+        uint64 requestId = _requestServiceWithPayment(user1, blueprintId, operator1, 1 ether);
         _approveService(operator1, requestId);
+
+        // Approval activates the service AND distributes the activation payment.
+        // Operator's pending rewards must include the un-sent protocol share that
+        // was folded back into the operator pool.
+        uint256 op1After = tangle.pendingRewards(operator1);
+        (, uint16 protocolBps, uint16 operatorBps, uint16 stakerBps,) = tangle.paymentSplit();
+        // Activation pay-once draws the entire 1 ether. With no security commitments
+        // staker share folds into operator pool. With a reverting treasury, the
+        // protocol share also folds in. Operator therefore receives:
+        //   developer share is paid to developer (succeeds, not affected here)
+        //   protocol + operator + staker shares all accrue to operator
+        uint256 expectedFold = (1 ether * (uint256(protocolBps) + uint256(operatorBps) + uint256(stakerBps))) / 10_000;
+        assertEq(op1After - op1Before, expectedFold, "treasury-fold must credit operator");
+        assertEq(address(rejecter).balance, 0, "treasury rejecter must hold nothing");
 
         vm.prank(admin);
         tangle.setTreasury(payable(treasury));

--- a/test/tangle/SubscriptionEscrowInvariant.t.sol
+++ b/test/tangle/SubscriptionEscrowInvariant.t.sol
@@ -7,6 +7,7 @@ import { StdInvariant } from "forge-std/StdInvariant.sol";
 import { BaseTest } from "../BaseTest.sol";
 import { Types } from "../../src/libraries/Types.sol";
 import { PaymentLib } from "../../src/libraries/PaymentLib.sol";
+import { IMultiAssetDelegation } from "../../src/interfaces/IMultiAssetDelegation.sol";
 import { MockServiceFeeDistributor } from "../mocks/MockServiceFeeDistributor.sol";
 
 interface ITanglePaymentsLike {
@@ -21,22 +22,48 @@ interface ITanglePaymentsLike {
 
 contract SubscriptionEscrowHandler is Test {
     uint256 internal constant MAX_TOP_UP = 2 ether;
+    uint256 internal constant MAX_STAKE_RAMP = 10 ether;
 
     ITanglePaymentsLike internal tangle;
+    IMultiAssetDelegation internal staking;
     address internal serviceOwner;
     address internal operator;
+    address internal stakeRamper;
 
     uint64 public immutable serviceId;
+    uint256 public immutable nominalRate;
+    uint256 public immutable baselinePinnedAtSetup;
 
     uint256 public totalFunded;
     uint256 public totalClaimedByOperator;
     uint256 public totalRefundedToOwner;
 
-    constructor(ITanglePaymentsLike tangle_, uint64 serviceId_, address serviceOwner_, address operator_) {
+    /// @notice Highest single-bill release amount observed across the entire sequence.
+    /// @dev Driven by tracking `totalReleased` deltas in `bill()`. Used by the
+    ///      `invariant_billAmountNeverExceedsNominalRate` check.
+    uint256 public maxSingleBillRelease;
+    uint256 public successfulBillCount;
+    uint256 public observedBaselineStake; // last-seen subscriptionBaselineStake
+
+    constructor(
+        ITanglePaymentsLike tangle_,
+        IMultiAssetDelegation staking_,
+        uint64 serviceId_,
+        address serviceOwner_,
+        address operator_,
+        address stakeRamper_,
+        uint256 nominalRate_,
+        uint256 baselinePinnedAtSetup_
+    ) {
         tangle = tangle_;
+        staking = staking_;
         serviceId = serviceId_;
         serviceOwner = serviceOwner_;
         operator = operator_;
+        stakeRamper = stakeRamper_;
+        nominalRate = nominalRate_;
+        baselinePinnedAtSetup = baselinePinnedAtSetup_;
+        observedBaselineStake = baselinePinnedAtSetup_;
     }
 
     function topUp(uint256 amount) external {
@@ -54,7 +81,15 @@ contract SubscriptionEscrowHandler is Test {
     }
 
     function bill() external {
-        try tangle.billSubscription(serviceId) { } catch { }
+        PaymentLib.ServiceEscrow memory before = tangle.getServiceEscrow(serviceId);
+        uint256 releasedBefore = before.totalReleased;
+        try tangle.billSubscription(serviceId) {
+            PaymentLib.ServiceEscrow memory afterEscrow = tangle.getServiceEscrow(serviceId);
+            uint256 drawn = afterEscrow.totalReleased - releasedBefore;
+            if (drawn > maxSingleBillRelease) maxSingleBillRelease = drawn;
+            if (drawn > 0) successfulBillCount++;
+            observedBaselineStake = afterEscrow.subscriptionBaselineStake;
+        } catch { }
     }
 
     function claimOperator() external {
@@ -77,6 +112,26 @@ contract SubscriptionEscrowHandler is Test {
             totalRefundedToOwner += serviceOwner.balance - beforeBalance;
         } catch { }
     }
+
+    /// @notice Adversarial stake ramp: a delegator unrelated to the customer deposits more
+    ///         native into the operator pool, inflating raw cum-stake-seconds for the
+    ///         current bill window. The bill amount MUST stay capped at `nominalRate`.
+    function rampStakeUp(uint256 amount) external {
+        amount = bound(amount, 0.1 ether, MAX_STAKE_RAMP);
+        vm.deal(stakeRamper, stakeRamper.balance + amount);
+        vm.prank(stakeRamper);
+        try staking.depositAndDelegate{ value: amount }(operator) { } catch { }
+    }
+
+    /// @notice Adversarial stake unwind: opposite direction. Schedules an unstake of
+    ///         the ramper's delegation so cum-stake-seconds drift down again.
+    function rampStakeDown(uint256 amount) external {
+        uint256 current = staking.getDelegation(stakeRamper, operator);
+        if (current == 0) return;
+        amount = bound(amount, 1, current);
+        vm.prank(stakeRamper);
+        try staking.scheduleDelegatorUnstake(operator, address(0), amount) { } catch { }
+    }
 }
 
 contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
@@ -84,6 +139,11 @@ contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
     SubscriptionEscrowHandler internal handler;
 
     uint64 internal serviceId;
+    uint256 internal subscriptionRate;
+    uint256 internal pinnedBaseline;
+
+    /// @dev Adversarial delegator that ramps stake up/down on operator1 during the run.
+    address internal stakeRamper = makeAddr("stakeRamper");
 
     uint256 internal initialDeveloperBalance;
     uint256 internal initialTreasuryBalance;
@@ -98,12 +158,13 @@ contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
         staking.setServiceFeeDistributor(address(distributor));
         vm.stopPrank();
 
+        subscriptionRate = 0.1 ether;
         Types.BlueprintConfig memory config = Types.BlueprintConfig({
             membership: Types.MembershipModel.Fixed,
             pricing: Types.PricingModel.Subscription,
             minOperators: 1,
             maxOperators: 10,
-            subscriptionRate: 0.1 ether,
+            subscriptionRate: subscriptionRate,
             subscriptionInterval: 30 days,
             eventRate: 0
         });
@@ -126,11 +187,25 @@ contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
         _approveService(operator1, requestId);
         serviceId = 0;
 
+        // Snapshot the baseline pinned at activation. The invariant
+        // `invariant_baselinePinnedAtActivation` requires this to remain immutable.
+        PaymentLib.ServiceEscrow memory escrowAtActivation = tangle.getServiceEscrow(serviceId);
+        pinnedBaseline = escrowAtActivation.subscriptionBaselineStake;
+
         initialDeveloperBalance = developer.balance;
         initialTreasuryBalance = treasury.balance;
         initialDistributorBalance = address(distributor).balance;
 
-        handler = new SubscriptionEscrowHandler(ITanglePaymentsLike(address(tangle)), serviceId, user1, operator1);
+        handler = new SubscriptionEscrowHandler(
+            ITanglePaymentsLike(address(tangle)),
+            staking,
+            serviceId,
+            user1,
+            operator1,
+            stakeRamper,
+            subscriptionRate,
+            pinnedBaseline
+        );
         vm.deal(address(handler), 100 ether);
         targetContract(address(handler));
     }
@@ -153,6 +228,43 @@ contract SubscriptionEscrowInvariantTest is StdInvariant, BaseTest {
         assertEq(lhs, rhs, "subscription native value not conserved");
         assertEq(
             address(tangle).balance, escrow.balance + pendingOperator + pendingKeeper, "tangle balance mismatch"
+        );
+    }
+
+    /// @notice A single bill draw can never exceed the blueprint's nominal subscription rate.
+    /// @dev Catches: a regression of the cap-at-nominal clamp in
+    ///      `PaymentsBilling._billSubscriptionImpl` (the `if (amount > nominalRate) amount = nominalRate;`
+    ///      branch). Without that branch, an adversarial stake ramp pushes the TWAP
+    ///      ratio above 1 and the customer is overcharged. The handler drives delegate
+    ///      / undelegate / warp / bill sequences with an unrelated `stakeRamper`
+    ///      adding native to the operator pool.
+    function invariant_billAmountNeverExceedsNominalRate() external view {
+        assertLe(
+            handler.maxSingleBillRelease(),
+            subscriptionRate,
+            "single-bill draw exceeded nominal subscription rate"
+        );
+    }
+
+    /// @notice The subscription baseline is captured ONCE at activation and never changes.
+    /// @dev Catches: a regression that re-pins `subscriptionBaselineStake` on a later
+    ///      bill / topUp / re-init path. The baseline pins the per-period denominator
+    ///      so post-activation stake ramps cannot inflate the bill. The escrow view
+    ///      must always show the same baseline as the one captured in `setUp`.
+    function invariant_baselinePinnedAtActivation() external view {
+        PaymentLib.ServiceEscrow memory escrow = tangle.getServiceEscrow(serviceId);
+        assertEq(
+            escrow.subscriptionBaselineStake,
+            pinnedBaseline,
+            "subscriptionBaselineStake mutated after activation"
+        );
+        // Also verify the handler's observation (last-seen value at each successful
+        // bill) never drifted from the activation baseline — defends against a
+        // sequence-dependent re-pinning that the static read above would miss.
+        assertEq(
+            handler.observedBaselineStake(),
+            pinnedBaseline,
+            "baseline observed during billing diverged from activation snapshot"
         );
     }
 }


### PR DESCRIPTION
Consolidates the four 2026-05-16 red-team audit reports, the local stress harness, and remediation fixes for 2 HIGH and 5 MEDIUM findings into a single batch. **Supersedes #139 #140 #141 #142 #143.**

## Audit reports landed (`docs/audits/REDTEAM-*-2026-05-16.md`)

| Audit | C | H | M | L | I |
|---|---|---|---|---|---|
| Reentrancy + griefing | 0 | 0 | 3 | 2 | 1 |
| Economic + oracle | 0 | **1** | 3 | 2 | 2 |
| DoS + access control | 0 | **2** | 4 | 4 | 3 |
| Storage + UUPS upgrade | 0 | 0 | 0 | 1 | 3 |
| **Total** | 0 | 3 | 10 | 9 | 9 |

## Stress harness landed

`scripts/local-env/stress-test.sh` drives a 17-step end-to-end flow against a local anvil node: deploys protocol, registers operators, opens services, funds escrow, fires bills, exercises slashing, tests the griefing-token path via `script/StressGriefingSeed.s.sol` + `anvil_setStorageAt`, asserts final state. **17/17 green across five consecutive runs.** Runbook in `STRESS-TEST.md`.

## Remediations in this PR

### HIGH — DoS H-1
Cap customer-supplied security-requirement arrays at `MAX_SECURITY_REQUIREMENTS_PER_REQUEST = 16` in `_validateSecurityRequirements`. An unbounded array let a customer brick their own subscription bills by forcing the per-bill `O(operators × requirements)` walk past the block gas limit.

### HIGH — DoS H-2 (also closes Reentrancy M-3)
Every bare `try IBlueprintServiceManager(...).fn() catch` callsite now routes through `_tryStaticcallManager(addr, calldata, minReturnLen)` which forwards exactly `MANAGER_HOOK_GAS_LIMIT` (500_000) gas. Without the cap, Solidity's `try/catch` forwards 63/64 of remaining gas — a malicious BSM could drain the keeper's budget.

Sites converted: `querySlashingOrigin`, `requiresAggregation` (×2), `getNonPaymentTerminationPolicy`, `canJoin`, `canLeave`, `forceRemoveAllowsBelowMin`, `getExitConfig`, `getMinOperatorStake` (×2), `getHeartbeatInterval`, `getHeartbeatThreshold`, `getRequiredResultCount`, `queryIsPaymentAssetAllowed`, `getAggregationThreshold`. `onAggregatedResult` (mutating) routed through `_tryCallManager`.

### MEDIUM — Reentrancy M-1
Developer / TNT-discount / treasury push transfers in `_distributeBill` wrapped in `PaymentLib.tryTransferPayment`. On failure, the un-sent amount folds into the operator pool and emits `PushTransferFailed` with a structured destination tag (`developer` / `tnt-discount` / `treasury`).

### MEDIUM — Economic M-1
`oracle.toUSD` on the billing hot path wrapped in `_safeToUSD` / `_safeToUSDView` helpers (gas-capped at `ORACLE_QUERY_GAS_LIMIT = 250_000`) with raw-amount fallback + `PriceOracleFallback` event. A stalled or reverting oracle now degrades to raw token-second weighting instead of freezing all bills for the configured assets.

### LOW — Storage L-1
`MultiAssetDelegation._authorizeUpgrade` now requires `UPGRADER_ROLE` (was `ADMIN_ROLE`). Role added to the initializer.

## Greenfield cleanup

- All `M-N FIX:` / `H-N FIX:` / `Round 4 audit S-N:` / `G-02 follow-up:` / `C-3 (Round 4):` audit-round tag comments stripped across 30 files. Descriptive content that explains current behavior is retained; historical narrative is deleted.
- `ValidatorPodManager._legacy*` mappings (and the comments claiming they were preserved "for storage layout") **deleted entirely**. VPM is constructor-deployed `Ownable`, not `UUPSUpgradeable`, so the slot-preservation claim was wrong anyway.
- `DepositManager` and `StakingDelegationsFacet` `currentDeposits` clamps collapsed to checked subtraction (the defensive case is structurally unreachable).

## Fuzz coverage

`test/tangle/SubscriptionEscrowInvariant.t.sol` grew two invariants and an adversarial actor:

- `invariant_billAmountNeverExceedsNominalRate` — catches a regression of the cap-at-nominal clamp under stake-ramp sequences.
- `invariant_baselinePinnedAtActivation` — catches any post-activation code path that re-pins `subscriptionBaselineStake`.
- `stakeRamper` handler actor that `depositAndDelegate`s / schedules unstakes against the operator during the run.

## What's deliberately deferred

- **HIGH Economic H-1** (oracle weight inflation): the proper fix is to snapshot per-(op, asset) USD prices at activation and reuse them at every bill, mirroring the baseline pin. Touches `TangleStorage` + `PaymentsBilling._accrueOperatorWeights` + `PaymentsDistribution._initSubscriptionBaseline` + `ServicesLifecycle._finalizeJoin`. Worth its own focused PR with negative-tested invariants. Customer is safe today (cap-at-nominal); residual risk is distributional between operators in the same service.
- **MEDIUM Reentrancy M-2** (escrow rescue path): admin-rescue route for stuck escrow tokens when the customer's token is centrally paused / blocklists the service owner. Moderate scope; better as its own PR.

## Test plan

- [x] `FOUNDRY_PROFILE=local_build forge build` clean
- [x] `FOUNDRY_PROFILE=fast forge test` regression (non-integration, non-invariant)
- [x] `scripts/local-env/stress-test.sh` 17/17 green
- [ ] Manual review of HIGH/MEDIUM remediations before merge
- [ ] Follow-up PR for HIGH Economic H-1 + MEDIUM Reentrancy M-2