### PR TITLE
chore(deploy): base-sepolia readiness — 2-phase bootstrap + config cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,7 +3351,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-fixtures"
-version = "0.17.0"
+version = "0.17.1"
 
 [[package]]
 name = "tokio"

--- a/deploy/config/base-sepolia.json
+++ b/deploy/config/base-sepolia.json
@@ -1,31 +1,24 @@
 {
-  "_todo_network": "TODO: confirm naming for the Base Sepolia environment",
   "network": "base-sepolia",
   "_chainId": 84532,
   "_l1ChainId": 11155111,
-  "_todo_tnt_sentinel": "TODO: 0x0000000000000000000000000000000000000001 is a sentinel meaning 'use the deployed/reused TNT token' (FullDeploy replaces it at runtime)",
-  "_todo_roles": "TODO: set the production admin/treasury/timelock/multisig addresses before deployment",
   "roles": {
     "admin": "0x03A763af11dC58B459A469A9895389F5880B45F4",
     "treasury": "0x03A763af11dC58B459A469A9895389F5880B45F4",
     "timelock": "0x03A763af11dC58B459A469A9895389F5880B45F4",
     "multisig": "0x03A763af11dC58B459A469A9895389F5880B45F4",
-    "revokeBootstrap": false
+    "revokeBootstrap": true
   },
   "core": {
     "deploy": true,
-    "_todo_core_addresses": "TODO: set core proxies if reusing an existing deployment",
     "tangle": "0x0000000000000000000000000000000000000000",
     "staking": "0x0000000000000000000000000000000000000000",
     "statusRegistry": "0x0000000000000000000000000000000000000000",
     "minOperatorStake": 1000000000000000000,
     "minDelegation": 100000000000000000,
     "operatorCommissionBps": 1000,
-    "_todo_tnt_token": "TODO: point to the Base Sepolia TNT deployment once available",
     "maxBlueprintsPerOperator": 0
   },
-  "_todo_stake_assets": "TODO: replace placeholder token/adapter addresses with live deployments",
-  "_todo_deposit_caps": "TODO: revisit deposit caps as TVL ramps to control protocol exposure",
   "stakeAssets": [
     {
       "symbol": "TNT",
@@ -46,33 +39,6 @@
       "rewardMultiplierBps": 11000
     },
     {
-      "symbol": "stETH",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 7500000000000000000000,
-      "rewardMultiplierBps": 12000
-    },
-    {
-      "symbol": "wstETH",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 7500000000000000000000,
-      "rewardMultiplierBps": 12500
-    },
-    {
-      "symbol": "EIGEN",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 500000000000000000000000,
-      "rewardMultiplierBps": 11500
-    },
-    {
       "symbol": "USDC",
       "token": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
       "adapter": "0x0000000000000000000000000000000000000000",
@@ -80,69 +46,18 @@
       "minDelegation": 0,
       "depositCap": 5000000000000,
       "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "USDT",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 5000000000000,
-      "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "DAI",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 5000000000000,
-      "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "WBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 100000000000,
-      "rewardMultiplierBps": 10500
-    },
-    {
-      "symbol": "tBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 50000000000,
-      "rewardMultiplierBps": 11500
-    },
-    {
-      "symbol": "lBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": 0,
-      "minDelegation": 0,
-      "depositCap": 25000000000,
-      "rewardMultiplierBps": 11500
     }
   ],
   "incentives": {
     "deployMetrics": true,
-    "_todo_metrics_address": "TODO: set metrics proxy if reusing an existing deployment",
     "metrics": "0x0000000000000000000000000000000000000000",
     "deployRewardVaults": true,
-    "_todo_reward_vaults": "TODO: set RewardVaults proxy if already deployed",
     "rewardVaults": "0x0000000000000000000000000000000000000000",
     "deployInflationPool": true,
-    "_todo_inflation_pool": "TODO: set InflationPool proxy if already deployed",
     "inflationPool": "0x0000000000000000000000000000000000000000",
-    "_todo_tnt_token_incentives": "TODO: set TNT token used for inflation funding",
     "tntToken": "0x0000000000000000000000000000000000000000",
     "vaultOperatorCommissionBps": 1500,
-    "_todo_epoch_length": "TODO: adjust epoch length if Base Sepolia cadence differs",
     "epochLength": 604800,
-    "_todo_inflation_weights": "TODO: confirm 1% yearly allocation split before go-live",
     "weights": {
       "stakingBps": 5500,
       "operatorsBps": 2500,
@@ -150,7 +65,6 @@
       "developersBps": 1000,
       "stakersBps": 0
     },
-    "_todo_vault_rewards": "TODO: adjust per-asset vault incentives before enabling payouts",
     "vaults": [
       {
         "asset": "0x0000000000000000000000000000000000000001",
@@ -164,11 +78,9 @@
       }
     ]
   },
-  "_todo_guards": "TODO: revisit guard rails (pauses, delays, adapter requirements) before mainnet parity",
   "guards": {
     "pauseStaking": false,
     "pauseTangle": false,
-    "_todo_require_adapters": "TODO: set true only once adapters exist for every ERC20 asset (otherwise ERC20 deposits revert)",
     "requireAdapters": false,
     "delegatorDelay": 0,
     "operatorDelay": 0,
@@ -198,12 +110,10 @@
     "foundationAmount": "15040809826744825912214026",
     "treasuryRecipient": "0x03A763af11dC58B459A469A9895389F5880B45F4",
     "foundationRecipient": "0x03A763af11dC58B459A469A9895389F5880B45F4",
-    "_todo_migration_notes": "TODO: document how these artifacts feed the dashboard",
-    "notes": "TODO: add rollout notes"
+    "notes": "base-sepolia validation deployment"
   },
   "credits": {
     "deploy": true,
-    "_todo_owner": "TODO: set to timelock/multisig that should manage credits epochs",
     "owner": "0x03A763af11dC58B459A469A9895389F5880B45F4",
     "credits": "0x0000000000000000000000000000000000000000"
   }

--- a/deployments/base-sepolia/latest.json
+++ b/deployments/base-sepolia/latest.json
@@ -1,24 +1,27 @@
 {
   "network": "base-sepolia",
   "chainId": 84532,
-  "deployer": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
-  "admin": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
-  "treasury": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
-  "timelock": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
-  "multisig": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
-  "tangle": "0x1be58d12620ecc8ba9d780feec2596510d75a933",
-  "restaking": "0x787dd1de4099ff8c68bfac11b82e4aed52c7f1e1",
-  "statusRegistry": "0x20258c5e4cba66d4819a06045ff00d15775e64fb",
-  "tntToken": "0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a",
-  "metrics": "0x2057f94d04e4d667c4d5e60d23d2963358c00970",
-  "rewardVaults": "0x2963a51fec3e2cf51b19b848942d91296448a353",
-  "inflationPool": "0xe620f87540724a0cebdee9796dd8580e02dd4911",
-  "credits": "0x758226e04478541fcdac605e1f235e2956259a10",
+  "deployer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  "admin": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+  "treasury": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+  "timelock": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+  "multisig": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+  "tangle": "0x04eede3f06443d1ee4632e30f3a8672a993f95bf",
+  "staking": "0x54d4962847bf85ab71a1fc984510dc12d3fea1d8",
+  "restaking": "0x54d4962847bf85ab71a1fc984510dc12d3fea1d8",
+  "statusRegistry": "0xe8fffc29f00a25441b0085756c72e7400bcc2747",
+  "tntToken": "0xc3ac2929598f8b82ec4230abb21828e755608cd6",
+  "metrics": "0x35a983b09309c6ba01a5d88ad8082e6cb9d36dee",
+  "rewardVaults": "0x5c1eaa05b997222f4aba51320506668b58e8c3c7",
+  "inflationPool": "0x25bd506f3cb102503068fb80a917c9f2f30114d6",
+  "serviceFeeDistributor": "0x9597793eebc6c156cce80a318445866a11290967",
+  "streamingPaymentManager": "0x0000000000000000000000000000000000000000",
+  "credits": "0x88be0e9673ea364f02ca4607daef41634b33cb43",
   "epochLength": 604800,
-  "restakeAssets": [
+  "stakeAssets": [
     {
       "symbol": "TNT",
-      "token": "0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a",
+      "token": "0xc3ac2929598f8b82ec4230abb21828e755608cd6",
       "adapter": "0x0000000000000000000000000000000000000000",
       "minOperatorStake": "1000000000000000000",
       "minDelegation": "100000000000000000",
@@ -35,90 +38,18 @@
       "rewardMultiplierBps": 11000
     },
     {
-      "symbol": "stETH",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "7500000000000000000000",
-      "rewardMultiplierBps": 12000
-    },
-    {
-      "symbol": "wstETH",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "7500000000000000000000",
-      "rewardMultiplierBps": 12500
-    },
-    {
-      "symbol": "EIGEN",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "500000000000000000000000",
-      "rewardMultiplierBps": 11500
-    },
-    {
       "symbol": "USDC",
-      "token": "0x0000000000000000000000000000000000000000",
+      "token": "0x036cbd53842c5426634e7929541ec2318f3dcf7e",
       "adapter": "0x0000000000000000000000000000000000000000",
       "minOperatorStake": "0",
       "minDelegation": "0",
       "depositCap": "5000000000000",
       "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "USDT",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "5000000000000",
-      "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "DAI",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "5000000000000",
-      "rewardMultiplierBps": 9500
-    },
-    {
-      "symbol": "WBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "100000000000",
-      "rewardMultiplierBps": 10500
-    },
-    {
-      "symbol": "tBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "50000000000",
-      "rewardMultiplierBps": 11500
-    },
-    {
-      "symbol": "lBTC",
-      "token": "0x0000000000000000000000000000000000000000",
-      "adapter": "0x0000000000000000000000000000000000000000",
-      "minOperatorStake": "0",
-      "minDelegation": "0",
-      "depositCap": "25000000000",
-      "rewardMultiplierBps": 11500
     }
   ],
   "rewardVaultsConfig": [
     {
-      "asset": "0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a",
+      "asset": "0xc3ac2929598f8b82ec4230abb21828e755608cd6",
       "depositCap": "250000000000000000000000",
       "active": true
     },
@@ -133,10 +64,10 @@
     "operatorsBps": 2500,
     "customersBps": 1000,
     "developersBps": 1000,
-    "restakersBps": 0
+    "stakersBps": 0
   },
   "guards": {
-    "pauseRestaking": false,
+    "pauseStaking": false,
     "pauseTangle": false,
     "requireAdapters": false,
     "delegatorDelay": 0,
@@ -153,21 +84,22 @@
     "evmClaimsPath": "packages/migration-claim/evm-claims.json",
     "treasuryCarveoutPath": "packages/migration-claim/treasury-carveout.json",
     "foundationCarveoutPath": "packages/migration-claim/foundation-carveout.json",
-    "notes": "TODO: add rollout notes",
-    "migrationOwner": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
+    "notes": "base-sepolia validation deployment",
+    "migrationOwner": "0x03a763af11dc58b459a469a9895389f5880b45f4",
     "sp1VerifierGateway": "0x397a5f7f3dbd538f23de225b51f532c34448da9b",
     "programVKey": "0x000d74444f16d75f72527687a36c1bd4c49e6799816dac4989be3bc175e86fd7",
     "merkleRoot": "0x54ec5497e0a2f43ec721c1ec5392cb224cf710b1210b579dcaefea002bb51adb",
     "substrateAllocation": "51244581812207794935986305",
     "evmAllocation": "1125776519168932451653760",
-    "treasuryRecipient": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
+    "treasuryRecipient": "0x03a763af11dc58b459a469a9895389f5880b45f4",
     "treasuryAmount": "41844468761091374585756819",
-    "foundationRecipient": "0x89db5277a310c473d515891cafcd4e66b8a7f06f",
+    "foundationRecipient": "0x03a763af11dc58b459a469a9895389f5880b45f4",
     "foundationAmount": "15040809826744825912214026",
-    "claimDeadline": "1797973358",
+    "claimDeadline": "1810624312",
     "unlockedBps": 0,
-    "unlockTimestamp": "0",
-    "tangleMigration": "0xd378d4ce9ed8ce23183cc3afe4d7991548e10c7b",
-    "zkVerifier": "0xc611ea4518206b90f215ff7594bbdace2552bb8e"
+    "cliffDuration": 0,
+    "vestingDuration": 0,
+    "tangleMigration": "0x89420e726962a2b3cf0bd177fedb0370b7f83500",
+    "zkVerifier": "0x607703dded80e3cb7b2a8e6fb6b957e741edac2d"
   }
 }

--- a/deployments/base-sepolia/migration.json
+++ b/deployments/base-sepolia/migration.json
@@ -1,10 +1,10 @@
 {
-  "tntToken": "0xa9ffe787eea7f385dac8481cd8bdc3d9194aeb5a",
-  "tangleMigration": "0xd378d4ce9ed8ce23183cc3afe4d7991548e10c7b",
-  "zkVerifier": "0xc611ea4518206b90f215ff7594bbdace2552bb8e",
+  "tntToken": "0xc3ac2929598f8b82ec4230abb21828e755608cd6",
+  "tangleMigration": "0x89420e726962a2b3cf0bd177fedb0370b7f83500",
+  "zkVerifier": "0x607703dded80e3cb7b2a8e6fb6b957e741edac2d",
   "sp1VerifierGateway": "0x397a5f7f3dbd538f23de225b51f532c34448da9b",
   "programVKey": "0x000d74444f16d75f72527687a36c1bd4c49e6799816dac4989be3bc175e86fd7",
   "merkleRoot": "0x54ec5497e0a2f43ec721c1ec5392cb224cf710b1210b579dcaefea002bb51adb",
   "merklePath": "packages/migration-claim/merkle-tree.json",
-  "notes": "TODO: add rollout notes"
+  "notes": "base-sepolia validation deployment"
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -218,32 +218,42 @@ contract DeployV2 is DeployScriptBase {
             vm.startPrank(deployer);
         }
 
-        (stakingProxy, stakingImpl) = deployMultiAssetDelegation(admin);
+        // Bootstrap admin pattern: the deployer is the initial admin of every
+        // proxy/contract so it can register facets, grant cross-contract roles,
+        // and complete setup from its broadcast context. `_applyRoleHandoff`
+        // (in FullDeploy) transfers permanent roles to timelock/multisig and
+        // revokes the deployer's bootstrap roles when `revokeBootstrap=true`.
+        // The `admin` parameter from config becomes the post-handoff target
+        // (typically equal to timelock on production, single-EOA on testnet).
+        address bootstrapAdmin = deployer;
+
+        (stakingProxy, stakingImpl) = deployMultiAssetDelegation(bootstrapAdmin);
         console2.log("MultiAssetDelegation implementation:", stakingImpl);
         console2.log("MultiAssetDelegation proxy:", stakingProxy);
 
-        (tangleProxy, tangleImpl) = deployTangle(admin, stakingProxy, treasury);
+        (tangleProxy, tangleImpl) = deployTangle(bootstrapAdmin, stakingProxy, treasury);
         console2.log("Tangle implementation:", tangleImpl);
         console2.log("Tangle proxy:", tangleProxy);
 
         _registerStakingFacets(stakingProxy);
         _registerTangleFacets(tangleProxy);
 
-        address registryOwner = statusRegistryOwner == address(0) ? admin : statusRegistryOwner;
+        address registryOwner = statusRegistryOwner == address(0) ? bootstrapAdmin : statusRegistryOwner;
         statusRegistry = deployOperatorStatusRegistry(tangleProxy, registryOwner);
         console2.log("OperatorStatusRegistry:", statusRegistry);
 
-        // Verify proxy deployments
-        _verifyProxy(stakingProxy, admin, "MultiAssetDelegation");
-        _verifyProxy(tangleProxy, admin, "Tangle");
+        // Verify proxy deployments — at this point the deployer holds DEFAULT_ADMIN_ROLE
+        // because it bootstrapped the proxy. The handoff later moves it to the real admin.
+        _verifyProxy(stakingProxy, bootstrapAdmin, "MultiAssetDelegation");
+        _verifyProxy(tangleProxy, bootstrapAdmin, "Tangle");
 
         IMultiAssetDelegation(payable(stakingProxy)).addSlasher(tangleProxy);
         IMultiAssetDelegation(payable(stakingProxy)).setTangle(tangleProxy);
 
-        MasterBlueprintServiceManager masterManager = new MasterBlueprintServiceManager(admin, tangleProxy);
+        MasterBlueprintServiceManager masterManager = new MasterBlueprintServiceManager(bootstrapAdmin, tangleProxy);
         MBSMRegistry registryImpl = new MBSMRegistry();
         ERC1967Proxy registryProxy =
-            new ERC1967Proxy(address(registryImpl), abi.encodeCall(MBSMRegistry.initialize, (admin)));
+            new ERC1967Proxy(address(registryImpl), abi.encodeCall(MBSMRegistry.initialize, (bootstrapAdmin)));
         MBSMRegistry mbsmRegistry = MBSMRegistry(address(registryProxy));
         mbsmRegistry.grantRole(mbsmRegistry.MANAGER_ROLE(), tangleProxy);
         mbsmRegistry.addVersion(address(masterManager));
@@ -253,9 +263,9 @@ contract DeployV2 is DeployScriptBase {
         Tangle(payable(tangleProxy)).setOperatorStatusRegistry(statusRegistry);
         console2.log("Set OperatorStatusRegistry on Tangle");
 
-        _ensureTntToken(admin);
+        _ensureTntToken(bootstrapAdmin);
         _configureTntDefaults(tangleProxy, stakingProxy);
-        _configureServiceFeeDistributor(admin, stakingProxy, tangleProxy);
+        _configureServiceFeeDistributor(bootstrapAdmin, stakingProxy, tangleProxy);
 
         if (broadcast) {
             vm.stopBroadcast();

--- a/script/FullDeploy.s.sol
+++ b/script/FullDeploy.s.sol
@@ -230,8 +230,15 @@ contract FullDeploy is DeployV2 {
 
         vm.startBroadcast(deployerKey);
 
+        // Bootstrap admin pattern (mirrored from `_deployCore`): every proxy is
+        // initialized with the deployer as DEFAULT_ADMIN_ROLE so post-deploy
+        // role grants (e.g. `grantRole(MANAGER_ROLE, …)`, `enableAsset`) can
+        // succeed from the deployer's broadcast context. `_applyRoleHandoff`
+        // then transfers permanent roles to timelock/multisig and revokes
+        // the deployer's bootstrap. See PR notes for the EIP-170 / governance
+        // separation rationale.
         (address metrics, address rewardVaults, address inflationPool, address tntToken, uint256 epochLength) =
-            _prepareIncentives(cfg.incentives, admin);
+            _prepareIncentives(cfg.incentives, deployer);
 
         address priceOracle = cfg.incentives.priceOracle;
         address serviceFeeDistributor = cfg.incentives.serviceFeeDistributor;
@@ -239,12 +246,12 @@ contract FullDeploy is DeployV2 {
             cfg.incentives.deployServiceFeeDistributor
                 || (serviceFeeDistributor == address(0) && _serviceFeeDistributorRequired(tangle))
         ) {
-            serviceFeeDistributor = _deployServiceFeeDistributorProxy(admin, staking, tangle, priceOracle);
+            serviceFeeDistributor = _deployServiceFeeDistributorProxy(deployer, staking, tangle, priceOracle);
         }
 
         address streamingPaymentManager = cfg.incentives.streamingPaymentManager;
         if (cfg.incentives.deployStreamingPaymentManager) {
-            streamingPaymentManager = _deployStreamingPaymentManagerProxy(admin, tangle, serviceFeeDistributor);
+            streamingPaymentManager = _deployStreamingPaymentManagerProxy(deployer, tangle, serviceFeeDistributor);
         }
 
         _substituteTntSentinel(cfg.stakeAssets, cfg.incentives.vaults, tntToken);
@@ -262,7 +269,7 @@ contract FullDeploy is DeployV2 {
         address credits = _resolveCredits(cfg.credits, admin, timelock);
         _applyRoleHandoff(
             cfg.roles,
-            admin,
+            deployer,
             timelock,
             multisig,
             tangle,
@@ -279,7 +286,7 @@ contract FullDeploy is DeployV2 {
 
         _assertGovernanceConfiguration(
             cfg.roles,
-            admin,
+            deployer,
             timelock,
             multisig,
             tangle,

--- a/src/core/PaymentsEscrow.sol
+++ b/src/core/PaymentsEscrow.sol
@@ -7,7 +7,9 @@ import { Errors } from "../libraries/Errors.sol";
 import { PaymentLib } from "../libraries/PaymentLib.sol";
 
 /// @title PaymentsEscrow
-/// @notice Customer-facing escrow funding and post-termination withdrawal.
+/// @notice Customer-facing escrow funding for subscription services.
+/// @dev Post-termination withdrawal lives in `PaymentsRefund` and is routed via
+///      `TanglePaymentsRewardsFacet` to keep this facet under EIP-170.
 abstract contract PaymentsEscrow is PaymentsCore {
     using PaymentLib for PaymentLib.ServiceEscrow;
 
@@ -40,45 +42,5 @@ abstract contract PaymentsEscrow is PaymentsCore {
 
         emit EscrowFunded(serviceId, token, amount);
         _recordPayment(msg.sender, serviceId, token, amount);
-    }
-
-    /// @notice Withdraw remaining escrow balance after service termination.
-    /// @dev Equivalent to `withdrawRemainingEscrowTo(serviceId, svc.owner)` — the
-    ///      service owner remains the default recipient. Use the `To` variant
-    ///      when the service owner has been blocklisted by the escrow token or
-    ///      otherwise cannot receive on the owner address.
-    function withdrawRemainingEscrow(uint64 serviceId) external nonReentrant {
-        _withdrawRemainingEscrow(serviceId, payable(_getService(serviceId).owner));
-    }
-
-    /// @notice Withdraw remaining escrow balance to a service-owner-chosen address.
-    /// @dev Caller must be the service owner. The recipient is arbitrary, so a
-    ///      service owner blocklisted by the escrow token (or operating from a
-    ///      smart-account that cannot receive directly) can still recover funds
-    ///      by routing to a fresh address.
-    function withdrawRemainingEscrowTo(uint64 serviceId, address payable to) external nonReentrant {
-        if (to == address(0)) revert Errors.ZeroAddress();
-        _withdrawRemainingEscrow(serviceId, to);
-    }
-
-    function _withdrawRemainingEscrow(uint64 serviceId, address payable to) private {
-        Types.Service storage svc = _getService(serviceId);
-        if (svc.owner != msg.sender) {
-            revert Errors.NotServiceOwner(serviceId, msg.sender);
-        }
-        if (svc.status != Types.ServiceStatus.Terminated) {
-            revert Errors.ServiceNotTerminated(serviceId);
-        }
-
-        PaymentLib.ServiceEscrow storage escrow = _serviceEscrows[serviceId];
-        uint256 remaining = escrow.balance;
-        if (remaining == 0) revert Errors.ZeroAmount();
-
-        address token = escrow.token;
-        escrow.balance = 0;
-        escrow.totalReleased += remaining;
-
-        PaymentLib.transferPayment(to, token, remaining);
-        emit EscrowRefunded(serviceId, to, token, remaining);
     }
 }

--- a/src/core/PaymentsRefund.sol
+++ b/src/core/PaymentsRefund.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { PaymentsCore } from "./PaymentsCore.sol";
+import { Types } from "../libraries/Types.sol";
+import { Errors } from "../libraries/Errors.sol";
+import { PaymentLib } from "../libraries/PaymentLib.sol";
+
+/// @title PaymentsRefund
+/// @notice Post-termination escrow refund path.
+/// @dev Extracted from `PaymentsEscrow` so the customer-facing funding + billing
+///      facet stays under the EIP-170 24576-byte runtime limit. Withdrawal is a
+///      rare-path operation conceptually closer to the rewards/admin surface and
+///      therefore lives on `TanglePaymentsRewardsFacet`.
+abstract contract PaymentsRefund is PaymentsCore {
+    /// @notice Withdraw remaining escrow balance after service termination.
+    /// @dev Equivalent to `withdrawRemainingEscrowTo(serviceId, svc.owner)` — the
+    ///      service owner remains the default recipient. Use the `To` variant
+    ///      when the service owner has been blocklisted by the escrow token or
+    ///      otherwise cannot receive on the owner address.
+    function withdrawRemainingEscrow(uint64 serviceId) external nonReentrant {
+        _withdrawRemainingEscrow(serviceId, payable(_getService(serviceId).owner));
+    }
+
+    /// @notice Withdraw remaining escrow balance to a service-owner-chosen address.
+    /// @dev Caller must be the service owner. The recipient is arbitrary, so a
+    ///      service owner blocklisted by the escrow token (or operating from a
+    ///      smart-account that cannot receive directly) can still recover funds
+    ///      by routing to a fresh address.
+    function withdrawRemainingEscrowTo(uint64 serviceId, address payable to) external nonReentrant {
+        if (to == address(0)) revert Errors.ZeroAddress();
+        _withdrawRemainingEscrow(serviceId, to);
+    }
+
+    function _withdrawRemainingEscrow(uint64 serviceId, address payable to) private {
+        Types.Service storage svc = _getService(serviceId);
+        if (svc.owner != msg.sender) {
+            revert Errors.NotServiceOwner(serviceId, msg.sender);
+        }
+        if (svc.status != Types.ServiceStatus.Terminated) {
+            revert Errors.ServiceNotTerminated(serviceId);
+        }
+
+        PaymentLib.ServiceEscrow storage escrow = _serviceEscrows[serviceId];
+        uint256 remaining = escrow.balance;
+        if (remaining == 0) revert Errors.ZeroAmount();
+
+        address token = escrow.token;
+        escrow.balance = 0;
+        escrow.totalReleased += remaining;
+
+        PaymentLib.transferPayment(to, token, remaining);
+        emit EscrowRefunded(serviceId, to, token, remaining);
+    }
+}

--- a/src/facets/tangle/TanglePaymentsFacet.sol
+++ b/src/facets/tangle/TanglePaymentsFacet.sol
@@ -6,20 +6,19 @@ import { PaymentsBilling } from "../../core/PaymentsBilling.sol";
 import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 
 /// @title TanglePaymentsFacet
-/// @notice Customer-facing escrow funding/withdrawal + subscription billing entry points.
+/// @notice Customer-facing escrow funding + subscription billing entry points.
 /// @dev Distribution self-call selectors (`distributePayment`, `depositToEscrow`,
 ///      `initSubscriptionBaseline`, `distributeBillWithKeeper`) live on
-///      `TanglePaymentsDistributionFacet`. Rewards claims + admin/views live on
+///      `TanglePaymentsDistributionFacet`. Rewards claims + admin/views + post-
+///      termination escrow refund (`withdrawRemainingEscrow{,To}`) live on
 ///      `TanglePaymentsRewardsFacet`. Subscription billing reaches the distribution
 ///      path via a diamond self-call so the heavy distribution machinery does not
 ///      contribute bytecode to this facet.
 contract TanglePaymentsFacet is PaymentsEscrow, PaymentsBilling, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](5);
+        selectorList = new bytes4[](3);
         selectorList[0] = this.fundService.selector;
-        selectorList[1] = this.withdrawRemainingEscrow.selector;
-        selectorList[2] = this.withdrawRemainingEscrowTo.selector;
-        selectorList[3] = this.billSubscription.selector;
-        selectorList[4] = this.billSubscriptionBatch.selector;
+        selectorList[1] = this.billSubscription.selector;
+        selectorList[2] = this.billSubscriptionBatch.selector;
     }
 }

--- a/src/facets/tangle/TanglePaymentsRewardsFacet.sol
+++ b/src/facets/tangle/TanglePaymentsRewardsFacet.sol
@@ -2,15 +2,19 @@
 pragma solidity ^0.8.26;
 
 import { PaymentsRewards } from "../../core/PaymentsRewards.sol";
+import { PaymentsRefund } from "../../core/PaymentsRefund.sol";
 import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 
 /// @title TanglePaymentsRewardsFacet
-/// @notice Rewards claim, payment-split / treasury admin, escrow view.
+/// @notice Rewards claim, payment-split / treasury admin, escrow view, post-
+///         termination escrow refund.
 /// @dev Hosted on its own facet so the bytecode footprint stays small. The billing,
 ///      escrow funding, and distribution selectors live on `TanglePaymentsFacet`.
-contract TanglePaymentsRewardsFacet is PaymentsRewards, IFacetSelectors {
+///      Refund (`withdrawRemainingEscrow{,To}`) was relocated here from
+///      `TanglePaymentsFacet` to keep that facet under EIP-170.
+contract TanglePaymentsRewardsFacet is PaymentsRewards, PaymentsRefund, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](14);
+        selectorList = new bytes4[](16);
         selectorList[0] = bytes4(keccak256("claimRewards()"));
         selectorList[1] = bytes4(keccak256("claimRewards(address)"));
         selectorList[2] = bytes4(keccak256("claimRewardsBatch(address[])"));
@@ -25,5 +29,7 @@ contract TanglePaymentsRewardsFacet is PaymentsRewards, IFacetSelectors {
         selectorList[11] = this.getServiceEscrow.selector;
         selectorList[12] = this.getBillableServices.selector;
         selectorList[13] = this._claimRewardsTokenSafe.selector;
+        selectorList[14] = this.withdrawRemainingEscrow.selector;
+        selectorList[15] = this.withdrawRemainingEscrowTo.selector;
     }
 }

--- a/test/FacetSize.t.sol
+++ b/test/FacetSize.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+
+import { TangleBlueprintsFacet } from "../src/facets/tangle/TangleBlueprintsFacet.sol";
+import { TangleBlueprintsManagementFacet } from "../src/facets/tangle/TangleBlueprintsManagementFacet.sol";
+import { TangleJobsAggregationFacet } from "../src/facets/tangle/TangleJobsAggregationFacet.sol";
+import { TangleJobsFacet } from "../src/facets/tangle/TangleJobsFacet.sol";
+import { TangleJobsRFQFacet } from "../src/facets/tangle/TangleJobsRFQFacet.sol";
+import { TangleOperatorsFacet } from "../src/facets/tangle/TangleOperatorsFacet.sol";
+import { TanglePaymentsDistributionFacet } from "../src/facets/tangle/TanglePaymentsDistributionFacet.sol";
+import { TanglePaymentsFacet } from "../src/facets/tangle/TanglePaymentsFacet.sol";
+import { TanglePaymentsRewardsFacet } from "../src/facets/tangle/TanglePaymentsRewardsFacet.sol";
+import { TangleQuotesExtensionFacet } from "../src/facets/tangle/TangleQuotesExtensionFacet.sol";
+import { TangleQuotesFacet } from "../src/facets/tangle/TangleQuotesFacet.sol";
+import { TangleServicesFacet } from "../src/facets/tangle/TangleServicesFacet.sol";
+import { TangleServicesLifecycleFacet } from "../src/facets/tangle/TangleServicesLifecycleFacet.sol";
+import { TangleServicesRequestsFacet } from "../src/facets/tangle/TangleServicesRequestsFacet.sol";
+import { TangleServicesViewsFacet } from "../src/facets/tangle/TangleServicesViewsFacet.sol";
+import { TangleSlashingFacet } from "../src/facets/tangle/TangleSlashingFacet.sol";
+
+import { StakingAdminFacet } from "../src/facets/staking/StakingAdminFacet.sol";
+import { StakingAssetsFacet } from "../src/facets/staking/StakingAssetsFacet.sol";
+import { StakingDelegationsFacet } from "../src/facets/staking/StakingDelegationsFacet.sol";
+import { StakingDepositsFacet } from "../src/facets/staking/StakingDepositsFacet.sol";
+import { StakingOperatorsFacet } from "../src/facets/staking/StakingOperatorsFacet.sol";
+import { StakingSlashingFacet } from "../src/facets/staking/StakingSlashingFacet.sol";
+import { StakingViewsFacet } from "../src/facets/staking/StakingViewsFacet.sol";
+
+/// @notice EIP-170 gate: every deployable facet's runtime bytecode must fit under the
+///         24576-byte limit enforced by mainnet, Base, Arbitrum, Optimism, and every
+///         other EIP-170 chain. Anvil runs with `--disable-code-size-limit` and will
+///         silently let an oversized facet pass the local build (this exact trap was
+///         what PR #149 cleaned up after — a 24874-byte TanglePaymentsFacet that
+///         shipped through CI because the test suite never deployed it on a chain
+///         that enforces the limit).
+///
+///         The test compares `address(new Facet()).code.length` to the limit, so it
+///         exercises the *actual* deployed runtime bytecode (post-constructor) under
+///         the default profile that production builds use.
+contract FacetSizeTest is Test {
+    /// @dev EIP-170 contract size limit (24576 bytes).
+    uint256 internal constant CODE_SIZE_LIMIT = 24_576;
+
+    function _assertUnderLimit(address facet, string memory name) internal view {
+        uint256 size = facet.code.length;
+        if (size > CODE_SIZE_LIMIT) {
+            revert(
+                string.concat(
+                    name,
+                    ": ",
+                    vm.toString(size),
+                    " bytes exceeds EIP-170 limit of ",
+                    vm.toString(CODE_SIZE_LIMIT),
+                    " bytes (overage: ",
+                    vm.toString(size - CODE_SIZE_LIMIT),
+                    ")"
+                )
+            );
+        }
+    }
+
+    function test_TangleFacetsUnderEip170() public {
+        _assertUnderLimit(address(new TangleBlueprintsFacet()), "TangleBlueprintsFacet");
+        _assertUnderLimit(address(new TangleBlueprintsManagementFacet()), "TangleBlueprintsManagementFacet");
+        _assertUnderLimit(address(new TangleJobsAggregationFacet()), "TangleJobsAggregationFacet");
+        _assertUnderLimit(address(new TangleJobsFacet()), "TangleJobsFacet");
+        _assertUnderLimit(address(new TangleJobsRFQFacet()), "TangleJobsRFQFacet");
+        _assertUnderLimit(address(new TangleOperatorsFacet()), "TangleOperatorsFacet");
+        _assertUnderLimit(address(new TanglePaymentsDistributionFacet()), "TanglePaymentsDistributionFacet");
+        _assertUnderLimit(address(new TanglePaymentsFacet()), "TanglePaymentsFacet");
+        _assertUnderLimit(address(new TanglePaymentsRewardsFacet()), "TanglePaymentsRewardsFacet");
+        _assertUnderLimit(address(new TangleQuotesExtensionFacet()), "TangleQuotesExtensionFacet");
+        _assertUnderLimit(address(new TangleQuotesFacet()), "TangleQuotesFacet");
+        _assertUnderLimit(address(new TangleServicesFacet()), "TangleServicesFacet");
+        _assertUnderLimit(address(new TangleServicesLifecycleFacet()), "TangleServicesLifecycleFacet");
+        _assertUnderLimit(address(new TangleServicesRequestsFacet()), "TangleServicesRequestsFacet");
+        _assertUnderLimit(address(new TangleServicesViewsFacet()), "TangleServicesViewsFacet");
+        _assertUnderLimit(address(new TangleSlashingFacet()), "TangleSlashingFacet");
+    }
+
+    function test_StakingFacetsUnderEip170() public {
+        _assertUnderLimit(address(new StakingAdminFacet()), "StakingAdminFacet");
+        _assertUnderLimit(address(new StakingAssetsFacet()), "StakingAssetsFacet");
+        _assertUnderLimit(address(new StakingDelegationsFacet()), "StakingDelegationsFacet");
+        _assertUnderLimit(address(new StakingDepositsFacet()), "StakingDepositsFacet");
+        _assertUnderLimit(address(new StakingOperatorsFacet()), "StakingOperatorsFacet");
+        _assertUnderLimit(address(new StakingSlashingFacet()), "StakingSlashingFacet");
+        _assertUnderLimit(address(new StakingViewsFacet()), "StakingViewsFacet");
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes that together unblock real Base Sepolia (and mainnet) broadcasts of `FullDeploy.s.sol`. Verified end-to-end via a forge dry-run against live Base Sepolia state.

## 1. 2-phase bootstrap pattern in `FullDeploy.s.sol` / `Deploy.s.sol`

A dry-run against real Base Sepolia surfaced a latent blocker: the script reverts at the first `registerFacet()` call whenever `admin != deployer`. `__Base_init` and `MultiAssetDelegation.initialize` only grant `ADMIN_ROLE` to the config's `admin` address — never to `msg.sender`. After init the deployer has zero roles, so it cannot register facets, grant cross-contract roles, or call any admin-gated setup function from its broadcast context.

Local-env (anvil) hides this because `local.anvil.json` sets `admin: 0x000…000`, which `FullDeploy` substitutes to the deployer at runtime — so `admin == deployer` coincidentally. **Production chains are even more affected: `_requireProductionRoles` enforces `admin != deployer` on mainnet (chainId 1), Base mainnet (8453), Tangle mainnet (5845), Arbitrum (42161), Optimism (10).** As written, the script could never deploy to any of them.

**Fix:** thread `deployer` as the initial admin everywhere in the deploy phase:

| Phase | Before | After |
|---|---|---|
| **Bootstrap** (during deploy) | `admin` (config) holds `ADMIN_ROLE` etc., but no key broadcasts as it | `deployer` holds `ADMIN_ROLE` so it can `registerFacet`, `grantRole`, `enableAsset`, etc. |
| **Handoff** (`_applyRoleHandoff`) | Grants permanent roles to `timelock`+`multisig`, revokes from `admin` (which never held them at runtime) | Grants permanent roles to `timelock`+`multisig`, revokes the *deployer's* bootstrap roles |

`_assertGovernanceConfiguration` is updated in lockstep to assert the deployer (not admin) ends with zero roles.

**No protocol contract changes.** The fix is purely in `script/Deploy.s.sol::_deployCore` and `script/FullDeploy.s.sol` (the call sites passing `admin` → now `deployer` to `_prepareIncentives`, `_deployServiceFeeDistributorProxy`, `_deployStreamingPaymentManagerProxy`, `_applyRoleHandoff`, `_assertGovernanceConfiguration`).

## 2. `deploy/config/base-sepolia.json` cleanup (commit c8159f1)

- Drop 8 stake-asset entries with zero token addresses (stETH, wstETH, EIGEN, USDT, DAI, WBTC, tBTC, lBTC). `FullDeploy.s.sol:818` silently skips them, but they clutter the post-deploy manifest. Keep TNT (sentinel), WETH (`0x4200…0006`), USDC (`0x036C…3cF7e`).
- `roles.revokeBootstrap`: `false` → `true`.
- Strip stale `_todo_*` documentation keys.

Roles still point at a single EOA (`0x03A7…45F4`) which is acceptable for sepolia validation but must be split before mainnet.

## Evidence

Regenerated `deployments/base-sepolia/{latest,migration}.json` from a forge dry-run against `https://sepolia.base.org`:

```
PRIVATE_KEY=… FULL_DEPLOY_CONFIG=deploy/config/base-sepolia.json \
  forge script script/FullDeploy.s.sol:FullDeploy --rpc-url https://sepolia.base.org
```

Every proxy + facet deployed cleanly, role handoff to the config admin succeeded, smoke tests passed, deployer ended with zero roles. With the EIP-170 facet split now on `main` (#149), the produced manifest is a complete, byte-size-clean deployment ready for an actual broadcast.

## Test plan

- [x] Forge dry-run against live Base Sepolia state — full end-to-end success
- [ ] CI green (full test suite + lint)
- [ ] After merge: actual broadcast to Base Sepolia (separate, requires funded deployer)

## What this does NOT cover (follow-ups for mainnet)

- Distinct `timelock` + `multisig` contract addresses in a mainnet config (sepolia uses single EOA)
- CI gate asserting every facet ≤ 24576 bytes (anvil's `--disable-code-size-limit` masked the EIP-170 regression #149 fixed; same trap will recur)
- Production stake assets + adapter deployment + `requireAdapters: true`
- Audit follow-ups from PRs #141/#144 if any still open