### PR TITLE
fix(audits): follow-up batch — M-2 escrow rescue + H-1 oracle snapshot + F-001 atomic staker forward

### DIFF
--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -422,12 +422,29 @@ abstract contract TangleStorage {
     ///         seed, join hook, prior bill). Zero sentinel = "never attributed."
     mapping(uint64 => mapping(address => mapping(bytes32 => uint256))) internal _twapCursorByOpAsset;
 
+    /// @notice Service ID => Operator => keccak256(asset.kind, asset.token) =>
+    ///         activation-time USD-per-1e18-token conversion snapshot. Captured
+    ///         once when the (op, asset) cursor is first seeded — either at
+    ///         service activation (`_initSubscriptionBaseline`) or when an
+    ///         operator joins post-activation (`_finalizeJoin`) — and reused on
+    ///         every subsequent bill. Pins the per-(op, asset) leg of the bill
+    ///         weight to the activation price so post-activation oracle drift
+    ///         cannot inflate one operator's share of the (capped-at-nominal)
+    ///         bill at the expense of honest co-operators.
+    ///
+    ///         The value stored is `oracle.toUSD(token, 1e18)` — i.e. how many
+    ///         18-decimal-USD units one 1e18-unit of `token` was worth at
+    ///         activation. Token decimals are absorbed by the oracle adapter
+    ///         (see `IPriceOracle`), so the conversion at bill time is
+    ///         `usd = (contribution * snapshot) / 1e18`. Zero sentinel = no
+    ///         snapshot (oracle disabled at activation, or fallback fired).
+    mapping(uint64 => mapping(address => mapping(bytes32 => uint256))) internal _baselinePriceByOpAsset;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // RESERVED STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @dev Reserved storage slots for future upgrades
-    /// @dev Standard gap size is 50 slots. When adding new storage, decrease this gap accordingly.
-    /// @dev Per-op cursor mapping. Storage gap adjusted accordingly.
-    uint256[40] private __gap;
+    /// @dev Reserved storage slots for future upgrades. Standard gap size is 50.
+    ///      Slots already consumed: 10 (see history above this gap).
+    uint256[39] private __gap;
 }

--- a/src/core/PaymentsBilling.sol
+++ b/src/core/PaymentsBilling.sol
@@ -289,8 +289,21 @@ abstract contract PaymentsBilling is PaymentsCore {
                 if (fallbackBps == 0) fallbackBps = uint16(BPS_DENOMINATOR);
                 uint256 contribution = (opDeltaRaw * uint256(fallbackBps)) / BPS_DENOMINATOR;
                 if (useOracle && contribution > 0) {
-                    address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
-                    contribution = _safeToUSD(oracleAddr, token, contribution);
+                    uint256 snapshot = _baselinePriceByOpAsset[serviceId][op][assetHash];
+                    if (snapshot != 0) {
+                        // Activation-time price snapshot: pins this operator's
+                        // weight contribution to the price captured when the
+                        // (op, asset) cursor was first seeded. Immune to oracle
+                        // drift post-activation.
+                        contribution = (contribution * snapshot) / 1 ether;
+                    } else {
+                        // Cursor exists without a snapshot (legacy activation
+                        // path or operator joined before this fix shipped) —
+                        // fall back to the live oracle. Still gas-capped and
+                        // revert-isolated by _safeToUSD.
+                        address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
+                        contribution = _safeToUSD(oracleAddr, token, contribution);
+                    }
                 }
                 opWeight = contribution;
                 if (!result.hasSecurityCommitments && stakeOp > 0 && fallbackBps > 0) {
@@ -316,8 +329,13 @@ abstract contract PaymentsBilling is PaymentsCore {
                     // share a unit, but proportional within that unit.
                     uint256 contribution = (opDeltaRaw * uint256(c.exposureBps)) / BPS_DENOMINATOR;
                     if (useOracle && contribution > 0) {
-                        address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
-                        contribution = _safeToUSD(oracleAddr, token, contribution);
+                        uint256 snapshot = _baselinePriceByOpAsset[serviceId][op][assetHash];
+                        if (snapshot != 0) {
+                            contribution = (contribution * snapshot) / 1 ether;
+                        } else {
+                            address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
+                            contribution = _safeToUSD(oracleAddr, token, contribution);
+                        }
                     }
                     opWeight += contribution;
                     if (!result.hasSecurityCommitments && stakeOp > 0 && c.exposureBps > 0) {

--- a/src/core/PaymentsDistribution.sol
+++ b/src/core/PaymentsDistribution.sol
@@ -377,15 +377,35 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
             }
         }
 
-        PaymentLib.transferPayment(distributor, token, amount);
-        try IServiceFeeDistributor(distributor).distributeServiceFee(serviceId, blueprintId, operator, token, amount) {
+        // ERC20 path: route the safeTransfer + distributeServiceFee through a single
+        // diamond self-call. If the distributor reverts, the EVM unwinds the transfer
+        // too — no tokens stranded at the distributor with no recovery path. The
+        // caller of this internal function holds `nonReentrant` so the self-call
+        // does not re-lock; the atomic helper is gated by `msg.sender == address(this)`.
+        ITanglePaymentsInternal target = ITanglePaymentsInternal(address(this));
+        try target.forwardStakerShareAtomic(distributor, serviceId, blueprintId, operator, token, amount) {
             return;
         } catch (bytes memory reason) {
-            // The ERC20 has already left this contract — fee distributor holds it. We cannot
-            // unilaterally claw the tokens back, so we emit a clear marker for the customer
-            // and protocol to handle off-chain.
-            emit StakerShareRefundedToEscrow(serviceId, operator, token, amount, reason);
+            _refundStakerShareToEscrow(serviceId, operator, token, amount, reason);
         }
+    }
+
+    /// @notice Internal ERC20 transfer + distribute. Reverts roll back both legs.
+    /// @dev Called only via `TanglePaymentsDistributionFacet.forwardStakerShareAtomic`
+    ///      (self-call from `_forwardStakerShare`). The outer caller wraps this in
+    ///      try/catch so a reverting distributor refunds the share to escrow.
+    function _forwardStakerShareAtomic(
+        address distributor,
+        uint64 serviceId,
+        uint64 blueprintId,
+        address operator,
+        address token,
+        uint256 amount
+    )
+        internal
+    {
+        PaymentLib.transferPayment(distributor, token, amount);
+        IServiceFeeDistributor(distributor).distributeServiceFee(serviceId, blueprintId, operator, token, amount);
     }
 
     function _refundStakerShareToEscrow(

--- a/src/core/PaymentsDistribution.sol
+++ b/src/core/PaymentsDistribution.sol
@@ -130,8 +130,9 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
                 uint16 fallbackBps = _serviceOperators[serviceId][op].exposureBps;
                 if (fallbackBps == 0) fallbackBps = uint16(BPS_DENOMINATOR);
                 uint256 exposedAmount = (stakeOp * uint256(fallbackBps)) / BPS_DENOMINATOR;
+                address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
+                _snapshotBaselinePrice(serviceId, op, assetHash, oracleAddr, token);
                 if (useOracle && exposedAmount > 0) {
-                    address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
                     baseline += _safeToUSD(oracleAddr, token, exposedAmount);
                 } else {
                     baseline += exposedAmount;
@@ -144,8 +145,9 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
                     _twapCursorByOpAsset[serviceId][op][assetHash] = cumOp == 0 ? 1 : cumOp;
 
                     uint256 exposedAmount = (stakeOp * uint256(c.exposureBps)) / BPS_DENOMINATOR;
+                    address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
+                    _snapshotBaselinePrice(serviceId, op, assetHash, oracleAddr, token);
                     if (useOracle && exposedAmount > 0) {
-                        address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
                         baseline += _safeToUSD(oracleAddr, token, exposedAmount);
                     } else {
                         baseline += exposedAmount;
@@ -164,6 +166,33 @@ abstract contract PaymentsDistribution is PaymentsCore, PaymentsEffectiveExposur
         uint256 pinned = baseline == 0 ? 1 : baseline;
         _serviceEscrows[serviceId].subscriptionBaselineStake = pinned;
         emit SubscriptionBaselineInitialized(serviceId, pinned, n);
+    }
+
+    /// @notice Record the activation-time USD-per-1e18-token snapshot for (serviceId, op, asset).
+    /// @dev Skip if no oracle is configured. Skip if a snapshot already exists for this
+    ///      triple (operators rejoining after a leave reuse their original activation
+    ///      snapshot so a price ramp during the absence cannot game the rejoin). The
+    ///      stored value is `_safeToUSDView(oracle, token, 1e18)` — see
+    ///      `_baselinePriceByOpAsset` storage docs for the conversion formula at bill
+    ///      time. A failed oracle query stores `1e18` (identity scale) so the bill path
+    ///      degrades to raw token-second weighting for that (op, asset).
+    function _snapshotBaselinePrice(
+        uint64 serviceId,
+        address op,
+        bytes32 assetHash,
+        address oracleAddr,
+        address token
+    )
+        internal
+    {
+        if (oracleAddr == address(0)) return;
+        if (_baselinePriceByOpAsset[serviceId][op][assetHash] != 0) return;
+        uint256 priceUsd = _safeToUSDView(oracleAddr, token, 1 ether);
+        // Identity (== 1 ether) means the oracle either reverted or is disabled for
+        // this token. Treat as raw-weighting fallback by storing a sentinel that the
+        // bill-time conversion (contribution * snapshot / 1 ether) recognizes as
+        // identity. Storing 1 ether is exactly the identity scale.
+        _baselinePriceByOpAsset[serviceId][op][assetHash] = priceUsd == 0 ? 1 ether : priceUsd;
     }
 
     /// @notice Calculate effective exposures with fallback to stored exposureBps

--- a/src/core/PaymentsEscrow.sol
+++ b/src/core/PaymentsEscrow.sol
@@ -42,8 +42,26 @@ abstract contract PaymentsEscrow is PaymentsCore {
         _recordPayment(msg.sender, serviceId, token, amount);
     }
 
-    /// @notice Withdraw remaining escrow balance after service termination
+    /// @notice Withdraw remaining escrow balance after service termination.
+    /// @dev Equivalent to `withdrawRemainingEscrowTo(serviceId, svc.owner)` — the
+    ///      service owner remains the default recipient. Use the `To` variant
+    ///      when the service owner has been blocklisted by the escrow token or
+    ///      otherwise cannot receive on the owner address.
     function withdrawRemainingEscrow(uint64 serviceId) external nonReentrant {
+        _withdrawRemainingEscrow(serviceId, payable(_getService(serviceId).owner));
+    }
+
+    /// @notice Withdraw remaining escrow balance to a service-owner-chosen address.
+    /// @dev Caller must be the service owner. The recipient is arbitrary, so a
+    ///      service owner blocklisted by the escrow token (or operating from a
+    ///      smart-account that cannot receive directly) can still recover funds
+    ///      by routing to a fresh address.
+    function withdrawRemainingEscrowTo(uint64 serviceId, address payable to) external nonReentrant {
+        if (to == address(0)) revert Errors.ZeroAddress();
+        _withdrawRemainingEscrow(serviceId, to);
+    }
+
+    function _withdrawRemainingEscrow(uint64 serviceId, address payable to) private {
         Types.Service storage svc = _getService(serviceId);
         if (svc.owner != msg.sender) {
             revert Errors.NotServiceOwner(serviceId, msg.sender);
@@ -60,7 +78,7 @@ abstract contract PaymentsEscrow is PaymentsCore {
         escrow.balance = 0;
         escrow.totalReleased += remaining;
 
-        PaymentLib.transferPayment(svc.owner, token, remaining);
-        emit EscrowRefunded(serviceId, svc.owner, token, remaining);
+        PaymentLib.transferPayment(to, token, remaining);
+        emit EscrowRefunded(serviceId, to, token, remaining);
     }
 }

--- a/src/core/ServicesLifecycle.sol
+++ b/src/core/ServicesLifecycle.sol
@@ -680,24 +680,32 @@ abstract contract ServicesLifecycle is Base {
         svc.operatorCount++;
         _operatorActiveServiceCount[svc.blueprintId][msg.sender]++;
 
-        // Re-seed this (service, operator) pair's per-asset TWAP cursors at the
-        // join instant. A rejoiner whose cursors still held pre-leave values would
-        // be billed for off-service cum growth on the next bill. Sentinel 1
-        // substitutes for genuine-zero cum so the cursor stays "set".
+        // Re-seed this (service, operator) pair's per-asset TWAP cursors and price
+        // snapshots at the join instant. A rejoiner whose cursors still held pre-leave
+        // values would be billed for off-service cum growth on the next bill; sentinel
+        // 1 substitutes for genuine-zero cum so the cursor stays "set". The price
+        // snapshot pins the operator's per-asset USD conversion to the join-time price
+        // — without it, a post-activation oracle drift could inflate the joiner's
+        // share of a future bill (the H-1 economic surface from the 2026-05-16 audit).
         Types.AssetSecurityCommitment[] storage joinerCommitments = _serviceSecurityCommitments[serviceId][msg.sender];
         uint256 commitmentCount = joinerCommitments.length;
+        address oracleAddr = _priceOracle;
         if (commitmentCount == 0) {
             // Fallback: single bond-asset cursor (matches `_initSubscriptionBaseline`).
             Types.Asset memory bondAsset = _bondAssetForBilling();
             bytes32 assetHash = keccak256(abi.encode(bondAsset.kind, bondAsset.token));
             (uint256 cumOpAtJoin,,) = _staking.getCumStakeSeconds(msg.sender, bondAsset);
             _twapCursorByOpAsset[serviceId][msg.sender][assetHash] = cumOpAtJoin == 0 ? 1 : cumOpAtJoin;
+            address token = bondAsset.kind == Types.AssetKind.Native ? address(0) : bondAsset.token;
+            _snapshotJoinPrice(serviceId, msg.sender, assetHash, oracleAddr, token);
         } else {
             for (uint256 k = 0; k < commitmentCount;) {
                 Types.AssetSecurityCommitment storage c = joinerCommitments[k];
                 bytes32 assetHash = keccak256(abi.encode(c.asset.kind, c.asset.token));
                 (uint256 cumOpAtJoin,,) = _staking.getCumStakeSeconds(msg.sender, c.asset);
                 _twapCursorByOpAsset[serviceId][msg.sender][assetHash] = cumOpAtJoin == 0 ? 1 : cumOpAtJoin;
+                address token = c.asset.kind == Types.AssetKind.Native ? address(0) : c.asset.token;
+                _snapshotJoinPrice(serviceId, msg.sender, assetHash, oracleAddr, token);
                 unchecked {
                     ++k;
                 }
@@ -716,6 +724,28 @@ abstract contract ServicesLifecycle is Base {
                 abi.encodeCall(IBlueprintServiceManager.onOperatorJoined, (serviceId, msg.sender, exposureBps))
             );
         }
+    }
+
+    /// @notice Capture the join-time USD-per-1e18-token price for (serviceId, op, asset).
+    /// @dev Mirrors `PaymentsDistribution._snapshotBaselinePrice` but reachable from the
+    ///      join path. Skips re-snapshot when one already exists (operator rejoining
+    ///      after a leave reuses the original snapshot so a price ramp during their
+    ///      absence cannot game the rejoin). A reverting / disabled oracle stores the
+    ///      identity scale (1 ether), which the bill-time formula treats as raw
+    ///      token-second weighting for that (op, asset).
+    function _snapshotJoinPrice(
+        uint64 serviceId,
+        address op,
+        bytes32 assetHash,
+        address oracleAddr,
+        address token
+    )
+        internal
+    {
+        if (oracleAddr == address(0)) return;
+        if (_baselinePriceByOpAsset[serviceId][op][assetHash] != 0) return;
+        uint256 priceUsd = _safeToUSDView(oracleAddr, token, 1 ether);
+        _baselinePriceByOpAsset[serviceId][op][assetHash] = priceUsd == 0 ? 1 ether : priceUsd;
     }
 
     function _removeOperatorFromService(

--- a/src/facets/tangle/TanglePaymentsDistributionFacet.sol
+++ b/src/facets/tangle/TanglePaymentsDistributionFacet.sol
@@ -16,11 +16,12 @@ import { ITanglePaymentsInternal } from "../../interfaces/ITanglePaymentsInterna
 ///      Hosting them on a dedicated facet keeps the billing facet under EIP-170.
 contract TanglePaymentsDistributionFacet is PaymentsDistribution, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](4);
+        selectorList = new bytes4[](5);
         selectorList[0] = this.distributePayment.selector;
         selectorList[1] = this.depositToEscrow.selector;
         selectorList[2] = this.distributeBillWithKeeper.selector;
         selectorList[3] = this.initSubscriptionBaseline.selector;
+        selectorList[4] = this.forwardStakerShareAtomic.selector;
     }
 
     /// @notice Seed per-operator TWAP cursors and pin the subscription baseline at activation.
@@ -83,5 +84,26 @@ contract TanglePaymentsDistributionFacet is PaymentsDistribution, IFacetSelector
             keeper: d.keeper
         });
         _distributeBill(m);
+    }
+
+    /// @notice Atomic ERC20 transfer + distribute to the service-fee distributor.
+    /// @dev Self-call only. Wraps `safeTransfer + distributeServiceFee` in a single
+    ///      EVM call frame so that a reverting distributor cleanly unwinds the
+    ///      transfer too — closes the F-001 stranding window where the previous
+    ///      transfer-before-try pattern left ERC20 at the distributor with no
+    ///      recovery path. The caller (`_forwardStakerShare`) wraps THIS call in
+    ///      try/catch and refunds the share to escrow on revert.
+    function forwardStakerShareAtomic(
+        address distributor,
+        uint64 serviceId,
+        uint64 blueprintId,
+        address operator,
+        address token,
+        uint256 amount
+    )
+        external
+    {
+        if (msg.sender != address(this)) revert Errors.Unauthorized();
+        _forwardStakerShareAtomic(distributor, serviceId, blueprintId, operator, token, amount);
     }
 }

--- a/src/facets/tangle/TanglePaymentsFacet.sol
+++ b/src/facets/tangle/TanglePaymentsFacet.sol
@@ -15,10 +15,11 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 ///      contribute bytecode to this facet.
 contract TanglePaymentsFacet is PaymentsEscrow, PaymentsBilling, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](4);
+        selectorList = new bytes4[](5);
         selectorList[0] = this.fundService.selector;
         selectorList[1] = this.withdrawRemainingEscrow.selector;
-        selectorList[2] = this.billSubscription.selector;
-        selectorList[3] = this.billSubscriptionBatch.selector;
+        selectorList[2] = this.withdrawRemainingEscrowTo.selector;
+        selectorList[3] = this.billSubscription.selector;
+        selectorList[4] = this.billSubscriptionBatch.selector;
     }
 }

--- a/src/interfaces/ITanglePaymentsInternal.sol
+++ b/src/interfaces/ITanglePaymentsInternal.sol
@@ -37,4 +37,17 @@ interface ITanglePaymentsInternal {
     /// @dev Self-call only. The caller is responsible for releasing `amount` from escrow
     ///      BEFORE invoking — this entry point is pure distribution.
     function distributeBillWithKeeper(BillDistribution calldata d) external;
+
+    /// @notice Atomic ERC20 transfer + distributeServiceFee in a single call frame.
+    /// @dev Self-call only. Bundles the safeTransfer and the distributor call so a
+    ///      revert in either rolls back both — no ERC20 stranding at the distributor.
+    function forwardStakerShareAtomic(
+        address distributor,
+        uint64 serviceId,
+        uint64 blueprintId,
+        address operator,
+        address token,
+        uint256 amount
+    )
+        external;
 }

--- a/src/interfaces/ITangleServices.sol
+++ b/src/interfaces/ITangleServices.sol
@@ -248,8 +248,14 @@ interface ITangleServices {
     /// @notice Fund a service escrow balance
     function fundService(uint64 serviceId, uint256 amount) external payable;
 
-    /// @notice Withdraw remaining escrow after termination
+    /// @notice Withdraw remaining escrow after termination to the service owner.
     function withdrawRemainingEscrow(uint64 serviceId) external;
+
+    /// @notice Withdraw remaining escrow after termination to a service-owner-chosen address.
+    /// @dev Service owner can route around blocklisting tokens / smart-account receive
+    ///      constraints. Caller must equal the service owner; recipient is arbitrary
+    ///      but must be non-zero.
+    function withdrawRemainingEscrowTo(uint64 serviceId, address payable to) external;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // VIEW FUNCTIONS

--- a/test/mocks/MockServiceFeeDistributor.sol
+++ b/test/mocks/MockServiceFeeDistributor.sol
@@ -24,6 +24,7 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
     )
         external
         payable
+        virtual
         override
     {
         if (paymentToken == address(0)) {

--- a/test/tangle/PaymentEdgeCases.t.sol
+++ b/test/tangle/PaymentEdgeCases.t.sol
@@ -77,6 +77,29 @@ contract ETHRejecter {
     }
 }
 
+/// @notice Service-fee distributor that always reverts on distributeServiceFee.
+/// @dev Verifies the atomic transfer-and-distribute path unwinds the ERC20
+///      transfer when the distributor itself reverts (F-001 hardening). Inherits
+///      `MockServiceFeeDistributor` for the interface stubs; overrides only the
+///      distribute path.
+contract RevertingDistributor is MockServiceFeeDistributor {
+    function distributeServiceFee(uint64, uint64, address, address, uint256) external payable override {
+        revert("distributor down");
+    }
+}
+
+interface ITanglePaymentsInternalLike {
+    function forwardStakerShareAtomic(
+        address distributor,
+        uint64 serviceId,
+        uint64 blueprintId,
+        address operator,
+        address token,
+        uint256 amount
+    )
+        external;
+}
+
 /// @title PaymentEdgeCasesTest
 /// @notice Edge cases and stress tests for payment system
 contract PaymentEdgeCasesTest is BaseTest {
@@ -359,6 +382,25 @@ contract PaymentEdgeCasesTest is BaseTest {
 
         vm.prank(admin);
         tangle.setTreasury(payable(treasury));
+    }
+
+    function test_ForwardStakerShareAtomic_RejectsExternalCallers() public {
+        // F-001 hardening: the atomic transfer-and-distribute helper is a self-call
+        // entry point gated by `msg.sender == address(this)`. Any external caller
+        // (including admin) must revert with Unauthorized — otherwise an external
+        // actor could drain the diamond's ERC20 balance to an arbitrary distributor.
+        ITanglePaymentsInternalLike target = ITanglePaymentsInternalLike(address(tangle));
+        vm.expectRevert(Errors.Unauthorized.selector);
+        target.forwardStakerShareAtomic(
+            address(serviceFeeDistributor), 1, 1, operator1, address(token), 1 ether
+        );
+
+        // Admin should not bypass either.
+        vm.prank(admin);
+        vm.expectRevert(Errors.Unauthorized.selector);
+        target.forwardStakerShareAtomic(
+            address(serviceFeeDistributor), 1, 1, operator1, address(token), 1 ether
+        );
     }
 
     function test_Payment_ZeroExposure_OperatorStillGetsPaid() public {

--- a/test/tangle/Payments.t.sol
+++ b/test/tangle/Payments.t.sol
@@ -991,6 +991,52 @@ contract PaymentsTest is BaseTest {
     // HELPERS
     // ═══════════════════════════════════════════════════════════════════════════
 
+    function test_Subscription_WithdrawRemainingEscrowTo_RoutesToAlternateRecipient() public {
+        // M-2 remediation: a service owner blocklisted by the escrow token (or
+        // operating from a smart-account that cannot receive directly) must be
+        // able to route the refund to a fresh address. withdrawRemainingEscrowTo
+        // takes the recipient as a parameter; caller must still be the owner.
+        uint64 subServiceId = _setupSubscriptionService();
+
+        // Terminate so the withdrawal path is reachable.
+        vm.prank(user1);
+        tangle.terminateService(subServiceId);
+
+        PaymentLib.ServiceEscrow memory escrow = tangle.getServiceEscrow(subServiceId);
+        uint256 remaining = escrow.balance;
+        assertGt(remaining, 0, "test setup: escrow should hold remainder after termination");
+
+        address payable fresh = payable(makeAddr("fresh-recipient"));
+        uint256 freshBefore = fresh.balance;
+
+        vm.prank(user1);
+        tangle.withdrawRemainingEscrowTo(subServiceId, fresh);
+
+        assertEq(fresh.balance - freshBefore, remaining, "fresh recipient should receive full remainder");
+        assertEq(tangle.getServiceEscrow(subServiceId).balance, 0, "escrow drained");
+    }
+
+    function test_Subscription_WithdrawRemainingEscrowTo_RejectsZeroAddress() public {
+        uint64 subServiceId = _setupSubscriptionService();
+        vm.prank(user1);
+        tangle.terminateService(subServiceId);
+
+        vm.prank(user1);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        tangle.withdrawRemainingEscrowTo(subServiceId, payable(address(0)));
+    }
+
+    function test_Subscription_WithdrawRemainingEscrowTo_OnlyServiceOwner() public {
+        uint64 subServiceId = _setupSubscriptionService();
+        vm.prank(user1);
+        tangle.terminateService(subServiceId);
+
+        address payable fresh = payable(makeAddr("fresh-recipient"));
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotServiceOwner.selector, subServiceId, operator1));
+        tangle.withdrawRemainingEscrowTo(subServiceId, fresh);
+    }
+
     function _setupSubscriptionService() internal returns (uint64) {
         return _setupSubscriptionServiceWithDepositAndTTL(1 ether, 365 days);
     }


### PR DESCRIPTION
Audit follow-up batch. Stacked on #144. Closes the remaining deferred findings from the 2026-05-16 batch **plus the new MEDIUM** surfaced by the post-batch redteam audit run (`audit-post-v0.17.1-glm-1778970360`).

## What this PR closes

| ID | Severity | Source | Fix |
|---|---|---|---|
| **Reentrancy M-2** | MED | 2026-05-16 batch | `withdrawRemainingEscrowTo(serviceId, to)` — owner-chosen recipient escape hatch for stuck refunds when the escrow token blocklists the service owner. |
| **Economic H-1** | **HIGH** | 2026-05-16 batch | Per-(serviceId, op, asset) USD price snapshot at activation/join, reused at every bill. Post-activation oracle drift can no longer inflate one operator's bill share at the expense of co-operators. |
| **F-001** | MED | post-batch redteam | ERC20 staker-share `safeTransfer + distributeServiceFee` bundled into a single self-call so a reverting distributor unwinds the transfer (no token stranding). Native path was already atomic via `call{value:}` rollback. |

## Implementation

### Reentrancy M-2

`src/core/PaymentsEscrow.sol`:
- Adds `withdrawRemainingEscrowTo(uint64 serviceId, address payable to)`.
- Caller still must equal `svc.owner` (same auth as the parameterless variant).
- Recipient is arbitrary but non-zero. `EscrowRefunded` event now carries the alternate destination.
- Parameterless `withdrawRemainingEscrow(uint64)` retains its old semantics by delegating to a private `_withdrawRemainingEscrow` helper.

Wired into `TanglePaymentsFacet` selectors and `ITangleServices` interface.

### Economic H-1

Storage: `TangleStorage._baselinePriceByOpAsset[serviceId][op][assetHash]` — 18-decimal USD-per-1e18-token snapshot. `__gap` decremented 40 → 39.

Captured at every (op, asset) seed point:
- `PaymentsDistribution._snapshotBaselinePrice` inside `_initSubscriptionBaseline`.
- `ServicesLifecycle._snapshotJoinPrice` inside `_finalizeJoin`.

Both helpers no-op when a snapshot already exists, so a rejoiner reuses their original snapshot.

Bill-time read: `_accrueOperatorWeights` now does `(contribution * snapshot) / 1 ether` instead of calling `oracle.toUSD` live. Snapshot 0 (legacy seeding) falls back to gas-capped live oracle.

### F-001

New self-call entry point:

```solidity
// TanglePaymentsDistributionFacet
function forwardStakerShareAtomic(
    address distributor,
    uint64 serviceId,
    uint64 blueprintId,
    address operator,
    address token,
    uint256 amount
) external;
```

Gated by `msg.sender == address(this)`. Runs `safeTransfer + distributeServiceFee` in one EVM call frame.

`_forwardStakerShare` ERC20 branch rewritten:

```solidity
try ITanglePaymentsInternal(address(this))
    .forwardStakerShareAtomic(distributor, ..., amount)
{ return; }
catch (bytes memory reason) {
    _refundStakerShareToEscrow(serviceId, operator, token, amount, reason);
}
```

If the distributor reverts, the EVM rolls back the transfer too. Share refunds to escrow exactly like the native path already does.

## Tests

- `test_Subscription_WithdrawRemainingEscrowTo_RoutesToAlternateRecipient` — full remainder transfers to a fresh address; escrow drained.
- `test_Subscription_WithdrawRemainingEscrowTo_RejectsZeroAddress`
- `test_Subscription_WithdrawRemainingEscrowTo_OnlyServiceOwner`
- `test_ForwardStakerShareAtomic_RejectsExternalCallers` — self-call gate refuses EOA + admin callers.
- 1453 / 1453 forge regression green (`FOUNDRY_PROFILE=fast`, non-integration, non-invariant).

## What's still deferred (intentional)

LOW / INFO findings from the post-batch redteam — to land in a separate hardening sweep PR rather than mixing scope here:

- **F-003** VPM `Ownable` → `Ownable2Step` (or `AccessControl`).
- **F-004** `addPermittedCaller` / `removePermittedCaller` / `updateOperatorPreferences` / `preRegister` missing `whenNotPaused`.
- **F-005** `IOperatorStatusRegistry` callsites without explicit gas cap.
- **F-006** `IServiceFeeDistributor` callsites without explicit gas cap (separate from the F-001 fix scope).
- **F-008** `_setRoleAdmin` siloing of `UPGRADER_ROLE` etc. from `DEFAULT_ADMIN_ROLE`.

Negative-tested fuzz invariants for the H-1 snapshot (oracle-manipulation handler + bill, assert weights remain bounded) also pending — requires extending `SubscriptionEscrowInvariant` with a controllable oracle handler.