### PR TITLE
chore(cargo): sync lockfile to bindings/fixtures v0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,7 +3351,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-fixtures"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 name = "tokio"


### PR DESCRIPTION
## Summary
- Stranded from #147 — the `bindings/Cargo.toml` and `fixtures/Cargo.toml` bumps to `0.17.1` landed but the corresponding `Cargo.lock` regen was never committed.
- 2-line diff, only the two workspace member versions; no transitive dependency churn.
- `cargo metadata --locked` succeeds locally with this committed.

## Test plan
- [x] `cargo metadata --locked` succeeds (lockfile in sync)
- [ ] CI passes