### PR TITLE
feat(blueprints): on-chain blueprint binary upgrade flow with auditor registry

### DIFF
--- a/deploy/register-blueprints.sh
+++ b/deploy/register-blueprints.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# One-click registration of every blueprint repo under $BLUEPRINT_ROOT
+# against a live Tangle deployment. Idempotent and safe to re-run.
+#
+# What it does, per blueprint repo:
+#   1. cd into the repo and sync its default branch to origin
+#   2. Invoke that repo's ./deploy/register-blueprint.sh with the right
+#      env vars (PRIVATE_KEY, RPC_URL, TANGLE_CORE, PAYMENT_TOKEN)
+#   3. Capture blueprint id + BSM address from the script's stdout
+#   4. Append the result to a deployments manifest at
+#      $DEPLOY_MANIFEST (default: deployments/<network>/blueprints.tsv)
+#
+# Repos that already have a successful entry in the manifest are
+# skipped so the script can run as a top-up.
+#
+# Usage (Base Sepolia, real broadcast):
+#
+#   export PRIVATE_KEY=0x...
+#   export RPC_URL=https://sepolia.base.org
+#   export TANGLE_CORE=0xC9b0716a187072be0f38A5D972392C6479b9Cfe3
+#   export PAYMENT_TOKEN=0x036CbD53842c5426634e7929541eC2318f3dCF7e
+#   ./deploy/register-blueprints.sh
+#
+# Or, pulling the shared testnet deployer key from dotenvx:
+#
+#   export PRIVATE_KEY=$(dotenvx get BASE_SEPOLIA_DEPLOYER_PRIVATE_KEY \
+#       -f ~/company/devops/secrets/shared-testnet-deployer.env)
+#   ./deploy/register-blueprints.sh
+#
+# Restrict to specific repos on retry:
+#
+#   ONLY_REPOS="llm-inference-blueprint voice-inference-blueprint" \
+#     ./deploy/register-blueprints.sh
+#
+
+set -uo pipefail
+
+: "${PRIVATE_KEY:?Set PRIVATE_KEY (or via dotenvx; see header).}"
+: "${RPC_URL:=https://sepolia.base.org}"
+: "${TANGLE_CORE:=0xC9b0716a187072be0f38A5D972392C6479b9Cfe3}"
+: "${PAYMENT_TOKEN:=0x036CbD53842c5426634e7929541eC2318f3dCF7e}"
+: "${TSUSD_ADDRESS:=$PAYMENT_TOKEN}"
+BLUEPRINT_ROOT="${BLUEPRINT_ROOT:-$HOME/code}"
+
+network_slug() {
+    case "$1" in
+        84532)  echo "base-sepolia" ;;
+        8453)   echo "base-mainnet" ;;
+        421614) echo "arbitrum-sepolia" ;;
+        42161)  echo "arbitrum-one" ;;
+        1)      echo "ethereum-mainnet" ;;
+        *)      echo "chain-$1" ;;
+    esac
+}
+
+CHAIN_ID=$(cast chain-id --rpc-url "$RPC_URL" 2>/dev/null || echo "0")
+NETWORK=$(network_slug "$CHAIN_ID")
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_MANIFEST="${DEPLOY_MANIFEST:-$REPO_ROOT/deployments/$NETWORK/blueprints.tsv}"
+mkdir -p "$(dirname "$DEPLOY_MANIFEST")"
+if [ ! -f "$DEPLOY_MANIFEST" ]; then
+    printf 'repo\tblueprint_id\tbsm_address\tstatus\ttimestamp\n' > "$DEPLOY_MANIFEST"
+fi
+
+# All blueprint repos we know about. Flag column:
+#   register — registration is part of normal launch
+#   skip     — utility/MPC blueprint that doesn't have an on-chain BSM yet
+#   pending  — has a register script but is gated (e.g. ai-trading still
+#              depends on its feature branch landing on main)
+REPOS=(
+    "ai-agent-sandbox-blueprint:register"
+    "llm-inference-blueprint:register"
+    "modal-inference-blueprint:register"
+    "image-gen-inference-blueprint:register"
+    "training-blueprint:register"
+    "vector-store-blueprint:register"
+    "distributed-inference-blueprint:register"
+    "voice-inference-blueprint:register"
+    "avatar-inference-blueprint:register"
+    "embedding-inference-blueprint:register"
+    "video-gen-inference-blueprint:register"
+    "openclaw-sandbox-blueprint:register"
+    "ai-trading-blueprint:pending"
+    "microvm-blueprint:skip"
+    "bls-blueprint:skip"
+    "frost-blueprint:skip"
+    "wsts-blueprint:skip"
+)
+
+echo "=== Tangle blueprint registration sweep ==="
+echo "Network:    $NETWORK (chainId $CHAIN_ID)"
+echo "Tangle:     $TANGLE_CORE"
+echo "RPC:        $RPC_URL"
+echo "Manifest:   $DEPLOY_MANIFEST"
+deployer_addr=$(cast wallet address --private-key "$PRIVATE_KEY")
+echo "Deployer:   $deployer_addr"
+echo "Balance:    $(cast balance --ether "$deployer_addr" --rpc-url "$RPC_URL") ETH"
+echo ""
+
+LOG_DIR=$(mktemp -d --suffix=-register-blueprints)
+RESULTS=()
+
+filter_in() {
+    [ -z "${ONLY_REPOS:-}" ] && return 0
+    for needle in $ONLY_REPOS; do
+        [ "$needle" = "$1" ] && return 0
+    done
+    return 1
+}
+
+already_registered() {
+    grep -qE "^$1\\b.+\\bregistered\\b" "$DEPLOY_MANIFEST" 2>/dev/null
+}
+
+for entry in "${REPOS[@]}"; do
+    repo="${entry%%:*}"
+    flag="${entry##*:}"
+    filter_in "$repo" || continue
+
+    case "$flag" in
+        skip)
+            RESULTS+=("$repo: SKIP (utility blueprint, no on-chain BSM yet)")
+            continue
+            ;;
+        pending)
+            RESULTS+=("$repo: PENDING (gated on upstream; see repo CHANGELOG)")
+            continue
+            ;;
+    esac
+
+    if already_registered "$repo"; then
+        existing=$(grep "^$repo\\b" "$DEPLOY_MANIFEST" | tail -1)
+        RESULTS+=("$repo: SKIP (already registered: $existing)")
+        continue
+    fi
+
+    repo_path="$BLUEPRINT_ROOT/$repo"
+    if [ ! -d "$repo_path" ]; then
+        RESULTS+=("$repo: MISSING (no checkout at $repo_path)")
+        continue
+    fi
+    if [ ! -x "$repo_path/deploy/register-blueprint.sh" ]; then
+        RESULTS+=("$repo: NO_SCRIPT (deploy/register-blueprint.sh missing)")
+        continue
+    fi
+
+    echo "============================================================"
+    echo "=== $repo"
+    echo "============================================================"
+
+    # Sync to default branch so we register against the latest merged script.
+    (
+        cd "$repo_path"
+        branch=$(git remote show origin 2>/dev/null | awk '/HEAD branch/{print $NF}')
+        git fetch origin --quiet 2>&1 | tail -2
+        git stash -u >/dev/null 2>&1 || true
+        git checkout "$branch" 2>&1 | tail -1
+        git reset --hard "origin/$branch" 2>&1 | tail -1
+    )
+
+    log="$LOG_DIR/$repo.log"
+    if (
+        cd "$repo_path"
+        PRIVATE_KEY="$PRIVATE_KEY" \
+            RPC_URL="$RPC_URL" \
+            TANGLE_CORE="$TANGLE_CORE" \
+            PAYMENT_TOKEN="$PAYMENT_TOKEN" \
+            TSUSD_ADDRESS="$TSUSD_ADDRESS" \
+            ./deploy/register-blueprint.sh
+    ) > "$log" 2>&1; then
+        bp=$(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+|Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
+        bsm=$(grep -oE 'DEPLOY_[A-Z_]*BSM[A-Z_]*=0x[0-9a-fA-F]{40}|(BSM[A-Za-z]*|BSM proxy)[^=:]*[=:][[:space:]]*0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
+        if [ -n "$bp" ]; then
+            printf '%s\t%s\t%s\tregistered\t%s\n' \
+                "$repo" "$bp" "${bsm:-}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                >> "$DEPLOY_MANIFEST"
+            RESULTS+=("$repo: OK id=$bp bsm=${bsm:-?}")
+            echo "OK id=$bp bsm=${bsm:-?}"
+        else
+            printf '%s\t-\t-\tunknown_output\t%s\n' \
+                "$repo" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                >> "$DEPLOY_MANIFEST"
+            RESULTS+=("$repo: UNKNOWN_OUTPUT (rc=0 but no id parsed; log=$log)")
+        fi
+    else
+        rc=$?
+        printf '%s\t-\t-\tfailed_rc_%d\t%s\n' \
+            "$repo" "$rc" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            >> "$DEPLOY_MANIFEST"
+        RESULTS+=("$repo: FAILED rc=$rc log=$log")
+        echo "FAILED (rc=$rc) — last 10 lines:"
+        tail -10 "$log"
+    fi
+    echo ""
+
+    sleep 5
+done
+
+echo ""
+echo "============== SUMMARY =============="
+printf '%s\n' "${RESULTS[@]}"
+echo ""
+echo "Manifest:   $DEPLOY_MANIFEST"
+echo "Per-repo logs: $LOG_DIR"

--- a/deploy/register-blueprints.sh
+++ b/deploy/register-blueprints.sh
@@ -8,11 +8,30 @@
 #   2. Invoke that repo's ./deploy/register-blueprint.sh with the right
 #      env vars (PRIVATE_KEY, RPC_URL, TANGLE_CORE, PAYMENT_TOKEN)
 #   3. Capture blueprint id + BSM address from the script's stdout
-#   4. Append the result to a deployments manifest at
+#   4. If a v0 binary artifact is configured for the repo, publish it
+#      on-chain via Tangle.publishBinaryVersion + setActiveBinaryVersion
+#      and capture the assigned versionId (see "v0 binary publish" below)
+#   5. Append the result to a deployments manifest at
 #      $DEPLOY_MANIFEST (default: deployments/<network>/blueprints.tsv)
 #
 # Repos that already have a successful entry in the manifest are
 # skipped so the script can run as a top-up.
+#
+# v0 binary publish (per repo, optional):
+#   This sweep only publishes the GENESIS version. New releases ship via
+#   `cargo tangle blueprint publish-version` (see docs/UPGRADING_BLUEPRINTS.md).
+#
+#   To publish a v0 here, set EITHER a per-repo or per-run binary path:
+#     <repo>/dist/blueprint-binary             — convention; auto-detected
+#     BLUEPRINT_BINARY_PATH=/abs/path/to/bin   — env override (single repo)
+#     BLUEPRINT_BINARY_URI=ipfs://<cid>        — required if a binary is
+#                                                 found / configured
+#     BLUEPRINT_ATTESTATION_PATH=/abs/path     — optional sigstore/SLSA bundle
+#
+#   The script computes sha256 locally, calls publishBinaryVersion(...) and
+#   then setActiveBinaryVersion(...) so AUTO services adopt it immediately.
+#   If on-chain already has >=1 published version for the blueprint, the
+#   sweep does NOT publish again — bump versions via cargo-tangle.
 #
 # Usage (Base Sepolia, real broadcast):
 #
@@ -60,8 +79,20 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEPLOY_MANIFEST="${DEPLOY_MANIFEST:-$REPO_ROOT/deployments/$NETWORK/blueprints.tsv}"
 mkdir -p "$(dirname "$DEPLOY_MANIFEST")"
+# Manifest schema (TSV, append-only):
+#   repo                — short blueprint repo name (matches REPOS entries)
+#   blueprint_id        — uint64 returned by Tangle.createBlueprint
+#   bsm_address         — per-blueprint BSM proxy address
+#   status              — registered | failed_rc_<N> | unknown_output | etc.
+#   binary_version_id   — uint64 returned by publishBinaryVersion, or '-'
+#   binary_sha256       — 0x-prefixed sha256 of the published artifact, or '-'
+#   binary_uri          — content-addressed pointer (ipfs:// or https://), or '-'
+#   binary_attestation  — bytes32 attestation bundle digest, or '-'
+#   note                — free-form (e.g. "no_v0_published — re-run when binary path is configured")
+#   timestamp           — UTC RFC3339
 if [ ! -f "$DEPLOY_MANIFEST" ]; then
-    printf 'repo\tblueprint_id\tbsm_address\tstatus\ttimestamp\n' > "$DEPLOY_MANIFEST"
+    printf 'repo\tblueprint_id\tbsm_address\tstatus\tbinary_version_id\tbinary_sha256\tbinary_uri\tbinary_attestation\tnote\ttimestamp\n' \
+        > "$DEPLOY_MANIFEST"
 fi
 
 # All blueprint repos we know about. Flag column:
@@ -69,6 +100,30 @@ fi
 #   skip     — utility/MPC blueprint that doesn't have an on-chain BSM yet
 #   pending  — has a register script but is gated (e.g. ai-trading still
 #              depends on its feature branch landing on main)
+#
+# v0 binary publish migration TODO (tracked in docs/UPGRADING_BLUEPRINTS.md):
+#   ai-trading-blueprint        — DONE: per-repo register-blueprint.sh wired
+#                                 to BLUEPRINT_BINARY_PATH (cloud variant by
+#                                 default; pin BLUEPRINT_TARGET_VARIANTS for
+#                                 instance/tee/validator).
+#   llm-inference-blueprint     — TODO: wire BLUEPRINT_BINARY_PATH into the
+#                                 per-repo register script.
+#   modal-inference-blueprint   — TODO: wire BLUEPRINT_BINARY_PATH.
+#   image-gen-inference-blueprint — TODO: wire BLUEPRINT_BINARY_PATH.
+#   training-blueprint          — TODO: wire BLUEPRINT_BINARY_PATH.
+#   vector-store-blueprint      — TODO: wire BLUEPRINT_BINARY_PATH.
+#   distributed-inference-blueprint — TODO: wire BLUEPRINT_BINARY_PATH.
+#   voice-inference-blueprint   — TODO: wire BLUEPRINT_BINARY_PATH.
+#   avatar-inference-blueprint  — TODO: wire BLUEPRINT_BINARY_PATH.
+#   embedding-inference-blueprint — TODO: wire BLUEPRINT_BINARY_PATH.
+#   video-gen-inference-blueprint — TODO: wire BLUEPRINT_BINARY_PATH.
+#   openclaw-sandbox-blueprint  — TODO: wire BLUEPRINT_BINARY_PATH.
+#   ai-agent-sandbox-blueprint  — TODO: wire BLUEPRINT_BINARY_PATH.
+# Until each repo's per-blueprint register script supports the publish hook,
+# the sweep falls back to the convention path (<repo>/dist/blueprint-binary)
+# in publish_v0_binary(). If neither is present the manifest row carries
+# "no_v0_published — re-run when binary path is configured" and the sweep
+# continues — single missing artifact does not block the rest of the run.
 REPOS=(
     "ai-agent-sandbox-blueprint:register"
     "llm-inference-blueprint:register"
@@ -101,6 +156,152 @@ echo ""
 
 LOG_DIR=$(mktemp -d --suffix=-register-blueprints)
 RESULTS=()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v0 binary publish helper
+#
+# Resolves the artifact path for a repo (env override > repo convention),
+# computes the sha256, and calls Tangle.publishBinaryVersion(...) followed by
+# Tangle.setActiveBinaryVersion(...). All output goes to a per-repo log so the
+# sweep stays tidy.
+#
+# Args:  $1 = repo name (matches REPOS entries)
+#        $2 = repo path (BLUEPRINT_ROOT/$repo)
+#        $3 = blueprint id (uint64)
+# Sets globals (caller reads these to populate the manifest row):
+#   BIN_VERSION_ID      — assigned version index, '-' if not published
+#   BIN_SHA256          — 0x-prefixed digest, '-' if not published
+#   BIN_URI             — published URI, '-' if not published
+#   BIN_ATTEST          — bytes32 attestation hash, '-' if not used
+#   BIN_NOTE            — short status line for the manifest's note column
+publish_v0_binary() {
+    local repo="$1" repo_path="$2" bp_id="$3"
+    BIN_VERSION_ID="-"
+    BIN_SHA256="-"
+    BIN_URI="-"
+    BIN_ATTEST="-"
+    BIN_NOTE="no_v0_published — re-run when binary path is configured"
+
+    # Resolve artifact path.
+    #   1. BLUEPRINT_BINARY_PATH env wins (per-run override; targets a single repo)
+    #   2. Per-repo convention: <repo>/dist/blueprint-binary
+    local artifact=""
+    if [ -n "${BLUEPRINT_BINARY_PATH:-}" ] && [ -f "$BLUEPRINT_BINARY_PATH" ]; then
+        artifact="$BLUEPRINT_BINARY_PATH"
+    elif [ -f "$repo_path/dist/blueprint-binary" ]; then
+        artifact="$repo_path/dist/blueprint-binary"
+    fi
+
+    if [ -z "$artifact" ]; then
+        return 0
+    fi
+
+    local bin_uri="${BLUEPRINT_BINARY_URI:-}"
+    if [ -z "$bin_uri" ]; then
+        BIN_NOTE="no_v0_published — artifact found at $artifact but BLUEPRINT_BINARY_URI not set"
+        return 0
+    fi
+
+    # Probe on-chain version count first — append-only, so we don't re-publish.
+    local count
+    count=$(cast call "$TANGLE_CORE" "getBinaryVersionCount(uint64)(uint64)" "$bp_id" \
+        --rpc-url "$RPC_URL" 2>/dev/null || echo "0")
+    # cast may return decoded number directly, e.g. "0" or "3"; strip whitespace.
+    count="${count// /}"
+    if [ -n "$count" ] && [ "$count" != "0" ]; then
+        BIN_NOTE="v0_already_published (on-chain count=$count) — use cargo tangle blueprint publish-version to ship a new release"
+        # Best-effort capture of existing genesis row for the manifest.
+        local row
+        if row=$(cast call "$TANGLE_CORE" "getBinaryVersion(uint64,uint64)((uint64,bytes32,string,bytes32,uint64,bool))" \
+                "$bp_id" 0 --rpc-url "$RPC_URL" 2>/dev/null); then
+            BIN_VERSION_ID="0"
+            # Decoded tuple looks like: (0, 0xsha..., "ipfs://...", 0xattest..., 1716000000, false)
+            BIN_SHA256=$(echo "$row" | grep -oE '0x[0-9a-fA-F]{64}' | head -1 || echo "-")
+            BIN_URI=$(echo "$row" | grep -oE '"[^"]+"' | head -1 | tr -d '"' || echo "-")
+            local att
+            att=$(echo "$row" | grep -oE '0x[0-9a-fA-F]{64}' | sed -n '2p')
+            [ -n "$att" ] && BIN_ATTEST="$att"
+        fi
+        return 0
+    fi
+
+    # Compute sha256. macOS uses `shasum -a 256`; Linux uses `sha256sum`.
+    local digest_hex=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        digest_hex=$(sha256sum "$artifact" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        digest_hex=$(shasum -a 256 "$artifact" | awk '{print $1}')
+    else
+        BIN_NOTE="no_v0_published — neither sha256sum nor shasum found"
+        return 0
+    fi
+    local sha_arg="0x${digest_hex}"
+
+    # Attestation: caller supplies the bundle file; we hash it. Treat anything
+    # missing as zero (meaning "no bundle"), which the contract accepts.
+    local attest_arg="0x0000000000000000000000000000000000000000000000000000000000000000"
+    if [ -n "${BLUEPRINT_ATTESTATION_PATH:-}" ] && [ -f "$BLUEPRINT_ATTESTATION_PATH" ]; then
+        local att_hex=""
+        if command -v sha256sum >/dev/null 2>&1; then
+            att_hex=$(sha256sum "$BLUEPRINT_ATTESTATION_PATH" | awk '{print $1}')
+        elif command -v shasum >/dev/null 2>&1; then
+            att_hex=$(shasum -a 256 "$BLUEPRINT_ATTESTATION_PATH" | awk '{print $1}')
+        fi
+        if [ -n "$att_hex" ]; then
+            attest_arg="0x${att_hex}"
+        fi
+    fi
+
+    echo ">>> Publishing v0 binary for $repo (blueprintId=$bp_id)"
+    echo "    artifact: $artifact"
+    echo "    sha256:   $sha_arg"
+    echo "    uri:      $bin_uri"
+    echo "    attest:   $attest_arg"
+
+    local pub_log="$LOG_DIR/$repo.publish.log"
+    if ! cast send "$TANGLE_CORE" \
+            "publishBinaryVersion(uint64,bytes32,string,bytes32)" \
+            "$bp_id" "$sha_arg" "$bin_uri" "$attest_arg" \
+            --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" \
+            > "$pub_log" 2>&1; then
+        BIN_NOTE="publishBinaryVersion_failed — see $pub_log"
+        echo "    !! publishBinaryVersion failed (see $pub_log)"
+        return 0
+    fi
+
+    # Re-read the count to discover the freshly assigned versionId. The first
+    # publish for a blueprint always lands at index 0; subsequent ones at N-1.
+    local new_count
+    new_count=$(cast call "$TANGLE_CORE" "getBinaryVersionCount(uint64)(uint64)" "$bp_id" \
+        --rpc-url "$RPC_URL" 2>/dev/null || echo "1")
+    new_count="${new_count// /}"
+    if [ -z "$new_count" ] || [ "$new_count" = "0" ]; then
+        BIN_NOTE="publishBinaryVersion_unexpected — version count still 0"
+        return 0
+    fi
+    local new_version_id=$((new_count - 1))
+
+    # Promote to active so AUTO services pick it up on the next resolution.
+    if ! cast send "$TANGLE_CORE" \
+            "setActiveBinaryVersion(uint64,uint64)" \
+            "$bp_id" "$new_version_id" \
+            --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" \
+            >> "$pub_log" 2>&1; then
+        BIN_VERSION_ID="$new_version_id"
+        BIN_SHA256="$sha_arg"
+        BIN_URI="$bin_uri"
+        BIN_ATTEST="$attest_arg"
+        BIN_NOTE="setActiveBinaryVersion_failed — see $pub_log"
+        return 0
+    fi
+
+    BIN_VERSION_ID="$new_version_id"
+    BIN_SHA256="$sha_arg"
+    BIN_URI="$bin_uri"
+    BIN_ATTEST="$attest_arg"
+    BIN_NOTE="v0_published_and_active"
+    echo "    -> versionId=$new_version_id (set active)"
+}
 
 filter_in() {
     [ -z "${ONLY_REPOS:-}" ] && return 0
@@ -173,20 +374,26 @@ for entry in "${REPOS[@]}"; do
         bp=$(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+|Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
         bsm=$(grep -oE 'DEPLOY_[A-Z_]*BSM[A-Z_]*=0x[0-9a-fA-F]{40}|(BSM[A-Za-z]*|BSM proxy)[^=:]*[=:][[:space:]]*0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
         if [ -n "$bp" ]; then
-            printf '%s\t%s\t%s\tregistered\t%s\n' \
-                "$repo" "$bp" "${bsm:-}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            # Globals set by publish_v0_binary: BIN_VERSION_ID, BIN_SHA256,
+            # BIN_URI, BIN_ATTEST, BIN_NOTE. Each defaults to '-' when no v0
+            # publish was attempted.
+            publish_v0_binary "$repo" "$repo_path" "$bp"
+            printf '%s\t%s\t%s\tregistered\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "$repo" "$bp" "${bsm:-}" \
+                "$BIN_VERSION_ID" "$BIN_SHA256" "$BIN_URI" "$BIN_ATTEST" "$BIN_NOTE" \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                 >> "$DEPLOY_MANIFEST"
-            RESULTS+=("$repo: OK id=$bp bsm=${bsm:-?}")
-            echo "OK id=$bp bsm=${bsm:-?}"
+            RESULTS+=("$repo: OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID ($BIN_NOTE)")
+            echo "OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID"
         else
-            printf '%s\t-\t-\tunknown_output\t%s\n' \
+            printf '%s\t-\t-\tunknown_output\t-\t-\t-\t-\t-\t%s\n' \
                 "$repo" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
                 >> "$DEPLOY_MANIFEST"
             RESULTS+=("$repo: UNKNOWN_OUTPUT (rc=0 but no id parsed; log=$log)")
         fi
     else
         rc=$?
-        printf '%s\t-\t-\tfailed_rc_%d\t%s\n' \
+        printf '%s\t-\t-\tfailed_rc_%d\t-\t-\t-\t-\t-\t%s\n' \
             "$repo" "$rc" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             >> "$DEPLOY_MANIFEST"
         RESULTS+=("$repo: FAILED rc=$rc log=$log")

--- a/docs/UPGRADING_BLUEPRINTS.md
+++ b/docs/UPGRADING_BLUEPRINTS.md
@@ -1,0 +1,645 @@
+# Shipping Blueprint Releases
+
+This is the operating manual for a developer who wrote a Tangle blueprint and
+wants to ship new releases to live operators. It is written for the reader
+who has never used Tangle before; every command is copy-paste runnable.
+
+You will need:
+
+- A blueprint already registered on a live Tangle deployment (Section A walks
+  through this if you don't have one yet).
+- The deployer key for that blueprint (i.e. the address that signed
+  `Tangle.createBlueprint`). On-chain ownership is the only credential that
+  can publish a new version.
+- A built release binary and somewhere to host it (IPFS, GitHub Releases,
+  S3 with stable URL — any content-addressable URI works).
+
+Conceptually the flow is:
+
+```
+  ┌──────────────┐    publishBinaryVersion()    ┌─────────────────┐
+  │ blueprint    │ ───────────────────────────▶ │  on-chain       │
+  │ owner (dev)  │                              │  version 0..N   │
+  └──────────────┘                              └────────┬────────┘
+                                                         │
+        setActiveBinaryVersion()                         │
+                ┌────────────────────────────────────────┘
+                ▼
+     ┌─────────────────────┐    AUTO   ┌───────────────────┐
+     │  service N (AUTO)   │ ────────▶ │ operator pulls    │
+     │  service M (APPROVE)│ ackBinary │ binary, restarts  │
+     │  service P (MANUAL) │ ────────▶ │ blueprint-manager │
+     └─────────────────────┘           └───────────────────┘
+```
+
+There are three roles in this doc: **blueprint owner** (publishes versions),
+**operator** (runs services and decides when to adopt versions), and
+**auditor** (publishes attestations). Most of the doc is written for the
+blueprint owner; Sections D and E call out operator + auditor flows.
+
+---
+
+## A. One-Time Setup
+
+### A.1. Register a blueprint
+
+Blueprints are templates that operators can spin services from. Registration
+puts the template on-chain and assigns it a `blueprintId`.
+
+Every blueprint repo under `~/code/` ships with a `deploy/register-blueprint.sh`
+that handles BSM deployment + `Tangle.createBlueprint(...)` in one shot.
+The canonical sweep script in tnt-core wraps all of them.
+
+```bash
+# From tnt-core, register every known blueprint repo against Base Sepolia.
+cd ~/code/tnt-core
+export PRIVATE_KEY=0x...                  # blueprint owner key
+export RPC_URL=https://sepolia.base.org
+export TANGLE_CORE=0xC9b0716a187072be0f38A5D972392C6479b9Cfe3
+./deploy/register-blueprints.sh
+```
+
+Output appends one row per blueprint to
+`deployments/<network>/blueprints.tsv`:
+
+```
+repo               blueprint_id  bsm_address    status      binary_version_id  binary_sha256  ...
+ai-trading-blueprint   42   0xBSM...   registered   -   -   -   -   no_v0_published   2026-05-22T...
+llm-inference-blueprint 43  0xBSM...   registered   -   -   -   -   no_v0_published   2026-05-22T...
+```
+
+The `binary_version_id` column is `-` because no v0 was published yet — the
+sweep script publishes v0 inline (see A.2). For now the blueprint exists
+on-chain but has zero binaries, which means `effectiveBinaryVersion(serviceId)`
+will revert until you publish at least one.
+
+You can also register a single blueprint by running its per-repo script
+directly:
+
+```bash
+cd ~/code/ai-trading-blueprint
+export PRIVATE_KEY=0x...
+export RPC_URL=https://sepolia.base.org
+export TANGLE_CORE=0xC9b0716a187072be0f38A5D972392C6479b9Cfe3
+BROADCAST=true ./deploy/register-blueprint.sh
+```
+
+The script prints `DEPLOY_BLUEPRINT_ID=<n>` to stdout — that's the
+`blueprintId` you'll use everywhere else in this doc.
+
+### A.2. Publish the v0 binary at registration time
+
+The sweep script publishes a v0 inline when it finds an artifact and a URI.
+For a single repo from CLI:
+
+```bash
+# Build a release artifact (whatever 'cargo build --release' produces)
+cd ~/code/ai-trading-blueprint
+cargo build --release -p trading-blueprint-bin
+
+# Pin to IPFS and capture the CID
+CID=$(ipfs add -Q target/release/trading-blueprint)
+echo "CID=$CID"
+
+# Wire it into the per-repo register script and re-run
+cd ~/code/ai-trading-blueprint
+export BLUEPRINT_BINARY_PATH=$(pwd)/target/release/trading-blueprint
+export BLUEPRINT_BINARY_URI=ipfs://$CID
+export PRIVATE_KEY=0x...
+export RPC_URL=https://sepolia.base.org
+export TANGLE_CORE=0xC9b0716a187072be0f38A5D972392C6479b9Cfe3
+BROADCAST=true ./deploy/register-blueprint.sh
+```
+
+Expected output (registration already done, so this only re-runs the publish):
+
+```
+=== AI Trading Blueprint Registration ===
+  ...
+  DEPLOY_BLUEPRINT_ID=42
+
+=== v0 Binary Publish ===
+  Artifact:  /home/you/code/ai-trading-blueprint/target/release/trading-blueprint
+  sha256:    0xabc...
+  URI:       ipfs://Qm...
+  Attest:    0x0000...0000
+  Variants:  cloud
+  -> publishing v0 for cloud (blueprintId=42)
+  OK cloud blueprintId=42 versionId=0 (active)
+```
+
+After this, `Tangle.effectiveBinaryVersion(serviceId)` returns the row you
+just published for any AUTO-policy service.
+
+If you skip A.2, the manifest carries `no_v0_published — re-run when binary
+path is configured` and operators can't run your blueprint yet.
+
+### A.3. Operator-side bring-up
+
+Operators run the **blueprint-manager** daemon, which:
+
+1. Watches `Tangle.OperatorServiceAdded` for services it's been assigned to.
+2. Resolves `effectiveBinaryVersion(serviceId)` to get
+   `(sha256Hash, binaryUri, attestationHash)`.
+3. Downloads the binary from `binaryUri`, verifies sha256 unconditionally,
+   and (optionally) verifies the attestation bundle.
+4. Spawns the binary with the service's runtime config.
+
+Each operator picks a per-service **upgrade policy** (Section E):
+
+- `AUTO` — adopt whatever the blueprint owner sets active.
+- `APPROVE` — operator explicitly acks each new version before it rolls out.
+- `MANUAL` — pinned to genesis (versionId=0) until policy changes.
+
+`APPROVE` is the default and the only safe choice for operators who don't
+fully trust the blueprint owner. `AUTO` is for first-party blueprints where
+the owner key and the operator key roll up to the same org.
+
+### A.4. Claim the blueprint as a publisher
+
+The dapp and tooling treat the on-chain blueprint owner as the canonical
+publisher. To wire your account into the dapp's "my blueprints" view and
+unlock `cargo tangle blueprint publish-version` (Section B), run:
+
+```bash
+cargo tangle blueprint claim \
+  --blueprint-id 42 \
+  --rpc-url https://sepolia.base.org
+```
+
+This signs a message proving control of the owner key and posts it to the
+dapp's claims indexer. No on-chain state changes — claims are dapp-side
+curation only.
+
+---
+
+## B. Shipping a New Release
+
+This is the loop you run every time you cut a release. The contract is
+**append-only**: every new release becomes versionId N+1 where N is the
+previous max. You cannot rewrite or replace a published version.
+
+### B.1. Build the binary
+
+```bash
+cd ~/code/my-blueprint
+cargo build --release -p my-blueprint
+```
+
+### B.2. Compute the sha256
+
+```bash
+sha256sum target/release/my-blueprint
+# d41d8cd98f00b204e9800998ecf8427e  target/release/my-blueprint
+```
+
+`cargo tangle blueprint publish-version` does this for you — this step is
+just for sanity-checking the build matches what your CI produced.
+
+### B.3. Host the artifact
+
+The binary must live at a content-addressed URI that operators can pull from.
+Two common patterns:
+
+```bash
+# IPFS (preferred — content-addressable, no rotation risk)
+ipfs add -Q target/release/my-blueprint
+# QmXyz...
+
+# GitHub Releases (works fine; URL must be stable for the version's lifetime)
+gh release upload v0.2.0 target/release/my-blueprint --repo myorg/my-blueprint
+# https://github.com/myorg/my-blueprint/releases/download/v0.2.0/my-blueprint
+```
+
+Mirror to a second host if uptime matters — operators fail closed on any
+sha256 mismatch, but they need the bytes to verify in the first place.
+
+### B.4. (Optional) Generate an attestation bundle
+
+The contract stores an `attestationHash` alongside the binary. Common bundle
+formats:
+
+```bash
+# sigstore/cosign predicate
+cosign attest --predicate scan-report.json \
+  --type custom target/release/my-blueprint > attestation.json
+
+# SLSA provenance from GitHub Actions
+gh attestation download target/release/my-blueprint \
+  --repo myorg/my-blueprint > attestation.json
+```
+
+The on-chain field is just a sha256 of the bundle file. Operators (and the
+dapp) re-fetch the full bundle out-of-band and verify it. Zero is accepted
+on-chain and means "no bundle published with this version."
+
+### B.5. Publish on-chain
+
+```bash
+cargo tangle blueprint publish-version \
+  --blueprint-id 42 \
+  --binary target/release/my-blueprint \
+  --binary-uri ipfs://QmXyz... \
+  --attestation-bundle attestation.json \
+  --rpc-url https://sepolia.base.org
+
+# Published versionId=5 · tx 0xabc...
+# sha256 = 0xd41d...
+# attestationHash = 0xfe09...
+```
+
+Equivalent raw `cast` invocation (if you're not running the CLI):
+
+```bash
+SHA=0x$(sha256sum target/release/my-blueprint | awk '{print $1}')
+ATT=0x$(sha256sum attestation.json | awk '{print $1}')
+cast send $TANGLE_CORE \
+  "publishBinaryVersion(uint64,bytes32,string,bytes32)" \
+  42 "$SHA" "ipfs://QmXyz..." "$ATT" \
+  --private-key $PRIVATE_KEY --rpc-url $RPC_URL
+```
+
+The transaction emits `BinaryVersionPublished(blueprintId, versionId,
+sha256Hash, binaryUri)`. The dapp indexer picks it up and surfaces the new
+version in the blueprint detail view, including the trust score derived from
+attestations on this version.
+
+### B.6. Promote to active (most cases)
+
+By default, publishing a new version does **not** auto-roll any services.
+You have to call `setActiveBinaryVersion` to tell AUTO-policy services to
+adopt it:
+
+```bash
+cargo tangle blueprint set-active-version \
+  --blueprint-id 42 \
+  --version-id 5
+
+# or raw cast:
+cast send $TANGLE_CORE \
+  "setActiveBinaryVersion(uint64,uint64)" \
+  42 5 \
+  --private-key $PRIVATE_KEY --rpc-url $RPC_URL
+```
+
+Effect:
+
+- `UpgradePolicy.AUTO` services pick up version 5 on the next
+  `effectiveBinaryVersion(serviceId)` poll (typically the next dispatcher
+  tick, single-digit seconds in production).
+- `UpgradePolicy.APPROVE` services stay on whatever version they previously
+  acked. They'll see the new version in the dapp and can opt in via the
+  operator-side `ack-binary-version` flow (Section E.2).
+- `UpgradePolicy.MANUAL` services stay pinned to versionId=0 (genesis).
+  They do not move until the operator changes policy.
+
+### B.7. Announce
+
+Tell operators something shipped. The on-chain event is visible to anyone
+running an indexer, but the dapp's "subscribe to blueprint updates" channel
+is what most operators will be watching. Include:
+
+- versionId
+- sha256 (so they can sanity-check against your release page)
+- changelog highlights, especially anything that changes operator
+  configuration shape or wire protocol
+- whether you set the version active, or are deferring to operator opt-in
+
+---
+
+## C. Promoting, Deprecating, and Rolling Back
+
+### C.1. When to set-active immediately vs. defer
+
+| Situation                                  | Recommendation                                |
+|--------------------------------------------|-----------------------------------------------|
+| Patch release, no behavior change          | `set-active-version` right after publish      |
+| Minor release, additive features only      | `set-active-version` after smoke-test         |
+| Major release, breaking config schema      | Publish, announce, defer set-active by 1 week |
+| Hotfix for known critical bug              | Publish + set-active in same script           |
+| Audit-blocked release                      | Publish (so auditors can attest), no set-active until audits clear |
+
+### C.2. Deprecating a bad release
+
+If you ship something broken, you cannot delete the version. You can flag it
+as deprecated, which:
+
+- Prevents operators from `ackBinaryVersion`-ing it under APPROVE policy.
+- Surfaces a warning badge in the dapp.
+- Does NOT pull the version from any service that already acked it (sticky
+  by design — see G.2).
+
+```bash
+cargo tangle blueprint deprecate-version \
+  --blueprint-id 42 \
+  --version-id 5
+```
+
+The contract enforces one-way deprecation. There is no `un-deprecate`. If
+you flag a version by accident, the path is to publish the same content as
+versionId N+1 and re-announce — operators ack the new id.
+
+### C.3. Emergency rollback
+
+If `setActiveBinaryVersion(42, 5)` shipped a broken active version, roll
+back by re-setting active to a known-good older versionId:
+
+```bash
+cargo tangle blueprint set-active-version \
+  --blueprint-id 42 \
+  --version-id 3
+```
+
+AUTO services adopt versionId=3 on the next poll. APPROVE services were
+never moved by `set-active` in the first place, so they're unaffected unless
+they had already manually acked versionId=5 — in which case they need to
+re-ack 3 themselves (Section G.2).
+
+Pair the rollback with a deprecation of the broken version so operators
+running APPROVE policy can't accidentally ack it later:
+
+```bash
+cargo tangle blueprint deprecate-version --blueprint-id 42 --version-id 5
+cargo tangle blueprint set-active-version --blueprint-id 42 --version-id 3
+```
+
+---
+
+## D. Requesting Audits
+
+The contract stores `attestationHash` per version, but the trust score
+shown in the dapp is computed from a separate attestation log indexed
+off-chain. Attestations are **permissionless** — anyone can attest any
+version. The dapp curates which attesters it weighs based on its own
+allowlist + reputation model.
+
+### D.1. Standard auditor flow
+
+Auditors review a published version and call:
+
+```bash
+cargo tangle attest \
+  --blueprint-id 42 \
+  --version-id 5 \
+  --kind audit \
+  --severity none \
+  --predicate audit-report-v5.json
+```
+
+`kind` values the dapp recognizes:
+
+- `audit` — full security review (use with `--severity none|low|medium|high|critical`)
+- `slsa` — SLSA provenance proof
+- `reproducibility` — independent rebuild that matches sha256
+- `runtime` — production-soak report from a third-party operator
+
+`severity` is required for `kind=audit`. Values are scored on the dapp side:
+
+| Severity | Trust score impact                                   |
+|----------|------------------------------------------------------|
+| none     | +full credit (clean audit)                           |
+| low      | +partial credit, badge in dapp                       |
+| medium   | neutral, badge in dapp                               |
+| high     | negative score, warn in dapp                         |
+| critical | negative score, dapp recommends operators don't ack  |
+
+### D.2. As a blueprint owner: requesting audits
+
+Auditors are out-of-band. The dapp surfaces a "request audit" button on the
+blueprint detail page that emails the auditor allowlist; the rest is human
+process (statement of work, payment, etc.). On-chain, you don't need to do
+anything — auditors call `cargo tangle attest` directly when they're done.
+
+### D.3. Showing the trust score
+
+The dapp aggregates attestations per `(blueprintId, versionId)` and renders
+a trust score from 0–100. Operators see this in their service detail view
+when deciding whether to ack a new version under APPROVE policy.
+
+---
+
+## E. Operator Side
+
+### E.1. Choosing an upgrade policy
+
+| Policy   | Behavior                                                       | When to use                                              |
+|----------|----------------------------------------------------------------|----------------------------------------------------------|
+| AUTO     | Service runs whatever the blueprint owner sets active.         | First-party blueprints, internal CI, dev/test services.  |
+| APPROVE  | Service runs the latest version this operator has acked. Default. | Untrusted blueprints, prod, anything where you want a review gate. |
+| MANUAL   | Service pinned to genesis (versionId=0) until policy changes.  | Hostile or unknown blueprint owner; investigation mode.  |
+
+Set policy via:
+
+```bash
+cargo tangle service set-upgrade-policy \
+  --service-id 7 \
+  --policy approve
+
+# raw cast:
+# 0 = APPROVE (default), 1 = AUTO, 2 = MANUAL
+cast send $TANGLE_CORE \
+  "setServiceUpgradePolicy(uint64,uint8)" \
+  7 0 \
+  --private-key $OPERATOR_KEY --rpc-url $RPC_URL
+```
+
+The contract requires the caller to be an active operator of the service.
+Policy changes do not retroactively reschedule in-flight jobs — they apply
+on the next `effectiveBinaryVersion(serviceId)` resolution.
+
+### E.2. Acking a new version (APPROVE policy)
+
+When the blueprint owner publishes a new version, the dapp shows the
+operator a card with the new versionId, sha256, URI, and trust score. The
+operator clicks "Adopt" — that calls:
+
+```bash
+cargo tangle service ack-binary-version \
+  --service-id 7 \
+  --version-id 5
+
+# raw cast:
+cast send $TANGLE_CORE \
+  "ackBinaryVersion(uint64,uint64)" \
+  7 5 \
+  --private-key $OPERATOR_KEY --rpc-url $RPC_URL
+```
+
+The contract rejects acks on deprecated versions — if the owner flagged the
+version after the operator already saw it but before the operator clicked,
+the call reverts `VersionDeprecatedCannotAck`. Refresh the dapp and ack the
+next non-deprecated version.
+
+### E.3. What happens during a swap
+
+The blueprint-manager runs a drain-then-restart sequence when
+`effectiveBinaryVersion(serviceId)` returns a different sha256 than what's
+running:
+
+1. Stop accepting new dispatches for the service.
+2. Wait up to `drain_timeout` (default 60s) for in-flight jobs to finish.
+3. SIGTERM the binary; SIGKILL after `kill_grace` (default 10s) if it
+   doesn't exit.
+4. Pull the new binary from `binaryUri`, verify sha256.
+5. Spawn the new binary with the same service config.
+6. Resume dispatch.
+
+In-flight jobs that don't finish during drain are restarted on the new
+binary. If your release changes job semantics in a backwards-incompatible
+way, plan for this — either bump a `workflow_version` field your jobs
+carry, or quiesce dispatch from the client side before publishing.
+
+---
+
+## F. Security Invariants
+
+These are the rules the contract enforces. Build your release process around
+them — they will not bend.
+
+### F.1. sha256 verification is unconditional
+
+The blueprint-manager refuses to spawn any binary whose sha256 does not
+match `effectiveBinaryVersion(serviceId).sha256Hash`. The contract is the
+trust root for what bytes should run. Mirror your binary anywhere you want;
+operators verify what they download against the on-chain hash.
+
+### F.2. The version log is append-only
+
+Once you publish versionId=5, that row is permanent. You cannot edit the
+sha256, URI, or attestation hash. The only way to "replace" a version is
+to publish a new one (versionId=6) and deprecate the old one. The history
+of every release lives on-chain forever.
+
+### F.3. Default policy is APPROVE
+
+`UpgradePolicy.APPROVE` is the default for new services. Operators have to
+explicitly opt in to AUTO, and they should only do so for blueprints they
+trust at the publisher level. This is fail-closed by design — a compromised
+publisher key cannot force-roll AUTO operators to a malicious binary
+*unless those operators opted into AUTO themselves*.
+
+### F.4. Attestations are permissionless
+
+The contract stores one attestation hash per version, but the broader
+attestation log (multiple attesters, multiple kinds) is dapp-side. Anyone
+can call `cargo tangle attest`. The trust score is curation, not consensus.
+A blueprint with zero attestations isn't blocked; it just shows up with a
+"no audits" badge.
+
+### F.5. Operator acks are sticky across deprecation
+
+If an operator acked versionId=5 and the publisher later deprecates 5, the
+operator's service keeps running 5. The contract does not yank out from
+under them. The operator decides when to re-ack a non-deprecated version.
+This protects operators from a compromised publisher key flagging
+known-good versions as deprecated to force operators onto a malicious
+"current" version.
+
+### F.6. Only the blueprint owner can publish / deprecate / set-active
+
+`Tangle.publishBinaryVersion`, `setActiveBinaryVersion`, and
+`deprecateBinaryVersion` all gate on `msg.sender == blueprint.owner`. If
+you transfer blueprint ownership (rare), the new owner inherits all three
+powers; the old owner loses them.
+
+---
+
+## G. Common Pitfalls
+
+### G.1. "I published a version but operators aren't updating"
+
+Check their upgrade policy. `setActiveBinaryVersion` only moves AUTO
+services; APPROVE operators have to ack explicitly.
+
+```bash
+# View per-service policy:
+cargo tangle service show-upgrade-policy --service-id 7
+# Or read it from chain:
+cast call $TANGLE_CORE "getServiceUpgradePolicy(uint64)(uint8)" 7 --rpc-url $RPC_URL
+# 0 = APPROVE (default), 1 = AUTO, 2 = MANUAL
+```
+
+If they're APPROVE: ping them, point at the dapp, tell them to ack. If
+they're MANUAL: there's nothing you as the publisher can do — the operator
+intentionally pinned to genesis.
+
+### G.2. "I deprecated a version but operators are still running it"
+
+Acks are sticky (F.5). The operator has to re-ack a newer non-deprecated
+version, or switch their policy to AUTO (which will pull the active version
+on the next poll). Communicate the deprecation reason — operators won't
+move just because of the badge.
+
+### G.3. "I want to revert to an older version"
+
+`setActiveBinaryVersion` to the older versionId. It does not matter if the
+older version is deprecated or not — `set-active` accepts deprecated
+versions for exactly this rollback case (a UI concern enforces "don't
+ship deprecated as active under normal conditions"; the contract permits
+it for emergencies).
+
+```bash
+cargo tangle blueprint set-active-version --blueprint-id 42 --version-id 3
+```
+
+### G.4. "My publish reverted with `VersionNotFound`"
+
+This is from `setActiveBinaryVersion` or `ackBinaryVersion`, not
+`publishBinaryVersion`. It means the versionId you passed doesn't exist
+yet — typo, or you queried a stale `getBinaryVersionCount` before the
+publish tx confirmed. Wait one block and retry.
+
+### G.5. "My publish reverted with `EmptyBinaryUri` or `ZeroBinaryHash`"
+
+The contract rejects publishes with empty URI or zero sha256. The CLI
+validates both before sending; if you're invoking raw `cast`, make sure
+your `$SHA` starts with `0x` and has exactly 64 hex chars, and that the
+URI string is non-empty.
+
+### G.6. "I set-active to a version no one has acked, but APPROVE services kept running v0"
+
+That's working as designed. `set-active` only moves AUTO services. APPROVE
+services stay on the last version their operator acked, or genesis (v0) if
+they've never acked. To roll APPROVE services forward, the operator must
+ack — there is no publisher-side override.
+
+### G.7. "My operator dropped the binary and the service is stuck"
+
+The blueprint-manager retries the binary fetch with exponential backoff.
+If your URI rotated (e.g. a GitHub release got deleted), republish the
+same bytes at a new URI as a new versionId and either set-active or wait
+for the operator to ack. The sha256 will match (same bytes) and operators
+running APPROVE policy will see "new version, same content" in the dapp.
+
+This is one reason IPFS is preferred over GitHub Releases — IPFS URIs
+don't rotate.
+
+---
+
+## Quick Reference
+
+```bash
+# Publisher (blueprint owner)
+cargo tangle blueprint publish-version --blueprint-id 42 \
+  --binary path/to/bin --binary-uri ipfs://... --attestation-bundle a.json
+cargo tangle blueprint set-active-version --blueprint-id 42 --version-id 5
+cargo tangle blueprint deprecate-version --blueprint-id 42 --version-id 5
+
+# Operator
+cargo tangle service set-upgrade-policy --service-id 7 --policy auto|approve|manual
+cargo tangle service ack-binary-version --service-id 7 --version-id 5
+
+# Auditor
+cargo tangle attest --blueprint-id 42 --version-id 5 \
+  --kind audit --severity none --predicate report.json
+
+# Read-only
+cast call $TANGLE_CORE "getBinaryVersionCount(uint64)(uint64)" 42 --rpc-url $RPC_URL
+cast call $TANGLE_CORE "getActiveBinaryVersionId(uint64)(uint64)" 42 --rpc-url $RPC_URL
+cast call $TANGLE_CORE "getServiceUpgradePolicy(uint64)(uint8)" 7 --rpc-url $RPC_URL
+cast call $TANGLE_CORE "getServiceAckedVersionId(uint64)(uint64)" 7 --rpc-url $RPC_URL
+cast call $TANGLE_CORE "effectiveBinaryVersion(uint64)((uint64,bytes32,string,bytes32,uint64,bool))" 7 --rpc-url $RPC_URL
+```
+
+For the underlying contract surface, see
+`src/core/BlueprintsBinaryVersions.sol`.

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,6 +11,7 @@ import { OperatorStatusRegistry } from "../src/staking/OperatorStatusRegistry.so
 import { TangleToken } from "../src/governance/TangleToken.sol";
 import { MasterBlueprintServiceManager } from "../src/MasterBlueprintServiceManager.sol";
 import { MBSMRegistry } from "../src/MBSMRegistry.sol";
+import { BlueprintAuditors } from "../src/governance/BlueprintAuditors.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { TangleBlueprintsFacet } from "../src/facets/tangle/TangleBlueprintsFacet.sol";
@@ -140,6 +141,14 @@ contract DeployV2 is DeployScriptBase {
     address public tntToken;
     uint256 public tntInitialSupply;
 
+    /// @notice Address of the most recently deployed `BlueprintAuditors` UUPS proxy.
+    /// @dev Set inside `_deployCore`. Exposed as a public state variable so
+    ///      inheriting scripts (`FullDeploy`) and post-deploy tooling can rotate
+    ///      governance roles + revoke bootstrap admin without re-deriving the
+    ///      proxy address. Off-chain consumers (dapp, blueprint-manager,
+    ///      cargo-tangle) read this from the deploy logs.
+    address public deployedBlueprintAuditors;
+
     function run() external virtual {
         uint256 deployerPrivateKey = _requireEnvUint("PRIVATE_KEY");
         address deployer = vm.addr(deployerPrivateKey);
@@ -161,6 +170,7 @@ contract DeployV2 is DeployScriptBase {
         console2.log("Tangle:", tangleProxy);
         console2.log("MultiAssetDelegation:", stakingProxy);
         console2.log("OperatorStatusRegistry:", statusRegistry);
+        console2.log("BlueprintAuditors:", deployedBlueprintAuditors);
     }
 
     /// @notice Dry-run deployment for testing/CI without env or broadcast
@@ -262,6 +272,20 @@ contract DeployV2 is DeployScriptBase {
         mbsmRegistry.grantRole(mbsmRegistry.MANAGER_ROLE(), tangleProxy);
         mbsmRegistry.addVersion(address(masterManager));
         Tangle(payable(tangleProxy)).setMBSMRegistry(address(mbsmRegistry));
+
+        // BlueprintAuditors — governance-curated weight map for the
+        // permissionless attestation registry. The deployer holds all three
+        // roles at bootstrap so it can grant/revoke from the broadcast context;
+        // FullDeploy's `_applyRoleHandoff` is responsible for rotating to
+        // timelock + security-council and revoking the deployer post-deploy.
+        BlueprintAuditors auditorsImpl = new BlueprintAuditors();
+        ERC1967Proxy auditorsProxy = new ERC1967Proxy(
+            address(auditorsImpl),
+            abi.encodeCall(BlueprintAuditors.initialize, (bootstrapAdmin, bootstrapAdmin, bootstrapAdmin))
+        );
+        deployedBlueprintAuditors = address(auditorsProxy);
+        console2.log("BlueprintAuditors implementation:", address(auditorsImpl));
+        console2.log("BlueprintAuditors proxy:", deployedBlueprintAuditors);
 
         console2.log("Granted SLASHER_ROLE and TANGLE_ROLE to Tangle");
         Tangle(payable(tangleProxy)).setOperatorStatusRegistry(statusRegistry);

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -15,6 +15,10 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { TangleBlueprintsFacet } from "../src/facets/tangle/TangleBlueprintsFacet.sol";
 import { TangleBlueprintsManagementFacet } from "../src/facets/tangle/TangleBlueprintsManagementFacet.sol";
+import { TangleBlueprintsBinaryVersionsFacet } from "../src/facets/tangle/TangleBlueprintsBinaryVersionsFacet.sol";
+import {
+    TangleBlueprintsBinaryAttestationsFacet
+} from "../src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol";
 import { TangleOperatorsFacet } from "../src/facets/tangle/TangleOperatorsFacet.sol";
 import { TangleServicesRequestsFacet } from "../src/facets/tangle/TangleServicesRequestsFacet.sol";
 import { TangleServicesFacet } from "../src/facets/tangle/TangleServicesFacet.sol";
@@ -408,6 +412,8 @@ contract DeployV2 is DeployScriptBase {
         Tangle router = Tangle(payable(tangleProxy));
         router.registerFacet(address(new TangleBlueprintsFacet()));
         router.registerFacet(address(new TangleBlueprintsManagementFacet()));
+        router.registerFacet(address(new TangleBlueprintsBinaryVersionsFacet()));
+        router.registerFacet(address(new TangleBlueprintsBinaryAttestationsFacet()));
         router.registerFacet(address(new TangleOperatorsFacet()));
         router.registerFacet(address(new TangleServicesRequestsFacet()));
         router.registerFacet(address(new TangleServicesFacet()));

--- a/script/DeployContractsOnly.s.sol
+++ b/script/DeployContractsOnly.s.sol
@@ -56,6 +56,15 @@ contract DeployContractsOnly is Script {
     address public blueprintAuditors;
 
     function run() external {
+        // This script is for local Anvil only. It hardcodes a well-known dev
+        // key, grants every role to the deployer, and performs NO role handoff
+        // to a timelock or multisig. Using it on a real chain would leave
+        // `BlueprintAuditors.GOVERNANCE_ROLE` (and so the sole `_authorizeUpgrade`
+        // authority) on the script's broadcast EOA. Production deploys MUST go
+        // through `FullDeploy.s.sol`, which performs the role handoff via
+        // `_applyRoleHandoff`.
+        require(block.chainid == 31_337, "DeployContractsOnly: local Anvil only; use FullDeploy for production");
+
         deployer = vm.addr(DEPLOYER_KEY);
 
         console2.log("=== Deploying Core Contracts Only ===");

--- a/script/DeployContractsOnly.s.sol
+++ b/script/DeployContractsOnly.s.sol
@@ -13,6 +13,11 @@ import { MBSMRegistry } from "../src/MBSMRegistry.sol";
 
 import { TangleBlueprintsFacet } from "../src/facets/tangle/TangleBlueprintsFacet.sol";
 import { TangleBlueprintsManagementFacet } from "../src/facets/tangle/TangleBlueprintsManagementFacet.sol";
+import { TangleBlueprintsBinaryVersionsFacet } from "../src/facets/tangle/TangleBlueprintsBinaryVersionsFacet.sol";
+import {
+    TangleBlueprintsBinaryAttestationsFacet
+} from "../src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol";
+import { BlueprintAuditors } from "../src/governance/BlueprintAuditors.sol";
 import { TangleOperatorsFacet } from "../src/facets/tangle/TangleOperatorsFacet.sol";
 import { TangleServicesRequestsFacet } from "../src/facets/tangle/TangleServicesRequestsFacet.sol";
 import { TangleServicesFacet } from "../src/facets/tangle/TangleServicesFacet.sol";
@@ -48,6 +53,7 @@ contract DeployContractsOnly is Script {
     address public tangleProxy;
     address public stakingProxy;
     address public statusRegistry;
+    address public blueprintAuditors;
 
     function run() external {
         deployer = vm.addr(DEPLOYER_KEY);
@@ -101,12 +107,28 @@ contract DeployContractsOnly is Script {
         tangle.setMBSMRegistry(address(registryProxy));
         console2.log("MBSMRegistry:", address(registryProxy));
 
+        // 8. Deploy BlueprintAuditors registry. Governance-curated weight map used
+        //    by off-chain aggregators scoring the permissionless attestations
+        //    written via `BlueprintsBinaryAttestations`. The deployer holds
+        //    `FIRST_PARTY_ADMIN_ROLE` so a security-council multisig can be
+        //    granted/handed-off post-deploy via the standard role flows. In
+        //    production, `governor` must be the TangleTimelock proxy address;
+        //    we pass `deployer` here as a placeholder for local Anvil runs and
+        //    leave production handoff to the FullDeploy / role-handoff scripts.
+        BlueprintAuditors auditorsImpl = new BlueprintAuditors();
+        ERC1967Proxy auditorsProxy = new ERC1967Proxy(
+            address(auditorsImpl), abi.encodeCall(BlueprintAuditors.initialize, (deployer, deployer, deployer))
+        );
+        blueprintAuditors = address(auditorsProxy);
+        console2.log("BlueprintAuditors:", blueprintAuditors);
+
         vm.stopBroadcast();
 
         console2.log("\n=== Deployment Complete ===");
         console2.log("Tangle:                  ", tangleProxy);
         console2.log("MultiAssetDelegation:    ", stakingProxy);
         console2.log("OperatorStatusRegistry:  ", statusRegistry);
+        console2.log("BlueprintAuditors:       ", blueprintAuditors);
         console2.log("\nNo blueprints, services, or operators created.");
         console2.log("Use CLI or cast to register operators and create blueprints.");
     }
@@ -127,6 +149,8 @@ contract DeployContractsOnly is Script {
         Tangle tangle = Tangle(payable(proxy));
         tangle.registerFacet(address(new TangleBlueprintsFacet()));
         tangle.registerFacet(address(new TangleBlueprintsManagementFacet()));
+        tangle.registerFacet(address(new TangleBlueprintsBinaryVersionsFacet()));
+        tangle.registerFacet(address(new TangleBlueprintsBinaryAttestationsFacet()));
         tangle.registerFacet(address(new TangleOperatorsFacet()));
         tangle.registerFacet(address(new TangleServicesRequestsFacet()));
         tangle.registerFacet(address(new TangleServicesFacet()));

--- a/script/FullDeploy.s.sol
+++ b/script/FullDeploy.s.sol
@@ -14,6 +14,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { Tangle } from "../src/Tangle.sol";
 import { Types } from "../src/libraries/Types.sol";
+import { BlueprintAuditors } from "../src/governance/BlueprintAuditors.sol";
 import { ITangleAdmin } from "../src/interfaces/ITangle.sol";
 import { IMultiAssetDelegation } from "../src/interfaces/IMultiAssetDelegation.sol";
 import { MultiAssetDelegation } from "../src/staking/MultiAssetDelegation.sol";
@@ -1173,6 +1174,27 @@ contract FullDeploy is DeployV2 {
                 _revokeRole(streamingPaymentManagerAddr, bytes32(0), bootstrapAdmin);
             }
         }
+
+        // BlueprintAuditors role handoff. `_deployCore` sets `deployedBlueprintAuditors`
+        // when the proxy is created. Without this rotation the deployer EOA
+        // retains `GOVERNANCE_ROLE` (and so the sole upgrade authorization) on
+        // the auditor registry — which is the exact attack surface the security
+        // review flagged. The multisig holds `FIRST_PARTY_ADMIN_ROLE` because
+        // fast-track admit of internal team auditors is a security-council
+        // operation, not a governance vote.
+        address auditorsAddr = deployedBlueprintAuditors;
+        if (auditorsAddr != address(0)) {
+            BlueprintAuditors auditors = BlueprintAuditors(auditorsAddr);
+            _grantRole(auditorsAddr, bytes32(0), timelock);
+            _grantRole(auditorsAddr, auditors.GOVERNANCE_ROLE(), timelock);
+            _grantRole(auditorsAddr, auditors.FIRST_PARTY_ADMIN_ROLE(), multisig);
+
+            if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
+                _revokeRole(auditorsAddr, auditors.FIRST_PARTY_ADMIN_ROLE(), bootstrapAdmin);
+                _revokeRole(auditorsAddr, auditors.GOVERNANCE_ROLE(), bootstrapAdmin);
+                _revokeRole(auditorsAddr, bytes32(0), bootstrapAdmin);
+            }
+        }
     }
 
     function _shouldRevokeBootstrap(
@@ -1272,7 +1294,9 @@ contract FullDeploy is DeployV2 {
 
             if (roles.revokeBootstrap && _shouldRevokeBootstrap(bootstrapAdmin, timelock, multisig)) {
                 _assertMissingRole(tangleAddr, bytes32(0), bootstrapAdmin, "Bootstrap still has Tangle admin");
-                _assertMissingRole(tangleAddr, tangle.ADMIN_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle ADMIN_ROLE");
+                _assertMissingRole(
+                    tangleAddr, tangle.ADMIN_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle ADMIN_ROLE"
+                );
                 _assertMissingRole(
                     tangleAddr, tangle.UPGRADER_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle UPGRADER_ROLE"
                 );
@@ -1280,10 +1304,7 @@ contract FullDeploy is DeployV2 {
                     tangleAddr, tangle.PAUSER_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle PAUSER_ROLE"
                 );
                 _assertMissingRole(
-                    tangleAddr,
-                    tangle.SLASH_ADMIN_ROLE(),
-                    bootstrapAdmin,
-                    "Bootstrap still has Tangle SLASH_ADMIN_ROLE"
+                    tangleAddr, tangle.SLASH_ADMIN_ROLE(), bootstrapAdmin, "Bootstrap still has Tangle SLASH_ADMIN_ROLE"
                 );
             }
         }
@@ -1337,36 +1358,16 @@ contract FullDeploy is DeployV2 {
         }
 
         _assertManagedContractRoles(
-            rewardVaultsAddr,
-            timelock,
-            bootstrapAdmin,
-            roles.revokeBootstrap,
-            "ADMIN_ROLE",
-            "UPGRADER_ROLE"
+            rewardVaultsAddr, timelock, bootstrapAdmin, roles.revokeBootstrap, "ADMIN_ROLE", "UPGRADER_ROLE"
         );
         _assertManagedContractRoles(
-            inflationPoolAddr,
-            timelock,
-            bootstrapAdmin,
-            roles.revokeBootstrap,
-            "ADMIN_ROLE",
-            "UPGRADER_ROLE"
+            inflationPoolAddr, timelock, bootstrapAdmin, roles.revokeBootstrap, "ADMIN_ROLE", "UPGRADER_ROLE"
         );
         _assertManagedContractRoles(
-            serviceFeeDistributorAddr,
-            timelock,
-            bootstrapAdmin,
-            roles.revokeBootstrap,
-            "ADMIN_ROLE",
-            "UPGRADER_ROLE"
+            serviceFeeDistributorAddr, timelock, bootstrapAdmin, roles.revokeBootstrap, "ADMIN_ROLE", "UPGRADER_ROLE"
         );
         _assertManagedContractRoles(
-            streamingPaymentManagerAddr,
-            timelock,
-            bootstrapAdmin,
-            roles.revokeBootstrap,
-            "ADMIN_ROLE",
-            "UPGRADER_ROLE"
+            streamingPaymentManagerAddr, timelock, bootstrapAdmin, roles.revokeBootstrap, "ADMIN_ROLE", "UPGRADER_ROLE"
         );
     }
 
@@ -1384,9 +1385,7 @@ contract FullDeploy is DeployV2 {
         if (target == address(0)) return;
         _assertHasRole(target, bytes32(0), timelock, "Managed contract missing DEFAULT_ADMIN_ROLE");
         _assertHasRole(target, keccak256(bytes(adminRoleName)), timelock, "Managed contract missing ADMIN_ROLE");
-        _assertHasRole(
-            target, keccak256(bytes(upgraderRoleName)), timelock, "Managed contract missing UPGRADER_ROLE"
-        );
+        _assertHasRole(target, keccak256(bytes(upgraderRoleName)), timelock, "Managed contract missing UPGRADER_ROLE");
 
         if (revokeBootstrap && bootstrapAdmin != address(0) && bootstrapAdmin != timelock) {
             _assertMissingRole(target, bytes32(0), bootstrapAdmin, "Bootstrap still has DEFAULT_ADMIN_ROLE");

--- a/src/BlueprintServiceManagerBase.sol
+++ b/src/BlueprintServiceManagerBase.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { IBlueprintServiceManager } from "./interfaces/IBlueprintServiceManager.sol";
+import { Types } from "./libraries/Types.sol";
 
 /// @title BlueprintServiceManagerBase
 /// @notice Base implementation of IBlueprintServiceManager with sensible defaults
@@ -161,16 +162,7 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     }
 
     /// @inheritdoc IBlueprintServiceManager
-    function computeBillAdjustmentBps(
-        uint64,
-        uint64,
-        uint64
-    )
-        external
-        view
-        virtual
-        returns (uint16)
-    {
+    function computeBillAdjustmentBps(uint64, uint64, uint64) external view virtual returns (uint16) {
         // Default: full bill (10_000 bps). Override to implement uptime-based
         // discounts, missed-result penalties, or any quality-of-service feedback.
         return 10_000;
@@ -390,6 +382,23 @@ contract BlueprintServiceManagerBase is IBlueprintServiceManager {
     /// @inheritdoc IBlueprintServiceManager
     function getMinOperatorStake() external view virtual returns (bool useDefault, uint256 minStake) {
         return (true, 0); // Use protocol default from staking module
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BINARY VERSION LIFECYCLE
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @inheritdoc IBlueprintServiceManager
+    function onBinaryVersionPublished(uint64, Types.BinaryVersion calldata) external virtual onlyFromTangle {
+        // No-op by default. Override to gate publishes (revert) or to surface
+        // off-chain notifications. The registry row has already been written when
+        // this fires, so reverts are observed but do not roll back the version.
+    }
+
+    /// @inheritdoc IBlueprintServiceManager
+    function onOperatorBinaryAcked(uint64, uint64, address) external virtual onlyFromTangle {
+        // No-op by default. Override to track operator ack reputation or to gate
+        // job dispatch behind acks.
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/MasterBlueprintServiceManager.sol
+++ b/src/MasterBlueprintServiceManager.sol
@@ -4,10 +4,16 @@ pragma solidity ^0.8.26;
 import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol";
 
 import { IMasterBlueprintServiceManager } from "./interfaces/IMasterBlueprintServiceManager.sol";
+import { Types } from "./libraries/Types.sol";
 
 /// @title MasterBlueprintServiceManager
-/// @notice Protocol-wide sink for blueprint definitions emitted by Tangle
-/// @dev Records every blueprint definition and allows governance to curate/inspect them.
+/// @notice Protocol-wide sink for blueprint definitions and binary-lifecycle events
+///         emitted by Tangle.
+/// @dev Records every blueprint definition and the authoritative cross-blueprint
+///      events for binary version publishes and operator acknowledgements. The
+///      per-blueprint BSM hook is dispatched separately by Tangle so it runs
+///      under Tangle's identity and respects the BSM's `onlyFromTangle` check;
+///      the master manager itself only emits indexer events.
 contract MasterBlueprintServiceManager is IMasterBlueprintServiceManager, AccessControl {
     bytes32 public constant TANGLE_ROLE = keccak256("TANGLE_ROLE");
 
@@ -21,6 +27,14 @@ contract MasterBlueprintServiceManager is IMasterBlueprintServiceManager, Access
     mapping(uint64 => BlueprintRecord) private _records;
 
     event BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition);
+
+    /// @notice Authoritative indexer event for a new binary version.
+    event BinaryVersionRecorded(
+        uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri
+    );
+
+    /// @notice Authoritative indexer event for an operator binary acknowledgement.
+    event OperatorBinaryAckRecorded(uint64 indexed serviceId, uint64 indexed versionId, address indexed operator);
 
     constructor(address admin, address initialTangle) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -52,6 +66,31 @@ contract MasterBlueprintServiceManager is IMasterBlueprintServiceManager, Access
             owner: owner, recordedAt: uint64(block.timestamp), encodedDefinition: encodedDefinition
         });
         emit BlueprintDefinitionRecorded(blueprintId, owner, encodedDefinition);
+    }
+
+    /// @inheritdoc IMasterBlueprintServiceManager
+    function onBinaryVersionPublished(
+        uint64 blueprintId,
+        Types.BinaryVersion calldata version
+    )
+        external
+        override
+        onlyRole(TANGLE_ROLE)
+    {
+        emit BinaryVersionRecorded(blueprintId, version.versionId, version.sha256Hash, version.binaryUri);
+    }
+
+    /// @inheritdoc IMasterBlueprintServiceManager
+    function onOperatorBinaryAcked(
+        uint64 serviceId,
+        uint64 versionId,
+        address operator
+    )
+        external
+        override
+        onlyRole(TANGLE_ROLE)
+    {
+        emit OperatorBinaryAckRecorded(serviceId, versionId, operator);
     }
 
     /// @notice Fetch stored blueprint metadata

--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -448,10 +448,47 @@ abstract contract TangleStorage {
     mapping(uint64 => mapping(address => mapping(bytes32 => uint256))) internal _baselinePriceByOpAsset;
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT BINARY VERSIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Append-only per-blueprint binary registry plus per-service upgrade policy
+    // and operator acknowledgement tracking. Resolution of the effective version
+    // for a service is handled by `BlueprintsBinaryVersions.effectiveBinaryVersion`.
+
+    /// @notice Blueprint ID => append-only list of binary versions. `versionId` is
+    ///         the array index; entries are never removed so indices stay stable.
+    mapping(uint64 => Types.BinaryVersion[]) internal _blueprintBinaryVersions;
+
+    /// @notice Blueprint ID => currently active version ID for `AUTO` services.
+    /// @dev Sentinel `0` is also the genesis version's index, so any blueprint with
+    ///      at least one published version has a well-defined active index. Reads
+    ///      against a blueprint with zero versions revert `VersionNotFound`.
+    mapping(uint64 => uint64) internal _blueprintActiveVersionId;
+
+    /// @notice Service ID => upgrade policy controlling how the effective version
+    ///         is resolved. Default value `0` corresponds to `UpgradePolicy.APPROVE`.
+    mapping(uint64 => Types.UpgradePolicy) internal _serviceUpgradePolicy;
+
+    /// @notice Service ID => last version ID an operator of the service acknowledged.
+    /// @dev Read only under `UpgradePolicy.APPROVE`. Sentinel `0` collapses with the
+    ///      genesis version's index; the resolution path explicitly handles both
+    ///      "no ack" and "ack == 0" by returning the genesis row.
+    mapping(uint64 => uint64) internal _serviceAckedVersionId;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT BINARY ATTESTATIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Blueprint ID => version ID => append-only attestation list. Rows
+    ///         are never deleted; revocation flips the `revoked` flag so historical
+    ///         indexers can reconstruct the full provenance trail.
+    mapping(uint64 => mapping(uint64 => Types.Attestation[])) internal _blueprintVersionAttestations;
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // RESERVED STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades. Standard gap size is 50.
-    ///      Slots already consumed: 10 (see history above this gap).
-    uint256[39] private __gap;
+    ///      Slots already consumed: 10 (initial) + 5 (binary versions block above:
+    ///      4 mappings for versions/policy/ack + 1 mapping for attestations).
+    uint256[34] private __gap;
 }

--- a/src/core/BlueprintsBinaryAttestations.sol
+++ b/src/core/BlueprintsBinaryAttestations.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Base } from "./Base.sol";
+import { Types } from "../libraries/Types.sol";
+import { Errors } from "../libraries/Errors.sol";
+
+/// @title BlueprintsBinaryAttestations
+/// @notice Permissionless attestations against a specific blueprint binary version.
+/// @dev Anyone may attest to a `(blueprintId, versionId)`. Only the original
+///      attester may revoke their own row. Rows are append-only; revocation flips
+///      the `revoked` flag so off-chain indexers retain a stable id space and a
+///      complete provenance history.
+///
+///      Trust model is intentionally minimal at the protocol layer: aggregation
+///      and weighting is delegated to `BlueprintAuditors` (which curates an
+///      address → weight map) plus off-chain scoring. Reading attestations on
+///      their own is not a security claim; weighting via the auditor registry is.
+abstract contract BlueprintsBinaryAttestations is Base {
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event BinaryVersionAttested(
+        uint64 indexed blueprintId,
+        uint64 indexed versionId,
+        uint64 attestationId,
+        address indexed attester,
+        Types.AttestationKind kind,
+        uint8 severityFound,
+        string reportUri
+    );
+    event BinaryVersionAttestationRevoked(
+        uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri
+    );
+
+    /// @notice Maximum severity value accepted by `attestBinaryVersion`.
+    /// @dev Matches the ladder documented on `Types.Attestation.severityFound`:
+    ///      0=none, 1=info, 2=low, 3=med, 4=high, 5=critical.
+    uint8 internal constant MAX_ATTESTATION_SEVERITY = 5;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // MUTATIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Submit a new attestation against a binary version.
+    /// @dev Permissionless. `msg.sender` is recorded as the attester. The targeted
+    ///      version must exist; missing versions revert `VersionNotFound`.
+    /// @param blueprintId Blueprint whose version is being attested.
+    /// @param versionId Version index on the blueprint's version list.
+    /// @param reportHash Digest of the report off-chain (e.g. PDF SHA256). Zero is
+    ///        allowed because not every attestation kind produces a hashable
+    ///        artifact (e.g. a SELF declaration may carry only a URI).
+    /// @param reportUri Pointer to the report; must be non-empty so consumers
+    ///        always have somewhere to read the substantive claim.
+    /// @param kind Attestation kind (see `Types.AttestationKind`).
+    /// @param severityFound CVSS-style worst severity discovered, in [0, 5].
+    /// @param expiresAt Optional expiry timestamp; 0 means no expiry. Non-zero
+    ///        values must be strictly in the future at submit time to avoid
+    ///        admitting already-expired rows that would mislead consumers.
+    /// @return attestationId The newly assigned attestation index for this version.
+    function attestBinaryVersion(
+        uint64 blueprintId,
+        uint64 versionId,
+        bytes32 reportHash,
+        string calldata reportUri,
+        Types.AttestationKind kind,
+        uint8 severityFound,
+        uint64 expiresAt
+    )
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint64 attestationId)
+    {
+        if (versionId >= _blueprintBinaryVersions[blueprintId].length) revert Errors.VersionNotFound();
+        if (bytes(reportUri).length == 0) revert Errors.EmptyReportUri();
+        if (severityFound > MAX_ATTESTATION_SEVERITY) revert Errors.InvalidSeverity();
+        if (expiresAt != 0 && expiresAt <= uint64(block.timestamp)) revert Errors.ExpiresInPast();
+
+        Types.Attestation[] storage list = _blueprintVersionAttestations[blueprintId][versionId];
+        attestationId = uint64(list.length);
+        list.push(
+            Types.Attestation({
+                attester: msg.sender,
+                reportHash: reportHash,
+                reportUri: reportUri,
+                kind: kind,
+                severityFound: severityFound,
+                attestedAt: uint64(block.timestamp),
+                expiresAt: expiresAt,
+                revoked: false
+            })
+        );
+
+        emit BinaryVersionAttested(blueprintId, versionId, attestationId, msg.sender, kind, severityFound, reportUri);
+    }
+
+    /// @notice Revoke an attestation. One-way; flips `revoked = true`.
+    /// @dev Only the original attester may revoke. The row is preserved so
+    ///      historical indexers can show "attested then revoked" with the reason.
+    /// @param reasonUri Off-chain pointer describing why the attestation was
+    ///        withdrawn (e.g. "new evidence invalidates audit"). Emitted in the
+    ///        revocation event for transparency; not stored on-chain.
+    function revokeAttestation(
+        uint64 blueprintId,
+        uint64 versionId,
+        uint64 attestationId,
+        string calldata reasonUri
+    )
+        external
+        whenNotPaused
+        nonReentrant
+    {
+        Types.Attestation[] storage list = _blueprintVersionAttestations[blueprintId][versionId];
+        if (attestationId >= list.length) revert Errors.AttestationNotFound();
+
+        Types.Attestation storage row = list[attestationId];
+        if (row.attester != msg.sender) revert Errors.NotAttester();
+        if (row.revoked) revert Errors.AttestationAlreadyRevoked();
+
+        row.revoked = true;
+        emit BinaryVersionAttestationRevoked(blueprintId, versionId, attestationId, reasonUri);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // VIEWS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function getAttestation(
+        uint64 blueprintId,
+        uint64 versionId,
+        uint64 attestationId
+    )
+        external
+        view
+        returns (Types.Attestation memory)
+    {
+        Types.Attestation[] storage list = _blueprintVersionAttestations[blueprintId][versionId];
+        if (attestationId >= list.length) revert Errors.AttestationNotFound();
+        return list[attestationId];
+    }
+
+    function getAttestationCount(uint64 blueprintId, uint64 versionId) external view returns (uint64) {
+        return uint64(_blueprintVersionAttestations[blueprintId][versionId].length);
+    }
+
+    /// @notice Return the full attestation list for a binary version.
+    /// @dev O(n) memory copy. Lists are unbounded in principle; off-chain
+    ///      consumers that expect very large lists should paginate via
+    ///      `getAttestation` / `getAttestationCount`.
+    function listAttestations(uint64 blueprintId, uint64 versionId) external view returns (Types.Attestation[] memory) {
+        Types.Attestation[] storage stored = _blueprintVersionAttestations[blueprintId][versionId];
+        Types.Attestation[] memory copy = new Types.Attestation[](stored.length);
+        for (uint256 i = 0; i < stored.length; ++i) {
+            copy[i] = stored[i];
+        }
+        return copy;
+    }
+}

--- a/src/core/BlueprintsBinaryVersions.sol
+++ b/src/core/BlueprintsBinaryVersions.sol
@@ -142,7 +142,12 @@ abstract contract BlueprintsBinaryVersions is Base {
     ///      does not retroactively change which version a previously dispatched
     ///      job was scheduled against (off-chain dispatchers resolve at job time).
     function setServiceUpgradePolicy(uint64 serviceId, Types.UpgradePolicy policy) external whenNotPaused nonReentrant {
-        _getService(serviceId);
+        Types.Service storage svc = _getService(serviceId);
+        // Terminated services do not clear `_serviceOperators[id][op].active`,
+        // so an ex-operator could otherwise keep emitting policy events against a
+        // dead service. Gate on `status == Active` to keep state changes scoped
+        // to live services.
+        if (svc.status != Types.ServiceStatus.Active) revert Errors.ServiceNotActive(serviceId);
         if (!_serviceOperators[serviceId][msg.sender].active) revert Errors.NotServiceOperator();
 
         _serviceUpgradePolicy[serviceId] = policy;
@@ -158,6 +163,10 @@ abstract contract BlueprintsBinaryVersions is Base {
     ///      to pin back to genesis.
     function ackBinaryVersion(uint64 serviceId, uint64 versionId) external whenNotPaused nonReentrant {
         Types.Service storage svc = _getService(serviceId);
+        // Same termination-status gate as `setServiceUpgradePolicy`. Acks against
+        // a terminated service have no operational meaning and would only pollute
+        // indexers.
+        if (svc.status != Types.ServiceStatus.Active) revert Errors.ServiceNotActive(serviceId);
         if (!_serviceOperators[serviceId][msg.sender].active) revert Errors.NotServiceOperator();
 
         Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[svc.blueprintId];

--- a/src/core/BlueprintsBinaryVersions.sol
+++ b/src/core/BlueprintsBinaryVersions.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Base } from "./Base.sol";
+import { Types } from "../libraries/Types.sol";
+import { Errors } from "../libraries/Errors.sol";
+import { IBlueprintServiceManager } from "../interfaces/IBlueprintServiceManager.sol";
+import { IMasterBlueprintServiceManager } from "../interfaces/IMasterBlueprintServiceManager.sol";
+
+/// @title BlueprintsBinaryVersions
+/// @notice Append-only binary version registry per blueprint plus per-service
+///         upgrade policy and operator acknowledgement tracking.
+/// @dev Resolution policy summary (see `effectiveBinaryVersion`):
+///        AUTO    → version[activeVersionId]              (blueprint owner-driven rollout)
+///        APPROVE → version[ackedVersionId] when ack > 0,
+///                  otherwise version[0]                  (genesis until opt-in)
+///        MANUAL  → version[0]                            (pinned to genesis)
+///      A blueprint with zero published versions reverts `VersionNotFound` from
+///      `effectiveBinaryVersion`; the genesis row is the first publish.
+///
+///      Storage invariants enforced by this mixin:
+///        - `_blueprintBinaryVersions[bp]` is strictly append-only; `versionId`
+///          equals the array index. Deprecation flips a flag in-place; the row is
+///          never removed.
+///        - `_blueprintActiveVersionId[bp]` is only writable to existing indices
+///          and is left at zero (genesis) for new blueprints.
+///        - `_serviceAckedVersionId[svc]` can only advance to versions the operator
+///          has opted into; deprecated versions are explicitly rejected at ack time.
+abstract contract BlueprintsBinaryVersions is Base {
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event BinaryVersionPublished(
+        uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri
+    );
+    event BinaryVersionDeprecated(uint64 indexed blueprintId, uint64 indexed versionId);
+    event BinaryActiveVersionChanged(uint64 indexed blueprintId, uint64 indexed versionId);
+    event ServiceUpgradePolicySet(uint64 indexed serviceId, Types.UpgradePolicy policy);
+    event OperatorBinaryAcked(uint64 indexed serviceId, uint64 indexed versionId, address indexed operator);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT-OWNER ACTIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Publish a new binary version for a blueprint.
+    /// @dev Append-only. The caller MUST be the blueprint owner. The first publish
+    ///      defines the genesis version (versionId == 0); the active version is
+    ///      left at zero so existing services do not auto-roll until the owner
+    ///      explicitly bumps `setActiveBinaryVersion` or operators ack a newer one.
+    /// @param blueprintId Target blueprint.
+    /// @param sha256Hash Canonical binary integrity digest; must be non-zero.
+    /// @param binaryUri IPFS / HTTPS pointer to the binary artifact; must be non-empty.
+    /// @param attestationHash Optional sigstore / SLSA bundle digest. Zero is accepted
+    ///        and means "no bundle published with this version."
+    /// @return versionId The newly assigned version index.
+    function publishBinaryVersion(
+        uint64 blueprintId,
+        bytes32 sha256Hash,
+        string calldata binaryUri,
+        bytes32 attestationHash
+    )
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint64 versionId)
+    {
+        Types.Blueprint storage bp = _getBlueprint(blueprintId);
+        if (bp.owner != msg.sender) revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
+        if (sha256Hash == bytes32(0)) revert Errors.ZeroBinaryHash();
+        if (bytes(binaryUri).length == 0) revert Errors.EmptyBinaryUri();
+
+        Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[blueprintId];
+        versionId = uint64(versions.length);
+
+        versions.push(
+            Types.BinaryVersion({
+                versionId: versionId,
+                sha256Hash: sha256Hash,
+                binaryUri: binaryUri,
+                attestationHash: attestationHash,
+                publishedAt: uint64(block.timestamp),
+                deprecated: false
+            })
+        );
+
+        emit BinaryVersionPublished(blueprintId, versionId, sha256Hash, binaryUri);
+
+        // Best-effort fan-out:
+        //   1. Per-blueprint BSM hook via Tangle's standard `_tryCallManager`
+        //      path so the BSM's `onlyFromTangle` modifier still applies
+        //      (msg.sender on the BSM side is Tangle, not the MBSM).
+        //   2. MBSM notification for the authoritative indexer event. Trusted
+        //      protocol code; non-best-effort.
+        // The version row is already persisted, so a reverting BSM is observable
+        // via `ManagerHookFailed` (Base) but does not roll back the publish.
+        if (bp.manager != address(0)) {
+            _tryCallManager(
+                bp.manager,
+                abi.encodeCall(IBlueprintServiceManager.onBinaryVersionPublished, (blueprintId, versions[versionId]))
+            );
+        }
+        _notifyMasterOnVersionPublished(blueprintId, versions[versionId]);
+    }
+
+    /// @notice Set the active binary version for a blueprint.
+    /// @dev Only affects services using `UpgradePolicy.AUTO`. Reverts if the
+    ///      target version does not exist. Setting the active version to a
+    ///      `deprecated` row is allowed (the owner may revert to an older known-good
+    ///      build); enforcement of "no deprecated active" is a UI concern.
+    function setActiveBinaryVersion(uint64 blueprintId, uint64 versionId) external whenNotPaused nonReentrant {
+        Types.Blueprint storage bp = _getBlueprint(blueprintId);
+        if (bp.owner != msg.sender) revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
+        if (versionId >= _blueprintBinaryVersions[blueprintId].length) revert Errors.VersionNotFound();
+
+        _blueprintActiveVersionId[blueprintId] = versionId;
+        emit BinaryActiveVersionChanged(blueprintId, versionId);
+    }
+
+    /// @notice Flag a binary version as deprecated. One-way.
+    /// @dev Operators cannot ack a deprecated version; existing acks remain so the
+    ///      effective version of an opted-in service stays stable until the
+    ///      operator explicitly acks a newer one.
+    function deprecateBinaryVersion(uint64 blueprintId, uint64 versionId) external whenNotPaused nonReentrant {
+        Types.Blueprint storage bp = _getBlueprint(blueprintId);
+        if (bp.owner != msg.sender) revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
+
+        Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[blueprintId];
+        if (versionId >= versions.length) revert Errors.VersionNotFound();
+        if (versions[versionId].deprecated) revert Errors.VersionAlreadyDeprecated();
+
+        versions[versionId].deprecated = true;
+        emit BinaryVersionDeprecated(blueprintId, versionId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // SERVICE-OPERATOR ACTIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Set the upgrade policy for a service.
+    /// @dev The caller MUST be an active operator of the service. Changing policy
+    ///      does not retroactively change which version a previously dispatched
+    ///      job was scheduled against (off-chain dispatchers resolve at job time).
+    function setServiceUpgradePolicy(uint64 serviceId, Types.UpgradePolicy policy) external whenNotPaused nonReentrant {
+        _getService(serviceId);
+        if (!_serviceOperators[serviceId][msg.sender].active) revert Errors.NotServiceOperator();
+
+        _serviceUpgradePolicy[serviceId] = policy;
+        emit ServiceUpgradePolicySet(serviceId, policy);
+    }
+
+    /// @notice Acknowledge a binary version for a service under `APPROVE` policy.
+    /// @dev The caller MUST be an active operator of the service. The target
+    ///      version must exist on the service's blueprint and must not be
+    ///      `deprecated` (acking a deprecated version would pin the service to a
+    ///      version the blueprint owner has flagged as obsolete). The ack is
+    ///      monotonic in intent — `setServiceUpgradePolicy(MANUAL)` is the path
+    ///      to pin back to genesis.
+    function ackBinaryVersion(uint64 serviceId, uint64 versionId) external whenNotPaused nonReentrant {
+        Types.Service storage svc = _getService(serviceId);
+        if (!_serviceOperators[serviceId][msg.sender].active) revert Errors.NotServiceOperator();
+
+        Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[svc.blueprintId];
+        if (versionId >= versions.length) revert Errors.VersionNotFound();
+        if (versions[versionId].deprecated) revert Errors.VersionDeprecatedCannotAck();
+
+        _serviceAckedVersionId[serviceId] = versionId;
+        emit OperatorBinaryAcked(serviceId, versionId, msg.sender);
+
+        // Same revert-isolation rationale as `publishBinaryVersion`: the ack is
+        // already persisted and the BSM hook is informational. The BSM hook
+        // runs first (under `_tryCallManager`'s gas cap and `onlyFromTangle`
+        // identity), then the MBSM gets its indexer event.
+        address manager = _blueprints[svc.blueprintId].manager;
+        if (manager != address(0)) {
+            _tryCallManager(
+                manager,
+                abi.encodeCall(IBlueprintServiceManager.onOperatorBinaryAcked, (serviceId, versionId, msg.sender))
+            );
+        }
+        _notifyMasterOnOperatorAcked(serviceId, svc.blueprintId, versionId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // INTERNAL — MBSM INDEXER NOTIFICATION
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @dev Notify the blueprint's pinned MBSM of a binary version publish for
+    ///      indexer purposes. The MBSM emits the authoritative cross-blueprint
+    ///      event; the per-blueprint BSM hook is dispatched separately by the
+    ///      caller so it runs with `msg.sender == Tangle` and clears the BSM's
+    ///      `onlyFromTangle` identity check. Skipped silently when no registry
+    ///      is configured (tests that bypass the registry path) — the
+    ///      blueprint-scoped event already persisted carries the same data.
+    function _notifyMasterOnVersionPublished(uint64 blueprintId, Types.BinaryVersion storage version) private {
+        if (address(_mbsmRegistry) == address(0)) return;
+        address master = _mbsmRegistry.getMBSM(blueprintId);
+        if (master == address(0)) return;
+        IMasterBlueprintServiceManager(master).onBinaryVersionPublished(blueprintId, version);
+    }
+
+    /// @dev MBSM indexer notification for an operator ack. See
+    ///      `_notifyMasterOnVersionPublished` for the rationale.
+    function _notifyMasterOnOperatorAcked(uint64 serviceId, uint64 blueprintId, uint64 versionId) private {
+        if (address(_mbsmRegistry) == address(0)) return;
+        address master = _mbsmRegistry.getMBSM(blueprintId);
+        if (master == address(0)) return;
+        IMasterBlueprintServiceManager(master).onOperatorBinaryAcked(serviceId, versionId, msg.sender);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // VIEWS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function getBinaryVersion(uint64 blueprintId, uint64 versionId) external view returns (Types.BinaryVersion memory) {
+        Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[blueprintId];
+        if (versionId >= versions.length) revert Errors.VersionNotFound();
+        return versions[versionId];
+    }
+
+    function getBinaryVersionCount(uint64 blueprintId) external view returns (uint64) {
+        return uint64(_blueprintBinaryVersions[blueprintId].length);
+    }
+
+    function getActiveBinaryVersionId(uint64 blueprintId) external view returns (uint64) {
+        return _blueprintActiveVersionId[blueprintId];
+    }
+
+    function getServiceUpgradePolicy(uint64 serviceId) external view returns (Types.UpgradePolicy) {
+        return _serviceUpgradePolicy[serviceId];
+    }
+
+    function getServiceAckedVersionId(uint64 serviceId) external view returns (uint64) {
+        return _serviceAckedVersionId[serviceId];
+    }
+
+    /// @notice Resolve the binary version a service should currently be running.
+    /// @dev Pure function of stored state — does not call into any external contract.
+    ///      Reverts `VersionNotFound` if the blueprint has zero published versions
+    ///      (a service can exist before any binary is published; off-chain
+    ///      dispatchers should treat that as "not yet provisioned").
+    function effectiveBinaryVersion(uint64 serviceId) external view returns (Types.BinaryVersion memory) {
+        Types.Service storage svc = _getService(serviceId);
+        Types.BinaryVersion[] storage versions = _blueprintBinaryVersions[svc.blueprintId];
+        if (versions.length == 0) revert Errors.VersionNotFound();
+
+        Types.UpgradePolicy policy = _serviceUpgradePolicy[serviceId];
+        if (policy == Types.UpgradePolicy.AUTO) {
+            uint64 active = _blueprintActiveVersionId[svc.blueprintId];
+            // `active` is constrained to existing indices by `setActiveBinaryVersion`;
+            // the default 0 always points to genesis when versions.length > 0.
+            return versions[active];
+        }
+        if (policy == Types.UpgradePolicy.APPROVE) {
+            uint64 acked = _serviceAckedVersionId[serviceId];
+            // Both "no ack" and "ack == 0" collapse to genesis. Acked indices
+            // beyond the array length are unreachable: ack writes are bounded.
+            return versions[acked];
+        }
+        // MANUAL: pinned to genesis until the operator switches policy.
+        return versions[0];
+    }
+}

--- a/src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol
+++ b/src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol
@@ -7,12 +7,17 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 /// @title TangleBlueprintsBinaryAttestationsFacet
 /// @notice Facet exposing permissionless attestations against blueprint binary versions.
 contract TangleBlueprintsBinaryAttestationsFacet is BlueprintsBinaryAttestations, IFacetSelectors {
+    /// @dev `listAttestations` is intentionally NOT exposed via Tangle's selector
+    ///      router. It returns an unbounded array, which is fine for off-chain
+    ///      `eth_call` enumeration but a footgun for any on-chain consumer that
+    ///      tried to invoke it through the Tangle proxy (spammed attestations
+    ///      would brick the consumer with OOG). On-chain reads should iterate
+    ///      via `getAttestationCount` + `getAttestation(id)` instead.
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](5);
+        selectorList = new bytes4[](4);
         selectorList[0] = this.attestBinaryVersion.selector;
         selectorList[1] = this.revokeAttestation.selector;
         selectorList[2] = this.getAttestation.selector;
         selectorList[3] = this.getAttestationCount.selector;
-        selectorList[4] = this.listAttestations.selector;
     }
 }

--- a/src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol
+++ b/src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BlueprintsBinaryAttestations } from "../../core/BlueprintsBinaryAttestations.sol";
+import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
+
+/// @title TangleBlueprintsBinaryAttestationsFacet
+/// @notice Facet exposing permissionless attestations against blueprint binary versions.
+contract TangleBlueprintsBinaryAttestationsFacet is BlueprintsBinaryAttestations, IFacetSelectors {
+    function selectors() external pure returns (bytes4[] memory selectorList) {
+        selectorList = new bytes4[](5);
+        selectorList[0] = this.attestBinaryVersion.selector;
+        selectorList[1] = this.revokeAttestation.selector;
+        selectorList[2] = this.getAttestation.selector;
+        selectorList[3] = this.getAttestationCount.selector;
+        selectorList[4] = this.listAttestations.selector;
+    }
+}

--- a/src/facets/tangle/TangleBlueprintsBinaryVersionsFacet.sol
+++ b/src/facets/tangle/TangleBlueprintsBinaryVersionsFacet.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BlueprintsBinaryVersions } from "../../core/BlueprintsBinaryVersions.sol";
+import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
+
+/// @title TangleBlueprintsBinaryVersionsFacet
+/// @notice Facet exposing the per-blueprint binary version registry and the
+///         per-service upgrade policy / operator-ack surface.
+contract TangleBlueprintsBinaryVersionsFacet is BlueprintsBinaryVersions, IFacetSelectors {
+    function selectors() external pure returns (bytes4[] memory selectorList) {
+        selectorList = new bytes4[](11);
+        selectorList[0] = this.publishBinaryVersion.selector;
+        selectorList[1] = this.setActiveBinaryVersion.selector;
+        selectorList[2] = this.deprecateBinaryVersion.selector;
+        selectorList[3] = this.setServiceUpgradePolicy.selector;
+        selectorList[4] = this.ackBinaryVersion.selector;
+        selectorList[5] = this.getBinaryVersion.selector;
+        selectorList[6] = this.getBinaryVersionCount.selector;
+        selectorList[7] = this.getActiveBinaryVersionId.selector;
+        selectorList[8] = this.getServiceUpgradePolicy.selector;
+        selectorList[9] = this.getServiceAckedVersionId.selector;
+        selectorList[10] = this.effectiveBinaryVersion.selector;
+    }
+}

--- a/src/governance/BlueprintAuditors.sol
+++ b/src/governance/BlueprintAuditors.sol
@@ -161,12 +161,16 @@ contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgra
     ///      attestation lookups. To "re-admit" an address, call
     ///      `setAuditorActive(true)` + `setAuditorWeight(newWeight)` rather than
     ///      `admitAuditor` (which is permanently blocked once a row exists).
+    ///      Emits both `AuditorWeightSet` and `AuditorActiveSet` so any consumer
+    ///      subscribed to a single event stream sees a complete state transition.
     function removeAuditor(address auditor) external onlyRole(GOVERNANCE_ROLE) {
         Auditor storage row = auditors[auditor];
         if (row.admittedAt == 0) revert Errors.AuditorNotFound();
+        uint16 oldWeight = row.weight;
         row.active = false;
-        emit AuditorWeightSet(auditor, row.weight, 0);
         row.weight = 0;
+        emit AuditorWeightSet(auditor, oldWeight, 0);
+        emit AuditorActiveSet(auditor, false);
         emit AuditorRemoved(auditor);
     }
 
@@ -179,10 +183,14 @@ contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgra
     }
 
     /// @notice Update an auditor's weight. Governance-only.
+    /// @dev Requires the auditor to be `active` so the invariant "removed ⇒
+    ///      weight 0" cannot be silently violated. To set a weight on a previously
+    ///      removed auditor, call `setAuditorActive(true)` first.
     function setAuditorWeight(address auditor, uint16 weight) external onlyRole(GOVERNANCE_ROLE) {
         if (weight > MAX_AUDITOR_WEIGHT) revert Errors.InvalidWeight();
         Auditor storage row = auditors[auditor];
         if (row.admittedAt == 0) revert Errors.AuditorNotFound();
+        if (!row.active) revert Errors.AuditorNotActive();
         uint16 oldWeight = row.weight;
         row.weight = weight;
         emit AuditorWeightSet(auditor, oldWeight, weight);
@@ -225,14 +233,18 @@ contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgra
     // SELF-SERVICE PATH
     // ═══════════════════════════════════════════════════════════════════════════
 
-    /// @notice Auditor updates their own metadata URI. Self-only.
-    /// @dev Restricted to existing auditors so a non-admitted address cannot
-    ///      pollute the storage map. Updating the on-chain name is intentionally
-    ///      not exposed — the human-readable label is governance-curated to
-    ///      defeat squatting.
+    /// @notice Auditor updates their own metadata URI. Self-only, active-only.
+    /// @dev Restricted to currently-active auditors so a soft-removed address
+    ///      cannot mutate its historical record post-removal (which would let an
+    ///      ex-auditor flip their metadataUri to a phishing target while the
+    ///      registry still resolves attestations from this address through the
+    ///      preserved row). Updating the on-chain name is intentionally not
+    ///      exposed — the human-readable label is governance-curated to defeat
+    ///      squatting.
     function updateAuditorMetadata(string calldata metadataUri) external {
         Auditor storage row = auditors[msg.sender];
         if (row.admittedAt == 0) revert Errors.NotAuditorSelf();
+        if (!row.active) revert Errors.AuditorNotActive();
         row.metadataUri = metadataUri;
         emit AuditorMetadataUpdated(msg.sender, metadataUri);
     }
@@ -258,6 +270,7 @@ contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgra
     }
 
     function auditorAt(uint256 index) external view returns (address) {
+        if (index >= _auditorList.length) revert Errors.IndexOutOfBounds();
         return _auditorList[index];
     }
 
@@ -267,4 +280,16 @@ contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgra
 
     /// @dev Upgrades must clear the governance bar; no other role authorizes them.
     function _authorizeUpgrade(address) internal override onlyRole(GOVERNANCE_ROLE) { }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // RESERVED STORAGE GAP
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @dev Storage gap for future upgrades. Slots consumed: `auditors` mapping
+    ///      (slot N) + `_auditorList` array (slot N+1) = 2 slots after the
+    ///      AccessControl/UUPS namespaced parents (which use ERC-7201 and do not
+    ///      consume sequential slots). Gap of 48 leaves room for future fields
+    ///      without bumping the storage layout in a way that would conflict with
+    ///      already-deployed proxies.
+    uint256[48] private __gap;
 }

--- a/src/governance/BlueprintAuditors.sol
+++ b/src/governance/BlueprintAuditors.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+import { Errors } from "../libraries/Errors.sol";
+
+/// @title BlueprintAuditors
+/// @notice Governance-curated registry of auditor identities and weights used by
+///         off-chain aggregators when scoring binary-version attestations.
+/// @dev Deliberately a standalone UUPS contract — NOT a Tangle facet — so that
+///      governance owns the address list independently of protocol upgrades.
+///      The protocol-side `BlueprintsBinaryAttestations` registry is permissionless;
+///      this contract supplies the trusted weight map that aggregators apply on
+///      top of those raw attestations.
+///
+///      Two admit paths exist:
+///        - `admitAuditor` is gated by `GOVERNANCE_ROLE` (held by TangleTimelock)
+///          and accepts any tier.
+///        - `admitFirstPartyAuditor` is gated by `FIRST_PARTY_ADMIN_ROLE` (held
+///          by a security council multisig) and is restricted to FIRST_PARTY
+///          tier. It exists so the security council can fast-track first-party
+///          team members without waiting on a governance vote.
+///
+///      Removal is a soft delete: `active=false` plus weight zeroed. The row
+///      itself is preserved so historical references on-chain (e.g. attester
+///      address inside an `Attestation` row) keep resolving to a real registry
+///      entry, with `active=false` signalling that aggregators should ignore
+///      new attestations from this address.
+contract BlueprintAuditors is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
+    // ═══════════════════════════════════════════════════════════════════════════
+    // ROLES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Role held by TangleTimelock. Authoritative path for admit/remove/weight
+    ///         changes across all tiers and is the sole authorizer of contract upgrades.
+    bytes32 public constant GOVERNANCE_ROLE = keccak256("GOVERNANCE_ROLE");
+
+    /// @notice Role held by the security council multisig. Permits fast-tracked
+    ///         admission of `FIRST_PARTY` auditors only; cannot mutate INDEPENDENT
+    ///         or COMMUNITY entries and cannot authorize upgrades.
+    bytes32 public constant FIRST_PARTY_ADMIN_ROLE = keccak256("FIRST_PARTY_ADMIN_ROLE");
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // TYPES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Tier classification for auditors. Append-only — values must never
+    ///         be reordered to preserve storage compatibility.
+    ///         FIRST_PARTY=0 (Tangle-team / vendor auditors with privileged trust),
+    ///         INDEPENDENT=1 (recognized external firms, governance-admitted),
+    ///         COMMUNITY=2 (open-source contributors with reputational standing).
+    enum AuditorTier {
+        FIRST_PARTY,
+        INDEPENDENT,
+        COMMUNITY
+    }
+
+    /// @notice On-chain auditor record. `admittedAt` is preserved across an
+    ///         `active=false` removal so the registry's history is auditable.
+    struct Auditor {
+        string name;
+        string metadataUri;
+        uint16 weight; // 0..1000, see `MAX_AUDITOR_WEIGHT`
+        AuditorTier tier;
+        bool active;
+        uint64 admittedAt;
+    }
+
+    /// @notice Hard ceiling on per-auditor weight. The 1000 cap (vs. 10000 bps)
+    ///         is intentional: aggregators normalize by the sum of active weights
+    ///         off-chain, so any single auditor's influence is capped at
+    ///         `weight / sum(weights)`. The cap removes the foot-gun of
+    ///         accidentally admitting a weight that swamps every other voice.
+    uint16 public constant MAX_AUDITOR_WEIGHT = 1000;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // STORAGE
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Address => auditor record. Soft-deleted entries remain queryable.
+    mapping(address => Auditor) public auditors;
+
+    /// @dev Enumeration list. Append-only — entries removed via `removeAuditor`
+    ///      stay here so historical indexers see a stable identifier space. Off-
+    ///      chain aggregators filter with `isActiveAuditor`.
+    address[] private _auditorList;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event AuditorAdmitted(address indexed auditor, string name, string metadataUri, uint16 weight, AuditorTier tier);
+    event AuditorRemoved(address indexed auditor);
+    event AuditorActiveSet(address indexed auditor, bool active);
+    event AuditorWeightSet(address indexed auditor, uint16 oldWeight, uint16 newWeight);
+    event AuditorMetadataUpdated(address indexed auditor, string metadataUri);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // INITIALIZATION
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize the registry.
+    /// @param admin Initial DEFAULT_ADMIN_ROLE; must be renounced/handed-off after
+    ///        cross-grants are set. Typically the deployer EOA pre-handoff.
+    /// @param governor Address that will hold GOVERNANCE_ROLE; typically TangleTimelock.
+    /// @param firstPartyAdmin Address that will hold FIRST_PARTY_ADMIN_ROLE;
+    ///        typically a security-council multisig. May equal `admin` initially
+    ///        if no separate multisig is yet provisioned.
+    function initialize(address admin, address governor, address firstPartyAdmin) external initializer {
+        if (admin == address(0) || governor == address(0) || firstPartyAdmin == address(0)) {
+            revert Errors.ZeroAddress();
+        }
+
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(GOVERNANCE_ROLE, governor);
+        _grantRole(FIRST_PARTY_ADMIN_ROLE, firstPartyAdmin);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // GOVERNANCE PATH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Admit a new auditor at any tier. Governance-only.
+    /// @dev Reverts if the address was previously admitted (even if currently
+    ///      inactive) — re-admission must go through `setAuditorActive` to keep
+    ///      the original `admittedAt` immutable. `weight` is bounded by
+    ///      `MAX_AUDITOR_WEIGHT`; `data.active` and `data.admittedAt` are
+    ///      authoritatively set by this contract (caller-supplied values for
+    ///      those fields are ignored).
+    function admitAuditor(address auditor, Auditor calldata data) external onlyRole(GOVERNANCE_ROLE) {
+        if (auditor == address(0)) revert Errors.ZeroAddress();
+        if (auditors[auditor].admittedAt != 0) revert Errors.AuditorAlreadyAdmitted();
+        if (bytes(data.name).length == 0) revert Errors.EmptyAuditorName();
+        if (data.weight > MAX_AUDITOR_WEIGHT) revert Errors.InvalidWeight();
+
+        auditors[auditor] = Auditor({
+            name: data.name,
+            metadataUri: data.metadataUri,
+            weight: data.weight,
+            tier: data.tier,
+            active: true,
+            admittedAt: uint64(block.timestamp)
+        });
+        _auditorList.push(auditor);
+        emit AuditorAdmitted(auditor, data.name, data.metadataUri, data.weight, data.tier);
+    }
+
+    /// @notice Soft-remove an auditor. Governance-only.
+    /// @dev `active=false`, weight zeroed. The row is preserved for historical
+    ///      attestation lookups. To "re-admit" an address, call
+    ///      `setAuditorActive(true)` + `setAuditorWeight(newWeight)` rather than
+    ///      `admitAuditor` (which is permanently blocked once a row exists).
+    function removeAuditor(address auditor) external onlyRole(GOVERNANCE_ROLE) {
+        Auditor storage row = auditors[auditor];
+        if (row.admittedAt == 0) revert Errors.AuditorNotFound();
+        row.active = false;
+        emit AuditorWeightSet(auditor, row.weight, 0);
+        row.weight = 0;
+        emit AuditorRemoved(auditor);
+    }
+
+    /// @notice Toggle an auditor's active flag. Governance-only.
+    function setAuditorActive(address auditor, bool active) external onlyRole(GOVERNANCE_ROLE) {
+        Auditor storage row = auditors[auditor];
+        if (row.admittedAt == 0) revert Errors.AuditorNotFound();
+        row.active = active;
+        emit AuditorActiveSet(auditor, active);
+    }
+
+    /// @notice Update an auditor's weight. Governance-only.
+    function setAuditorWeight(address auditor, uint16 weight) external onlyRole(GOVERNANCE_ROLE) {
+        if (weight > MAX_AUDITOR_WEIGHT) revert Errors.InvalidWeight();
+        Auditor storage row = auditors[auditor];
+        if (row.admittedAt == 0) revert Errors.AuditorNotFound();
+        uint16 oldWeight = row.weight;
+        row.weight = weight;
+        emit AuditorWeightSet(auditor, oldWeight, weight);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // FIRST-PARTY FAST-TRACK PATH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Fast-track admission for FIRST_PARTY auditors only.
+    /// @dev Held by the security council multisig to onboard internal staff
+    ///      without governance latency. Restricted to the FIRST_PARTY tier;
+    ///      external firms and community auditors must still go through governance.
+    function admitFirstPartyAuditor(
+        address auditor,
+        string calldata name,
+        uint16 weight
+    )
+        external
+        onlyRole(FIRST_PARTY_ADMIN_ROLE)
+    {
+        if (auditor == address(0)) revert Errors.ZeroAddress();
+        if (auditors[auditor].admittedAt != 0) revert Errors.AuditorAlreadyAdmitted();
+        if (bytes(name).length == 0) revert Errors.EmptyAuditorName();
+        if (weight > MAX_AUDITOR_WEIGHT) revert Errors.InvalidWeight();
+
+        auditors[auditor] = Auditor({
+            name: name,
+            metadataUri: "",
+            weight: weight,
+            tier: AuditorTier.FIRST_PARTY,
+            active: true,
+            admittedAt: uint64(block.timestamp)
+        });
+        _auditorList.push(auditor);
+        emit AuditorAdmitted(auditor, name, "", weight, AuditorTier.FIRST_PARTY);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // SELF-SERVICE PATH
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Auditor updates their own metadata URI. Self-only.
+    /// @dev Restricted to existing auditors so a non-admitted address cannot
+    ///      pollute the storage map. Updating the on-chain name is intentionally
+    ///      not exposed — the human-readable label is governance-curated to
+    ///      defeat squatting.
+    function updateAuditorMetadata(string calldata metadataUri) external {
+        Auditor storage row = auditors[msg.sender];
+        if (row.admittedAt == 0) revert Errors.NotAuditorSelf();
+        row.metadataUri = metadataUri;
+        emit AuditorMetadataUpdated(msg.sender, metadataUri);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // VIEWS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function getAuditor(address auditor) external view returns (Auditor memory) {
+        return auditors[auditor];
+    }
+
+    function isActiveAuditor(address auditor) external view returns (bool) {
+        return auditors[auditor].active;
+    }
+
+    function auditorWeight(address auditor) external view returns (uint16) {
+        return auditors[auditor].weight;
+    }
+
+    function auditorCount() external view returns (uint256) {
+        return _auditorList.length;
+    }
+
+    function auditorAt(uint256 index) external view returns (address) {
+        return _auditorList[index];
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // UPGRADE AUTHORIZATION
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @dev Upgrades must clear the governance bar; no other role authorizes them.
+    function _authorizeUpgrade(address) internal override onlyRole(GOVERNANCE_ROLE) { }
+}

--- a/src/interfaces/IBlueprintServiceManager.sol
+++ b/src/interfaces/IBlueprintServiceManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
+import { Types } from "../libraries/Types.sol";
+
 /// @title IBlueprintServiceManager
 /// @notice Full interface for blueprint-specific service managers
 /// @dev Blueprint developers implement this to customize all aspects of their blueprint.
@@ -375,4 +377,20 @@ interface IBlueprintServiceManager {
     /// @return useDefault True to use protocol default from staking module
     /// @return minStake Custom minimum stake amount (only used if useDefault=false)
     function getMinOperatorStake() external view returns (bool useDefault, uint256 minStake);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BINARY VERSION LIFECYCLE
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Called when a new binary version is published for this blueprint
+    /// @dev Custom BSMs MAY revert to gate the publish (e.g. require a publisher-multisig sig).
+    ///      Tangle forwards this call best-effort via `_tryCallManager`, so a revert is
+    ///      observed off-chain via `ManagerHookFailed` but does NOT undo the on-chain
+    ///      version row — the registry is append-only by design.
+    function onBinaryVersionPublished(uint64 blueprintId, Types.BinaryVersion calldata version) external;
+
+    /// @notice Called when an operator acknowledges a binary version for a service
+    /// @dev Default no-op; custom BSMs MAY react (e.g. emit reputation events, gate
+    ///      future job dispatch on the ack). Forwarded best-effort.
+    function onOperatorBinaryAcked(uint64 serviceId, uint64 versionId, address operator) external;
 }

--- a/src/interfaces/IMasterBlueprintServiceManager.sol
+++ b/src/interfaces/IMasterBlueprintServiceManager.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
+import { Types } from "../libraries/Types.sol";
+
 /// @title IMasterBlueprintServiceManager
 /// @notice Interface for the protocol-wide master blueprint service manager
 interface IMasterBlueprintServiceManager {
@@ -9,4 +11,23 @@ interface IMasterBlueprintServiceManager {
     /// @param owner The blueprint owner
     /// @param encodedDefinition ABI-encoded blueprint definition data
     function onBlueprintCreated(uint64 blueprintId, address owner, bytes calldata encodedDefinition) external;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BINARY VERSION LIFECYCLE
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Indexer notification for a new binary version publish.
+    /// @dev The per-blueprint BSM hook is dispatched separately by Tangle so it
+    ///      runs under Tangle's identity (`onlyFromTangle`). The master manager
+    ///      only records the publish for cross-blueprint analytics / off-chain
+    ///      consumers.
+    /// @param blueprintId Blueprint receiving the new version.
+    /// @param version Full binary version record.
+    function onBinaryVersionPublished(uint64 blueprintId, Types.BinaryVersion calldata version) external;
+
+    /// @notice Indexer notification for an operator binary acknowledgement.
+    /// @param serviceId Service whose operator acked the version.
+    /// @param versionId Version index that was acked.
+    /// @param operator Operator that submitted the ack.
+    function onOperatorBinaryAcked(uint64 serviceId, uint64 versionId, address operator) external;
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -599,4 +599,12 @@ library Errors {
 
     /// @notice Self-update path requires the caller to be an admitted auditor.
     error NotAuditorSelf();
+
+    /// @notice Mutation requires the auditor row to be `active`; soft-removed
+    ///         auditors cannot have weight or metadata mutated until governance
+    ///         re-activates them via `setAuditorActive(true)`.
+    error AuditorNotActive();
+
+    /// @notice Enumeration index past the end of the auditor list.
+    error IndexOutOfBounds();
 }

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -528,4 +528,75 @@ library Errors {
 
     /// @notice Generic transfer failure (used by `claimDisputeBond`).
     error TransferFailed();
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT BINARY VERSIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Note: owner-check reverts reuse the existing `NotBlueprintOwner(uint64, address)`
+    // declared above for consistency with other blueprint-owner-gated paths.
+
+    /// @notice Binary URI must be non-empty.
+    error EmptyBinaryUri();
+
+    /// @notice Binary hash must be a real digest, not the zero sentinel.
+    error ZeroBinaryHash();
+
+    /// @notice Referenced binary version does not exist for the blueprint.
+    error VersionNotFound();
+
+    /// @notice Cannot deprecate a binary version that has already been deprecated;
+    ///         deprecation is a one-way signal.
+    error VersionAlreadyDeprecated();
+
+    /// @notice Caller is not an active operator of the targeted service.
+    error NotServiceOperator();
+
+    /// @notice An operator cannot acknowledge a deprecated binary version. Deprecation
+    ///         is a final signal — the blueprint owner has indicated the version is
+    ///         no longer recommended and `ack` would otherwise pin the service to it.
+    error VersionDeprecatedCannotAck();
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT BINARY ATTESTATIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Referenced attestation does not exist.
+    error AttestationNotFound();
+
+    /// @notice Caller is not the original attester and therefore cannot revoke.
+    error NotAttester();
+
+    /// @notice Attestation has already been revoked; revoke is one-way.
+    error AttestationAlreadyRevoked();
+
+    /// @notice Attestation report URI must be non-empty.
+    error EmptyReportUri();
+
+    /// @notice Severity value must be in [0,5]. See `Types.Attestation.severityFound`.
+    error InvalidSeverity();
+
+    /// @notice Attestation expiry must be either zero ("never expires") or strictly
+    ///         in the future at submission time. Rejecting past-dated expiries
+    ///         removes the ambiguity of an "already-expired" attestation row.
+    error ExpiresInPast();
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT AUDITORS REGISTRY
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Auditor address is already admitted to the registry.
+    error AuditorAlreadyAdmitted();
+
+    /// @notice Auditor address has never been admitted.
+    error AuditorNotFound();
+
+    /// @notice Auditor weight must be in [0, 1000]. The registry caps weights so a
+    ///         single auditor cannot dominate off-chain aggregate score formulas.
+    error InvalidWeight();
+
+    /// @notice Auditor display name must be non-empty.
+    error EmptyAuditorName();
+
+    /// @notice Self-update path requires the caller to be an admitted auditor.
+    error NotAuditorSelf();
 }

--- a/src/libraries/Types.sol
+++ b/src/libraries/Types.sol
@@ -769,4 +769,77 @@ library Types {
         Executable, // Queue duration passed, can execute
         Completed // Exit completed (operator left)
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BLUEPRINT BINARY VERSIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Append-only binary version record for a blueprint.
+    /// @dev Versions are assigned monotonically by `publishBinaryVersion` and never
+    ///      removed. `deprecated` is a one-way signal: once set the version is
+    ///      flagged for off-chain consumers but its slot is preserved so `versionId`
+    ///      indices remain stable. The `sha256Hash` field is named explicitly to
+    ///      avoid colliding with the global `sha256` precompile alias and is the
+    ///      canonical integrity anchor for the binary referenced by `binaryUri`.
+    ///      `attestationHash` is an optional pointer to a SLSA / sigstore bundle
+    ///      digest; zero means "no attestation bundle published with this version."
+    struct BinaryVersion {
+        uint64 versionId; // monotonic, append-only per blueprint
+        bytes32 sha256Hash; // canonical binary hash
+        string binaryUri; // ipfs://... or https://...
+        bytes32 attestationHash; // optional sigstore / SLSA bundle hash; zero if unset
+        uint64 publishedAt; // block.timestamp at publish
+        bool deprecated; // append-only signal, never rolled back
+    }
+
+    /// @notice Upgrade policy selected per-service for resolving the effective binary.
+    /// @dev IMPORTANT: Enum values must only be APPENDED, never reordered or inserted.
+    ///      APPROVE=0 (default): operator must `ackBinaryVersion` to opt in to a new
+    ///      version; until then the service runs the genesis version (versionId 0).
+    ///      AUTO=1: service tracks the blueprint's currently active version, opting
+    ///      operators in automatically.
+    ///      MANUAL=2: service is pinned to the genesis version (versionId 0) until
+    ///      the operator switches policy. Use for production services that must not
+    ///      follow blueprint-owner version changes.
+    enum UpgradePolicy {
+        APPROVE,
+        AUTO,
+        MANUAL
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BINARY ATTESTATIONS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Kind of attestation produced for a binary version.
+    /// @dev IMPORTANT: Enum values must only be APPENDED, never reordered or inserted.
+    ///      AUDIT=0 (human review), FUZZ=1 (continuous fuzzing campaign), FORMAL=2
+    ///      (machine-checked formal verification), BUG_BOUNTY=3 (issued by a bounty
+    ///      program operator), SELF=4 (developer self-attestation, weakest signal).
+    enum AttestationKind {
+        AUDIT,
+        FUZZ,
+        FORMAL,
+        BUG_BOUNTY,
+        SELF
+    }
+
+    /// @notice Permissionless attestation against a specific binary version.
+    /// @dev `severityFound` follows the CVSS-style ladder used elsewhere in Tangle:
+    ///      0=none, 1=info, 2=low, 3=med, 4=high, 5=critical. Validated at submit
+    ///      time so off-chain consumers do not need to filter out-of-range values.
+    ///      `expiresAt == 0` means the attestation never auto-expires; finite values
+    ///      must be in the future at submission time. `revoked` is set by the
+    ///      original attester only; the row is never deleted so off-chain history is
+    ///      stable and `attestationId` indices remain valid.
+    struct Attestation {
+        address attester;
+        bytes32 reportHash;
+        string reportUri;
+        AttestationKind kind;
+        uint8 severityFound;
+        uint64 attestedAt;
+        uint64 expiresAt;
+        bool revoked;
+    }
 }

--- a/test/core/BlueprintsBinaryAttestations.t.sol
+++ b/test/core/BlueprintsBinaryAttestations.t.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { UpgradeFlowHarness } from "../support/UpgradeFlowHarness.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+import { BlueprintsBinaryAttestations } from "../../src/core/BlueprintsBinaryAttestations.sol";
+
+/// @title BlueprintsBinaryAttestationsTest
+/// @notice Coverage for the permissionless attestation registry. High-risk paths
+///         covered: input validation (severity, expiry, empty URI), revoke-only-
+///         by-attester, and append-only history (revoked rows stay readable).
+contract BlueprintsBinaryAttestationsTest is UpgradeFlowHarness {
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENTS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event BinaryVersionAttested(
+        uint64 indexed blueprintId,
+        uint64 indexed versionId,
+        uint64 attestationId,
+        address indexed attester,
+        Types.AttestationKind kind,
+        uint8 severityFound,
+        string reportUri
+    );
+    event BinaryVersionAttestationRevoked(
+        uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // FIXTURES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    bytes32 internal constant HASH_V0 = bytes32(uint256(0x11));
+    bytes32 internal constant REPORT_HASH = bytes32(uint256(0xBB));
+
+    uint64 internal blueprintId;
+
+    function setUp() public virtual override {
+        super.setUp();
+        blueprintId = _createBlueprint(developer);
+        vm.prank(developer);
+        versions.publishBinaryVersion(blueprintId, HASH_V0, "ipfs://v0", bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // attestBinaryVersion - gating
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_attest_revertWhen_versionMissing() public {
+        vm.prank(user1);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        attestations.attestBinaryVersion(blueprintId, 5, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0);
+    }
+
+    function test_attest_revertWhen_blueprintMissing() public {
+        vm.prank(user1);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        attestations.attestBinaryVersion(99, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0);
+    }
+
+    function test_attest_revertWhen_emptyReportUri() public {
+        vm.prank(user1);
+        vm.expectRevert(Errors.EmptyReportUri.selector);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "", Types.AttestationKind.AUDIT, 3, 0);
+    }
+
+    function test_attest_revertWhen_severityTooHigh() public {
+        vm.prank(user1);
+        vm.expectRevert(Errors.InvalidSeverity.selector);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 6, 0);
+    }
+
+    function test_attest_severityFiveAccepted() public {
+        // Boundary check - 5 (critical) must be accepted, 6 must not.
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 5, 0);
+        assertEq(attestations.getAttestationCount(blueprintId, 0), 1);
+    }
+
+    function test_attest_severityZeroAccepted() public {
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.SELF, 0, 0);
+        assertEq(attestations.getAttestation(blueprintId, 0, 0).severityFound, 0);
+    }
+
+    function test_attest_revertWhen_expiresInPast() public {
+        vm.warp(2_000_000);
+        vm.prank(user1);
+        vm.expectRevert(Errors.ExpiresInPast.selector);
+        attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, uint64(block.timestamp - 1)
+        );
+    }
+
+    function test_attest_revertWhen_expiresEqualsNow() public {
+        // The check is `<= block.timestamp` so an expiry equal to now must revert.
+        vm.warp(2_000_000);
+        vm.prank(user1);
+        vm.expectRevert(Errors.ExpiresInPast.selector);
+        attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, uint64(block.timestamp)
+        );
+    }
+
+    function test_attest_expiresZeroIsTreatedAsNoExpiry() public {
+        vm.warp(2_000_000);
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0);
+        assertEq(attestations.getAttestation(blueprintId, 0, 0).expiresAt, 0);
+    }
+
+    function test_attest_futureExpiryAccepted() public {
+        vm.warp(2_000_000);
+        vm.prank(user1);
+        attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, uint64(block.timestamp + 30 days)
+        );
+        assertEq(attestations.getAttestation(blueprintId, 0, 0).expiresAt, uint64(block.timestamp + 30 days));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // attestBinaryVersion - happy path
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_attest_happyPath_storesAllFieldsAndEmits() public {
+        vm.warp(2_000_000);
+        uint64 expiry = uint64(block.timestamp + 7 days);
+
+        vm.prank(user1);
+        vm.expectEmit(true, true, true, true, address(tangleProxy));
+        emit BinaryVersionAttested(blueprintId, 0, 0, user1, Types.AttestationKind.FORMAL, 2, "ipfs://r");
+        uint64 aid = attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.FORMAL, 2, expiry
+        );
+
+        assertEq(aid, 0);
+        Types.Attestation memory a = attestations.getAttestation(blueprintId, 0, 0);
+        assertEq(a.attester, user1);
+        assertEq(a.reportHash, REPORT_HASH);
+        assertEq(a.reportUri, "ipfs://r");
+        assertEq(uint8(a.kind), uint8(Types.AttestationKind.FORMAL));
+        assertEq(a.severityFound, 2);
+        assertEq(a.attestedAt, uint64(block.timestamp));
+        assertEq(a.expiresAt, expiry);
+        assertFalse(a.revoked);
+    }
+
+    function test_attest_permissionless_anyAddressCanAttest() public {
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "u1", Types.AttestationKind.AUDIT, 1, 0);
+        vm.prank(operator1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "op1", Types.AttestationKind.FUZZ, 2, 0);
+        vm.prank(developer);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "dev", Types.AttestationKind.SELF, 0, 0);
+
+        assertEq(attestations.getAttestationCount(blueprintId, 0), 3);
+    }
+
+    function test_attest_sameSenderCanAttestMultipleTimes_distinctIds() public {
+        vm.startPrank(user1);
+        uint64 a0 =
+            attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r0", Types.AttestationKind.AUDIT, 1, 0);
+        uint64 a1 =
+            attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r1", Types.AttestationKind.AUDIT, 2, 0);
+        uint64 a2 =
+            attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r2", Types.AttestationKind.AUDIT, 3, 0);
+        vm.stopPrank();
+
+        assertEq(a0, 0);
+        assertEq(a1, 1);
+        assertEq(a2, 2);
+        assertEq(attestations.getAttestationCount(blueprintId, 0), 3);
+    }
+
+    function test_attest_zeroReportHashAllowed() public {
+        // SELF declarations may carry only a URI; the spec allows reportHash=0.
+        vm.prank(user1);
+        uint64 aid = attestations.attestBinaryVersion(
+            blueprintId, 0, bytes32(0), "ipfs://self", Types.AttestationKind.SELF, 0, 0
+        );
+        assertEq(attestations.getAttestation(blueprintId, 0, aid).reportHash, bytes32(0));
+    }
+
+    function test_attest_indicesMonotonic_acrossVersions_independentArrays() public {
+        // Publish a second version and assert that attestation ids are independent
+        // per (blueprintId, versionId) - i.e. v1's first attestation is also aid 0.
+        vm.prank(developer);
+        versions.publishBinaryVersion(blueprintId, bytes32(uint256(0x22)), "ipfs://v1", bytes32(0));
+
+        vm.prank(user1);
+        uint64 a0 =
+            attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r", Types.AttestationKind.AUDIT, 1, 0);
+        vm.prank(user1);
+        uint64 b0 =
+            attestations.attestBinaryVersion(blueprintId, 1, REPORT_HASH, "r", Types.AttestationKind.AUDIT, 1, 0);
+
+        assertEq(a0, 0);
+        assertEq(b0, 0);
+        assertEq(attestations.getAttestationCount(blueprintId, 0), 1);
+        assertEq(attestations.getAttestationCount(blueprintId, 1), 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // revokeAttestation
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_revoke_revertWhen_nonAttesterCaller() public {
+        vm.prank(user1);
+        uint64 aid = attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0
+        );
+
+        vm.prank(user2);
+        vm.expectRevert(Errors.NotAttester.selector);
+        attestations.revokeAttestation(blueprintId, 0, aid, "ipfs://reason");
+    }
+
+    function test_revoke_revertWhen_idMissing() public {
+        vm.prank(user1);
+        vm.expectRevert(Errors.AttestationNotFound.selector);
+        attestations.revokeAttestation(blueprintId, 0, 0, "ipfs://reason");
+    }
+
+    function test_revoke_revertWhen_alreadyRevoked() public {
+        vm.prank(user1);
+        uint64 aid = attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0
+        );
+
+        vm.prank(user1);
+        attestations.revokeAttestation(blueprintId, 0, aid, "ipfs://reason");
+
+        vm.prank(user1);
+        vm.expectRevert(Errors.AttestationAlreadyRevoked.selector);
+        attestations.revokeAttestation(blueprintId, 0, aid, "ipfs://reason-second");
+    }
+
+    function test_revoke_happyPath_flipsFlagPreservesRow_emits() public {
+        vm.prank(user1);
+        uint64 aid = attestations.attestBinaryVersion(
+            blueprintId, 0, REPORT_HASH, "ipfs://r", Types.AttestationKind.AUDIT, 3, 0
+        );
+
+        vm.prank(user1);
+        vm.expectEmit(true, true, false, true, address(tangleProxy));
+        emit BinaryVersionAttestationRevoked(blueprintId, 0, aid, "ipfs://reason");
+        attestations.revokeAttestation(blueprintId, 0, aid, "ipfs://reason");
+
+        Types.Attestation memory a = attestations.getAttestation(blueprintId, 0, aid);
+        assertTrue(a.revoked);
+        // Other fields untouched: provenance preserved.
+        assertEq(a.attester, user1);
+        assertEq(a.reportHash, REPORT_HASH);
+        assertEq(a.reportUri, "ipfs://r");
+    }
+
+    function test_revoke_doesNotChangeAttestationCount() public {
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r0", Types.AttestationKind.AUDIT, 1, 0);
+        vm.prank(user2);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r1", Types.AttestationKind.AUDIT, 2, 0);
+
+        vm.prank(user1);
+        attestations.revokeAttestation(blueprintId, 0, 0, "reason");
+
+        assertEq(attestations.getAttestationCount(blueprintId, 0), 2, "count is append-only: revoke must not shrink");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // VIEWS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_getAttestation_revertWhen_missing() public {
+        vm.expectRevert(Errors.AttestationNotFound.selector);
+        attestations.getAttestation(blueprintId, 0, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // listAttestations — facet routing policy
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // The TangleBlueprintsBinaryAttestationsFacet intentionally does NOT expose
+    // `listAttestations` through the Tangle selector router (see the NatSpec on
+    // `selectors()`): the function copies the full unbounded array into memory
+    // and an on-chain consumer that called through the proxy would OOG once the
+    // list grows. Off-chain enumeration must use `getAttestationCount` +
+    // `getAttestation(id)`. The tests below pin that gating and verify the
+    // count-based iteration produces the same data the array view would have.
+
+    function test_listAttestations_NotRoutedViaTangle() public {
+        // The selector is deliberately omitted from `selectors()`; calling it via
+        // the proxy must revert with the router's UnknownSelector error.
+        (bool ok, bytes memory ret) = address(tangleProxy)
+            .call(
+                abi.encodeWithSelector(BlueprintsBinaryAttestations.listAttestations.selector, blueprintId, uint64(0))
+            );
+        assertFalse(ok, "listAttestations must not be routable through Tangle");
+        // Decode error selector (skip 4-byte selector, decode is unnecessary;
+        // we only need to confirm the revert came from the router).
+        bytes4 errSel;
+        assembly {
+            errSel := mload(add(ret, 32))
+        }
+        assertEq(errSel, bytes4(keccak256("UnknownSelector(bytes4)")), "router rejects with UnknownSelector");
+    }
+
+    function test_countBasedEnumeration_matchesArrayViewIntent_includingRevoked() public {
+        // Even without the array view exposed via Tangle, the documented offchain
+        // enumeration pattern (count + getAttestation per index) must return
+        // every row including revoked ones. This test pins that invariant.
+        vm.prank(user1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r0", Types.AttestationKind.AUDIT, 1, 0);
+        vm.prank(user2);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r1", Types.AttestationKind.FUZZ, 2, 0);
+        vm.prank(operator1);
+        attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r2", Types.AttestationKind.FORMAL, 3, 0);
+
+        vm.prank(user2);
+        attestations.revokeAttestation(blueprintId, 0, 1, "reason");
+
+        uint64 count = attestations.getAttestationCount(blueprintId, 0);
+        assertEq(count, 3, "count is append-only across revocations");
+
+        Types.Attestation memory a0 = attestations.getAttestation(blueprintId, 0, 0);
+        Types.Attestation memory a1 = attestations.getAttestation(blueprintId, 0, 1);
+        Types.Attestation memory a2 = attestations.getAttestation(blueprintId, 0, 2);
+        assertEq(a0.attester, user1);
+        assertEq(a1.attester, user2);
+        assertTrue(a1.revoked, "revoked row still readable by id");
+        assertEq(a2.attester, operator1);
+    }
+
+    function test_countBasedEnumeration_orderMatchesInsertionOrder() public {
+        address[3] memory attesters = [user1, user2, operator1];
+        for (uint256 i = 0; i < attesters.length; i++) {
+            vm.prank(attesters[i]);
+            attestations.attestBinaryVersion(blueprintId, 0, REPORT_HASH, "r", Types.AttestationKind.AUDIT, 1, 0);
+        }
+        for (uint256 i = 0; i < attesters.length; i++) {
+            assertEq(attestations.getAttestation(blueprintId, 0, uint64(i)).attester, attesters[i]);
+        }
+    }
+}

--- a/test/core/BlueprintsBinaryVersions.t.sol
+++ b/test/core/BlueprintsBinaryVersions.t.sol
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { UpgradeFlowHarness } from "../support/UpgradeFlowHarness.sol";
+import { MockBinaryHookBSM } from "../mocks/MockBinaryHookBSM.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+import { BlueprintsBinaryVersions } from "../../src/core/BlueprintsBinaryVersions.sol";
+
+/// @title BlueprintsBinaryVersionsTest
+/// @notice Coverage for the per-blueprint binary version registry, per-service
+///         upgrade policy and operator ack surface. The high-risk areas covered:
+///         resolution matrix, append-only invariants, deprecation stickiness,
+///         BSM hook identity, and revert isolation.
+contract BlueprintsBinaryVersionsTest is UpgradeFlowHarness {
+    // ═══════════════════════════════════════════════════════════════════════════
+    // EVENTS (re-declared for `vm.expectEmit`)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    event BinaryVersionPublished(
+        uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri
+    );
+    event BinaryVersionDeprecated(uint64 indexed blueprintId, uint64 indexed versionId);
+    event BinaryActiveVersionChanged(uint64 indexed blueprintId, uint64 indexed versionId);
+    event ServiceUpgradePolicySet(uint64 indexed serviceId, Types.UpgradePolicy policy);
+    event OperatorBinaryAcked(uint64 indexed serviceId, uint64 indexed versionId, address indexed operator);
+    event ManagerHookFailed(address indexed manager, bytes4 indexed selector, bytes returnData);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // FIXTURES
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    bytes32 internal constant HASH_V0 = bytes32(uint256(0x11));
+    bytes32 internal constant HASH_V1 = bytes32(uint256(0x22));
+    bytes32 internal constant HASH_V2 = bytes32(uint256(0x33));
+    bytes32 internal constant HASH_V3 = bytes32(uint256(0x44));
+    bytes32 internal constant ATT_HASH = bytes32(uint256(0xAA));
+
+    function _publishV(uint64 blueprintId, address owner, bytes32 h, string memory uri) internal returns (uint64) {
+        vm.prank(owner);
+        return versions.publishBinaryVersion(blueprintId, h, uri, bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // publishBinaryVersion - gating
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_publish_revertWhen_callerNotOwner() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotBlueprintOwner.selector, bp, user1));
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+    }
+
+    function test_publish_revertWhen_zeroBinaryHash() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.prank(developer);
+        vm.expectRevert(Errors.ZeroBinaryHash.selector);
+        versions.publishBinaryVersion(bp, bytes32(0), "ipfs://v0", bytes32(0));
+    }
+
+    function test_publish_revertWhen_emptyBinaryUri() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.prank(developer);
+        vm.expectRevert(Errors.EmptyBinaryUri.selector);
+        versions.publishBinaryVersion(bp, HASH_V0, "", bytes32(0));
+    }
+
+    function test_publish_revertWhen_blueprintMissing() public {
+        // Blueprint id 99 was never created - `_getBlueprint` should revert before
+        // hitting ownership / hash checks.
+        vm.prank(developer);
+        vm.expectRevert();
+        versions.publishBinaryVersion(99, HASH_V0, "ipfs://v0", bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // publishBinaryVersion - storage + events
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_publish_genesisRowFieldsAreCorrect() public {
+        uint64 bp = _createBlueprint(developer);
+
+        vm.prank(developer);
+        vm.expectEmit(true, true, false, true, address(tangleProxy));
+        emit BinaryVersionPublished(bp, 0, HASH_V0, "ipfs://v0");
+        uint64 vid = versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", ATT_HASH);
+
+        assertEq(vid, 0, "genesis versionId");
+        assertEq(versions.getBinaryVersionCount(bp), 1, "count");
+
+        Types.BinaryVersion memory row = versions.getBinaryVersion(bp, 0);
+        assertEq(row.versionId, 0);
+        assertEq(row.sha256Hash, HASH_V0);
+        assertEq(row.binaryUri, "ipfs://v0");
+        assertEq(row.attestationHash, ATT_HASH);
+        assertEq(row.publishedAt, uint64(block.timestamp));
+        assertFalse(row.deprecated);
+    }
+
+    function test_publish_sequentialVersionIdsAreMonotonic() public {
+        uint64 bp = _createBlueprint(developer);
+        uint64 v0 = _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        uint64 v1 = _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        uint64 v2 = _publishV(bp, developer, HASH_V2, "ipfs://v2");
+        assertEq(v0, 0);
+        assertEq(v1, 1);
+        assertEq(v2, 2);
+        assertEq(versions.getBinaryVersionCount(bp), 3);
+    }
+
+    function test_publish_zeroAttestationHashAllowed() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.prank(developer);
+        uint64 vid = versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        assertEq(versions.getBinaryVersion(bp, vid).attestationHash, bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // publishBinaryVersion - BSM hook identity + revert isolation
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_publish_bsmHookSeesTangleAsSender() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        uint64 bp = _createBlueprint(developer, address(bsm));
+
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        assertEq(bsm.publishCallCount(), 1, "hook called once");
+        MockBinaryHookBSM.PublishCall memory pc = bsm.publishCallAt(0);
+        assertEq(pc.senderAtCall, address(tangleProxy), "msg.sender on BSM must be Tangle (not MBSM)");
+        assertEq(pc.blueprintId, bp);
+        assertEq(pc.versionId, 0);
+        assertEq(pc.sha256Hash, HASH_V0);
+    }
+
+    function test_publish_bsmRevertEmitsManagerHookFailedButPersistsRow() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        bsm.setRevertOnPublish(true);
+        uint64 bp = _createBlueprint(developer, address(bsm));
+
+        // The publish should succeed end-to-end: BinaryVersionPublished AND
+        // ManagerHookFailed both fire and the row persists.
+        vm.prank(developer);
+        vm.expectEmit(true, true, false, true, address(tangleProxy));
+        emit BinaryVersionPublished(bp, 0, HASH_V0, "ipfs://v0");
+        // Also expect the failure-observability event without asserting topic2 or payload.
+        vm.expectEmit(true, false, false, false, address(tangleProxy));
+        emit ManagerHookFailed(address(bsm), bytes4(0), "");
+        uint64 vid = versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+
+        assertEq(vid, 0);
+        assertEq(versions.getBinaryVersionCount(bp), 1, "row still persisted despite BSM revert");
+        assertEq(bsm.publishCallCount(), 0, "hook reverted before recording");
+    }
+
+    function test_publish_bsmGateRequiringAttestationStillPersistsRow() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        bsm.setRequireAttestation(true);
+        uint64 bp = _createBlueprint(developer, address(bsm));
+
+        // No attestation hash → BSM reverts → row still persisted (documented design).
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        assertEq(versions.getBinaryVersionCount(bp), 1, "row persisted even though BSM gated on attestation");
+
+        // With attestation hash → BSM passes → row persisted AND hook recorded.
+        vm.prank(developer);
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", ATT_HASH);
+        assertEq(versions.getBinaryVersionCount(bp), 2);
+        assertEq(bsm.publishCallCount(), 1, "second publish reached the BSM successfully");
+    }
+
+    function test_publish_noBSM_eventStillEmitted() public {
+        uint64 bp = _createBlueprint(developer, address(0));
+        vm.prank(developer);
+        vm.expectEmit(true, true, false, true, address(tangleProxy));
+        emit BinaryVersionPublished(bp, 0, HASH_V0, "ipfs://v0");
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        assertEq(versions.getBinaryVersionCount(bp), 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // setActiveBinaryVersion
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_setActive_revertWhen_callerNotOwner() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotBlueprintOwner.selector, bp, user1));
+        versions.setActiveBinaryVersion(bp, 0);
+    }
+
+    function test_setActive_revertWhen_versionMissing() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(developer);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        versions.setActiveBinaryVersion(bp, 5);
+    }
+
+    function test_setActive_emitsAndStores() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(developer);
+        vm.expectEmit(true, true, false, false, address(tangleProxy));
+        emit BinaryActiveVersionChanged(bp, 1);
+        versions.setActiveBinaryVersion(bp, 1);
+
+        assertEq(versions.getActiveBinaryVersionId(bp), 1);
+    }
+
+    function test_setActive_acceptsDeprecatedVersion_rollbackPath() public {
+        // Regression: setActiveBinaryVersion(deprecated) is intentionally allowed
+        // so the blueprint owner can roll back to an older known-good build.
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 1);
+
+        // Even though v1 is deprecated, setActive(1) must NOT revert.
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 1);
+
+        assertEq(versions.getActiveBinaryVersionId(bp), 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // deprecateBinaryVersion
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_deprecate_revertWhen_callerNotOwner() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotBlueprintOwner.selector, bp, user1));
+        versions.deprecateBinaryVersion(bp, 0);
+    }
+
+    function test_deprecate_revertWhen_versionMissing() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.prank(developer);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        versions.deprecateBinaryVersion(bp, 0);
+    }
+
+    function test_deprecate_revertWhen_alreadyDeprecated() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 0);
+
+        vm.prank(developer);
+        vm.expectRevert(Errors.VersionAlreadyDeprecated.selector);
+        versions.deprecateBinaryVersion(bp, 0);
+    }
+
+    function test_deprecate_emitsAndFlipsFlag() public {
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(developer);
+        vm.expectEmit(true, true, false, false, address(tangleProxy));
+        emit BinaryVersionDeprecated(bp, 0);
+        versions.deprecateBinaryVersion(bp, 0);
+
+        assertTrue(versions.getBinaryVersion(bp, 0).deprecated);
+    }
+
+    function test_deprecate_existingAckRemainsReadable_stickiness() public {
+        // Operator acks v1, then the owner deprecates v1.
+        // The ack remains readable AND effectiveBinaryVersion still returns v1.
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 1);
+
+        assertEq(versions.getServiceAckedVersionId(sid), 1, "ack readable after deprecation");
+        Types.BinaryVersion memory eff = versions.effectiveBinaryVersion(sid);
+        assertEq(eff.versionId, 1, "ack-stickiness: effective version stays at the deprecated row");
+        assertTrue(eff.deprecated);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // ackBinaryVersion
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_ack_revertWhen_callerNotOperator() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(operator2);
+        vm.expectRevert(Errors.NotServiceOperator.selector);
+        versions.ackBinaryVersion(sid, 0);
+    }
+
+    function test_ack_revertWhen_versionMissing() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        vm.prank(operator1);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        versions.ackBinaryVersion(sid, 5);
+    }
+
+    function test_ack_revertWhen_versionDeprecated() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 1);
+
+        vm.prank(operator1);
+        vm.expectRevert(Errors.VersionDeprecatedCannotAck.selector);
+        versions.ackBinaryVersion(sid, 1);
+    }
+
+    function test_ack_storesAndEmits() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(operator1);
+        vm.expectEmit(true, true, true, false, address(tangleProxy));
+        emit OperatorBinaryAcked(sid, 1, operator1);
+        versions.ackBinaryVersion(sid, 1);
+
+        assertEq(versions.getServiceAckedVersionId(sid), 1);
+    }
+
+    function test_ack_bsmHookSeesTangleAsSender() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        _registerOperator(operator1);
+        uint64 bp = _createBlueprint(developer, address(bsm));
+        _registerForBlueprint(operator1, bp);
+        uint64 reqId = _requestService(user1, bp, operator1);
+        _approveService(operator1, reqId);
+        uint64 sid = tangle.serviceCount() - 1;
+
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        // Reset publish-side recorder so we count ack-side cleanly.
+        uint256 publishCount = bsm.publishCallCount();
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 0);
+
+        assertEq(bsm.ackCallCount(), 1, "ack hook called");
+        MockBinaryHookBSM.AckCall memory ac = bsm.ackCallAt(0);
+        assertEq(ac.senderAtCall, address(tangleProxy), "msg.sender on BSM is Tangle");
+        assertEq(ac.operator, operator1);
+        assertEq(ac.serviceId, sid);
+        assertEq(ac.versionId, 0);
+        // Sanity: publish path still recorded earlier.
+        assertEq(publishCount, 1);
+    }
+
+    function test_ack_bsmRevertEmitsManagerHookFailedButPersistsAck() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        _registerOperator(operator1);
+        uint64 bp = _createBlueprint(developer, address(bsm));
+        _registerForBlueprint(operator1, bp);
+        uint64 reqId = _requestService(user1, bp, operator1);
+        _approveService(operator1, reqId);
+        uint64 sid = tangle.serviceCount() - 1;
+
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        bsm.setRevertOnAck(true);
+
+        vm.prank(operator1);
+        vm.expectEmit(true, true, true, false, address(tangleProxy));
+        emit OperatorBinaryAcked(sid, 0, operator1);
+        // Don't pin topic2 (selector) so the test stays resilient to the exact
+        // selector hash on the BSM interface.
+        vm.expectEmit(true, false, false, false, address(tangleProxy));
+        emit ManagerHookFailed(address(bsm), bytes4(0), "");
+        versions.ackBinaryVersion(sid, 0);
+
+        assertEq(versions.getServiceAckedVersionId(sid), 0, "ack persisted despite BSM revert");
+        assertEq(bsm.ackCallCount(), 0, "ack hook reverted before recording");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // setServiceUpgradePolicy
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_setPolicy_revertWhen_callerNotOperator() public {
+        (, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.prank(operator2);
+        vm.expectRevert(Errors.NotServiceOperator.selector);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+    }
+
+    function test_setPolicy_storesAndEmits_each() public {
+        (, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+
+        vm.prank(operator1);
+        vm.expectEmit(true, false, false, true, address(tangleProxy));
+        emit ServiceUpgradePolicySet(sid, Types.UpgradePolicy.AUTO);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+        assertEq(uint8(versions.getServiceUpgradePolicy(sid)), uint8(Types.UpgradePolicy.AUTO));
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+        assertEq(uint8(versions.getServiceUpgradePolicy(sid)), uint8(Types.UpgradePolicy.MANUAL));
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.APPROVE);
+        assertEq(uint8(versions.getServiceUpgradePolicy(sid)), uint8(Types.UpgradePolicy.APPROVE));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // effectiveBinaryVersion - RESOLUTION MATRIX
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_effective_revertWhen_noVersionsPublished() public {
+        (, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        versions.effectiveBinaryVersion(sid);
+    }
+
+    function test_effective_revertWhen_serviceMissing() public {
+        vm.expectRevert();
+        versions.effectiveBinaryVersion(99);
+    }
+
+    function test_effective_singleVersion_defaultPolicy_returnsGenesis() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+
+        // Default policy is APPROVE (enum 0), no ack yet → genesis.
+        assertEq(uint8(versions.getServiceUpgradePolicy(sid)), uint8(Types.UpgradePolicy.APPROVE));
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    function test_effective_multipleVersions_APPROVE_noAck_returnsGenesis() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    function test_effective_APPROVE_withAckV2_returnsV2() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 2);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 2);
+    }
+
+    function test_effective_AUTO_defaultActiveZero_returnsGenesis() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+        // Active version defaults to 0 because no setActive call was made.
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    function test_effective_AUTO_withActiveV3_returnsV3() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+        _publishV(bp, developer, HASH_V3, "ipfs://v3");
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 3);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 3);
+    }
+
+    function test_effective_MANUAL_anyState_returnsGenesis() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+
+        // Move global state around - none of it should matter under MANUAL.
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 2);
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+
+        // Even with an ack from a prior APPROVE phase, MANUAL pins to genesis.
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.APPROVE);
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 2);
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    function test_effective_AUTO_withDeprecatedActive_stillReturnsDeprecated() public {
+        // Rollback path: the owner may set active=deprecated for AUTO services.
+        // Documented in setActiveBinaryVersion NatSpec ("the owner may revert to an
+        // older known-good build; enforcement of 'no deprecated active' is a UI
+        // concern"). This test pins that behaviour so future PRs can't silently
+        // tighten the on-chain enforcement and break rollback.
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 1);
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 1);
+
+        Types.BinaryVersion memory eff = versions.effectiveBinaryVersion(sid);
+        assertEq(eff.versionId, 1, "AUTO still resolves to deprecated active version");
+        assertTrue(eff.deprecated, "deprecated flag readable");
+    }
+
+    function test_effective_policySwitch_APPROVE_to_MANUAL_ackBecomesDormant() public {
+        // The ack is not deleted when policy changes; switching to MANUAL hides it,
+        // switching back to APPROVE restores it. Tests both directions.
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+        _publishV(bp, developer, HASH_V2, "ipfs://v2");
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 2);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 2);
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0, "MANUAL hides the ack");
+        assertEq(versions.getServiceAckedVersionId(sid), 2, "ack itself is preserved");
+    }
+
+    function test_effective_policySwitch_MANUAL_to_APPROVE_restoresAck() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.APPROVE);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 1, "ack revived");
+    }
+
+    function test_effective_AUTO_servicesOnSameBlueprint_pickUpNewActiveImmediately() public {
+        (uint64 bp, uint64 sid1) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        // Spin a second AUTO service on the same blueprint.
+        _registerOperator(operator2);
+        _registerForBlueprint(operator2, bp);
+        uint64 reqId = _requestService(user2, bp, operator2);
+        _approveService(operator2, reqId);
+        uint64 sid2 = tangle.serviceCount() - 1;
+
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid1, Types.UpgradePolicy.AUTO);
+        vm.prank(operator2);
+        versions.setServiceUpgradePolicy(sid2, Types.UpgradePolicy.AUTO);
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 1);
+
+        assertEq(versions.effectiveBinaryVersion(sid1).versionId, 1);
+        assertEq(versions.effectiveBinaryVersion(sid2).versionId, 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // VIEWS / GETTERS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_views_getBinaryVersion_revertWhen_missing() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.expectRevert(Errors.VersionNotFound.selector);
+        versions.getBinaryVersion(bp, 0);
+    }
+
+    function test_views_emptyDefaultsForFreshBlueprint() public {
+        uint64 bp = _createBlueprint(developer);
+        assertEq(versions.getBinaryVersionCount(bp), 0);
+        assertEq(versions.getActiveBinaryVersionId(bp), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // STORAGE-LAYOUT SLOT REGRESSION
+    // ═══════════════════════════════════════════════════════════════════════════
+    // The append-only invariants only hold if the mapping slots stay where they
+    // are. These golden assertions catch a slot shift before any logic breaks.
+
+    function test_storageSlots_binaryVersionsMappingsAreAtExpectedOffsets() public {
+        // Storage layout (TangleStorage.sol, captured at branch
+        // `feat/blueprint-binary-versions`):
+        //   Slot 0..4 - protocol config (staking, treasury, _maxBlueprints..., split, domainSep)
+        //              packs into ~5 slots; staking is the first variable.
+        //   `_blueprintBinaryVersions`        - declared after a long chain of mappings.
+        //   `_blueprintActiveVersionId`       - immediately after.
+        //   `_serviceUpgradePolicy`           - immediately after.
+        //   `_serviceAckedVersionId`          - immediately after.
+        //   `_blueprintVersionAttestations`   - after the four above.
+        //
+        // Rather than hardcoding numeric slot indices (which churn whenever an
+        // earlier slot pack changes), we verify the *relative* invariant: the
+        // mappings sit in declaration order, contiguous, with no other reads
+        // intercepting them. We do that by writing through the public entrypoints
+        // and then reading back via the documented view selectors. A storage
+        // collision elsewhere in TangleStorage would corrupt one of these reads.
+        uint64 bp = _createBlueprint(developer);
+        _publishV(bp, developer, HASH_V0, "ipfs://v0");
+        _publishV(bp, developer, HASH_V1, "ipfs://v1");
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 1);
+
+        assertEq(versions.getBinaryVersionCount(bp), 2);
+        assertEq(versions.getActiveBinaryVersionId(bp), 1);
+        assertEq(versions.getBinaryVersion(bp, 0).sha256Hash, HASH_V0);
+        assertEq(versions.getBinaryVersion(bp, 1).sha256Hash, HASH_V1);
+
+        // Now a second blueprint must NOT see blueprint 0's data - proves the
+        // mapping key path didn't collide.
+        uint64 bp2 = _createBlueprint(developer);
+        assertEq(versions.getBinaryVersionCount(bp2), 0);
+        assertEq(versions.getActiveBinaryVersionId(bp2), 0);
+    }
+}

--- a/test/governance/BlueprintAuditors.t.sol
+++ b/test/governance/BlueprintAuditors.t.sol
@@ -1,0 +1,615 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
+
+import { BlueprintAuditors } from "../../src/governance/BlueprintAuditors.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+
+/// @title BlueprintAuditorsTest
+/// @notice Coverage for the governance-curated auditor registry. High-risk areas:
+///         role separation (governance vs first-party admin), append-only weight
+///         bounds, soft-delete invariants, and UUPS upgrade authorization.
+contract BlueprintAuditorsTest is Test {
+    BlueprintAuditors internal auditorsImpl;
+    BlueprintAuditors internal auditors;
+
+    address internal admin = makeAddr("admin");
+    address internal governor = makeAddr("governor");
+    address internal firstPartyAdmin = makeAddr("firstPartyAdmin");
+
+    address internal auditor1 = makeAddr("auditor1");
+    address internal auditor2 = makeAddr("auditor2");
+    address internal auditor3 = makeAddr("auditor3");
+    address internal outsider = makeAddr("outsider");
+
+    // Cached role hashes. Reading `auditors.X_ROLE()` is a proxy call, which
+    // would consume `vm.prank` when used inline as an `expectRevert(...)`
+    // argument (because the prank applies to the very next call). Caching them
+    // here keeps the prank intact for the real assertion target.
+    bytes32 internal constant GOV_ROLE = keccak256("GOVERNANCE_ROLE");
+    bytes32 internal constant FP_ROLE = keccak256("FIRST_PARTY_ADMIN_ROLE");
+    bytes32 internal constant ADMIN_ROLE = bytes32(0);
+
+    // Re-declared for vm.expectEmit
+    event AuditorAdmitted(
+        address indexed auditor, string name, string metadataUri, uint16 weight, BlueprintAuditors.AuditorTier tier
+    );
+    event AuditorRemoved(address indexed auditor);
+    event AuditorActiveSet(address indexed auditor, bool active);
+    event AuditorWeightSet(address indexed auditor, uint16 oldWeight, uint16 newWeight);
+    event AuditorMetadataUpdated(address indexed auditor, string metadataUri);
+
+    function setUp() public virtual {
+        auditorsImpl = new BlueprintAuditors();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(auditorsImpl), abi.encodeCall(BlueprintAuditors.initialize, (admin, governor, firstPartyAdmin))
+        );
+        auditors = BlueprintAuditors(address(proxy));
+    }
+
+    function _admitData(
+        string memory name,
+        uint16 weight,
+        BlueprintAuditors.AuditorTier tier
+    )
+        internal
+        pure
+        returns (BlueprintAuditors.Auditor memory)
+    {
+        return BlueprintAuditors.Auditor({
+            name: name,
+            metadataUri: "ipfs://meta",
+            weight: weight,
+            tier: tier,
+            active: false, // ignored by contract
+            admittedAt: 0 // ignored by contract
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // INITIALIZATION
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_init_rolesGrantedToExpectedAddresses() public view {
+        assertTrue(auditors.hasRole(ADMIN_ROLE, admin));
+        assertTrue(auditors.hasRole(GOV_ROLE, governor));
+        assertTrue(auditors.hasRole(FP_ROLE, firstPartyAdmin));
+
+        assertFalse(auditors.hasRole(GOV_ROLE, firstPartyAdmin));
+        assertFalse(auditors.hasRole(FP_ROLE, governor));
+    }
+
+    function test_init_revertWhen_reInitialized() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        auditors.initialize(admin, governor, firstPartyAdmin);
+    }
+
+    function test_init_implementation_constructor_disablesInitializer() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        auditorsImpl.initialize(admin, governor, firstPartyAdmin);
+    }
+
+    function test_init_revertWhen_zeroAdmin() public {
+        BlueprintAuditors fresh = new BlueprintAuditors();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ERC1967Proxy(
+            address(fresh), abi.encodeCall(BlueprintAuditors.initialize, (address(0), governor, firstPartyAdmin))
+        );
+    }
+
+    function test_init_revertWhen_zeroGovernor() public {
+        BlueprintAuditors fresh = new BlueprintAuditors();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ERC1967Proxy(
+            address(fresh), abi.encodeCall(BlueprintAuditors.initialize, (admin, address(0), firstPartyAdmin))
+        );
+    }
+
+    function test_init_revertWhen_zeroFirstPartyAdmin() public {
+        BlueprintAuditors fresh = new BlueprintAuditors();
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        new ERC1967Proxy(address(fresh), abi.encodeCall(BlueprintAuditors.initialize, (admin, governor, address(0))));
+    }
+
+    function test_constants_maxWeightIs1000() public view {
+        assertEq(auditors.MAX_AUDITOR_WEIGHT(), 1000);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // admitAuditor (governance path)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_admit_revertWhen_callerNotGovernor() public {
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, GOV_ROLE)
+        );
+        auditors.admitAuditor(auditor1, _admitData("Acme", 500, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_revertWhen_firstPartyAdminTries() public {
+        // FIRST_PARTY_ADMIN_ROLE cannot mutate INDEPENDENT/COMMUNITY entries via the
+        // governance entrypoint - confirms tier separation.
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, firstPartyAdmin, GOV_ROLE)
+        );
+        auditors.admitAuditor(auditor1, _admitData("Acme", 500, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_revertWhen_zeroAddress() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        auditors.admitAuditor(address(0), _admitData("Acme", 500, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_revertWhen_emptyName() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.EmptyAuditorName.selector);
+        auditors.admitAuditor(auditor1, _admitData("", 500, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_revertWhen_weightAboveCap() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.InvalidWeight.selector);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 1001, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_acceptsMaxWeight() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 1000, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        assertEq(auditors.auditorWeight(auditor1), 1000);
+    }
+
+    function test_admit_revertWhen_alreadyAdmitted_evenIfRemoved() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        // Soft-remove - `admittedAt` is preserved.
+        vm.prank(governor);
+        auditors.removeAuditor(auditor1);
+
+        vm.prank(governor);
+        vm.expectRevert(Errors.AuditorAlreadyAdmitted.selector);
+        auditors.admitAuditor(auditor1, _admitData("Acme2", 200, BlueprintAuditors.AuditorTier.INDEPENDENT));
+    }
+
+    function test_admit_happyPath_storesAndEmits() public {
+        vm.warp(12_345);
+        BlueprintAuditors.Auditor memory data = _admitData("Acme", 500, BlueprintAuditors.AuditorTier.INDEPENDENT);
+
+        vm.prank(governor);
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorAdmitted(auditor1, "Acme", "ipfs://meta", 500, BlueprintAuditors.AuditorTier.INDEPENDENT);
+        auditors.admitAuditor(auditor1, data);
+
+        BlueprintAuditors.Auditor memory row = auditors.getAuditor(auditor1);
+        assertEq(row.name, "Acme");
+        assertEq(row.metadataUri, "ipfs://meta");
+        assertEq(row.weight, 500);
+        assertEq(uint8(row.tier), uint8(BlueprintAuditors.AuditorTier.INDEPENDENT));
+        assertTrue(row.active);
+        assertEq(row.admittedAt, uint64(block.timestamp));
+
+        assertTrue(auditors.isActiveAuditor(auditor1));
+        assertEq(auditors.auditorWeight(auditor1), 500);
+        assertEq(auditors.auditorCount(), 1);
+        assertEq(auditors.auditorAt(0), auditor1);
+    }
+
+    function test_admit_ignoresCallerSuppliedActiveAndAdmittedAt() public {
+        BlueprintAuditors.Auditor memory data = BlueprintAuditors.Auditor({
+            name: "Acme",
+            metadataUri: "ipfs://m",
+            weight: 100,
+            tier: BlueprintAuditors.AuditorTier.COMMUNITY,
+            active: false, // caller says inactive
+            admittedAt: 9999 // caller-supplied bogus
+        });
+
+        vm.warp(1_000_000);
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, data);
+
+        BlueprintAuditors.Auditor memory row = auditors.getAuditor(auditor1);
+        assertTrue(row.active, "active is contract-controlled");
+        assertEq(row.admittedAt, uint64(block.timestamp), "admittedAt is set to now");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // admitFirstPartyAuditor (security council path)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_admitFP_revertWhen_callerNotFirstPartyAdmin() public {
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, FP_ROLE)
+        );
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 800);
+    }
+
+    function test_admitFP_revertWhen_governorTries() public {
+        vm.prank(governor);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, governor, FP_ROLE)
+        );
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 800);
+    }
+
+    function test_admitFP_revertWhen_zeroAddress() public {
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        auditors.admitFirstPartyAuditor(address(0), "Tangle Sec", 800);
+    }
+
+    function test_admitFP_revertWhen_emptyName() public {
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(Errors.EmptyAuditorName.selector);
+        auditors.admitFirstPartyAuditor(auditor1, "", 800);
+    }
+
+    function test_admitFP_revertWhen_weightAboveCap() public {
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(Errors.InvalidWeight.selector);
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 1001);
+    }
+
+    function test_admitFP_revertWhen_alreadyAdmitted() public {
+        vm.prank(firstPartyAdmin);
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 800);
+
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(Errors.AuditorAlreadyAdmitted.selector);
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec V2", 900);
+    }
+
+    function test_admitFP_revertWhen_alreadyAdmittedViaGovernance() public {
+        // FP admin cannot overwrite a governance-admitted row at any tier.
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("ChainSec", 600, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(Errors.AuditorAlreadyAdmitted.selector);
+        auditors.admitFirstPartyAuditor(auditor1, "ChainSec", 600);
+    }
+
+    function test_admitFP_happyPath_forcesFirstPartyTier() public {
+        vm.warp(7777);
+        vm.prank(firstPartyAdmin);
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorAdmitted(auditor1, "Tangle Sec", "", 800, BlueprintAuditors.AuditorTier.FIRST_PARTY);
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 800);
+
+        BlueprintAuditors.Auditor memory row = auditors.getAuditor(auditor1);
+        assertEq(row.name, "Tangle Sec");
+        assertEq(row.metadataUri, "");
+        assertEq(row.weight, 800);
+        assertEq(uint8(row.tier), uint8(BlueprintAuditors.AuditorTier.FIRST_PARTY));
+        assertTrue(row.active);
+        assertEq(row.admittedAt, uint64(block.timestamp));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // setAuditorWeight
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_setWeight_revertWhen_callerNotGovernor() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, GOV_ROLE)
+        );
+        auditors.setAuditorWeight(auditor1, 200);
+    }
+
+    function test_setWeight_revertWhen_firstPartyAdminTries() public {
+        // The FP admin cannot bump the weight even on a FIRST_PARTY-tier auditor.
+        vm.prank(firstPartyAdmin);
+        auditors.admitFirstPartyAuditor(auditor1, "Tangle Sec", 100);
+
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, firstPartyAdmin, GOV_ROLE)
+        );
+        auditors.setAuditorWeight(auditor1, 200);
+    }
+
+    function test_setWeight_revertWhen_auditorNotFound() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.AuditorNotFound.selector);
+        auditors.setAuditorWeight(auditor1, 100);
+    }
+
+    function test_setWeight_revertWhen_aboveCap() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(governor);
+        vm.expectRevert(Errors.InvalidWeight.selector);
+        auditors.setAuditorWeight(auditor1, 1001);
+    }
+
+    function test_setWeight_happyPath_emitsAndUpdates() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(governor);
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorWeightSet(auditor1, 100, 250);
+        auditors.setAuditorWeight(auditor1, 250);
+
+        assertEq(auditors.auditorWeight(auditor1), 250);
+    }
+
+    function test_setWeight_canSetToZero() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(governor);
+        auditors.setAuditorWeight(auditor1, 0);
+        assertEq(auditors.auditorWeight(auditor1), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // setAuditorActive
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_setActive_revertWhen_callerNotGovernor() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, GOV_ROLE)
+        );
+        auditors.setAuditorActive(auditor1, false);
+    }
+
+    function test_setActive_revertWhen_auditorNotFound() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.AuditorNotFound.selector);
+        auditors.setAuditorActive(auditor1, true);
+    }
+
+    function test_setActive_togglesAndEmits() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(governor);
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorActiveSet(auditor1, false);
+        auditors.setAuditorActive(auditor1, false);
+
+        assertFalse(auditors.isActiveAuditor(auditor1));
+
+        vm.prank(governor);
+        auditors.setAuditorActive(auditor1, true);
+        assertTrue(auditors.isActiveAuditor(auditor1));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // removeAuditor (soft delete)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_remove_revertWhen_callerNotGovernor() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, GOV_ROLE)
+        );
+        auditors.removeAuditor(auditor1);
+    }
+
+    function test_remove_revertWhen_auditorNotFound() public {
+        vm.prank(governor);
+        vm.expectRevert(Errors.AuditorNotFound.selector);
+        auditors.removeAuditor(auditor1);
+    }
+
+    function test_remove_setsInactiveZerosWeight_preservesAdmittedAt_emits() public {
+        vm.warp(5555);
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 400, BlueprintAuditors.AuditorTier.COMMUNITY));
+        uint64 admittedAt = auditors.getAuditor(auditor1).admittedAt;
+
+        vm.warp(10_000);
+        vm.prank(governor);
+        // Both events are emitted in order: weight-set then removed.
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorWeightSet(auditor1, 400, 0);
+        vm.expectEmit(true, false, false, false, address(auditors));
+        emit AuditorRemoved(auditor1);
+        auditors.removeAuditor(auditor1);
+
+        BlueprintAuditors.Auditor memory row = auditors.getAuditor(auditor1);
+        assertFalse(row.active);
+        assertEq(row.weight, 0);
+        assertEq(row.admittedAt, admittedAt, "admittedAt preserved across soft-delete");
+        assertFalse(auditors.isActiveAuditor(auditor1));
+    }
+
+    function test_remove_doesNotShrinkEnumeration() public {
+        vm.startPrank(governor);
+        auditors.admitAuditor(auditor1, _admitData("A", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        auditors.admitAuditor(auditor2, _admitData("B", 200, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        auditors.admitAuditor(auditor3, _admitData("C", 300, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        auditors.removeAuditor(auditor2);
+        vm.stopPrank();
+
+        assertEq(auditors.auditorCount(), 3, "soft delete keeps enumeration intact");
+        assertEq(auditors.auditorAt(0), auditor1);
+        assertEq(auditors.auditorAt(1), auditor2);
+        assertEq(auditors.auditorAt(2), auditor3);
+        // But the middle one is inactive - aggregators filter via isActiveAuditor.
+        assertTrue(auditors.isActiveAuditor(auditor1));
+        assertFalse(auditors.isActiveAuditor(auditor2));
+        assertTrue(auditors.isActiveAuditor(auditor3));
+    }
+
+    function test_remove_thenSetActiveTrue_resurrectsButWeightStaysZero() public {
+        // Documented re-admission flow: removeAuditor then setAuditorActive(true)
+        // brings the row back, but weight must be set again explicitly.
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 400, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        vm.prank(governor);
+        auditors.removeAuditor(auditor1);
+        vm.prank(governor);
+        auditors.setAuditorActive(auditor1, true);
+
+        assertTrue(auditors.isActiveAuditor(auditor1));
+        assertEq(auditors.auditorWeight(auditor1), 0);
+
+        vm.prank(governor);
+        auditors.setAuditorWeight(auditor1, 500);
+        assertEq(auditors.auditorWeight(auditor1), 500);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // updateAuditorMetadata (self-service)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_updateMeta_revertWhen_callerNotAdmitted() public {
+        vm.prank(outsider);
+        vm.expectRevert(Errors.NotAuditorSelf.selector);
+        auditors.updateAuditorMetadata("ipfs://new");
+    }
+
+    function test_updateMeta_happyPath_updatesAndEmits() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(auditor1);
+        vm.expectEmit(true, false, false, true, address(auditors));
+        emit AuditorMetadataUpdated(auditor1, "ipfs://new");
+        auditors.updateAuditorMetadata("ipfs://new");
+
+        assertEq(auditors.getAuditor(auditor1).metadataUri, "ipfs://new");
+    }
+
+    function test_updateMeta_acceptsEmptyString() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(auditor1);
+        auditors.updateAuditorMetadata("");
+        assertEq(auditors.getAuditor(auditor1).metadataUri, "");
+    }
+
+    function test_updateMeta_revertWhen_removedAuditor() public {
+        // Documented behaviour: soft-removed auditors CANNOT update metadata.
+        // See NatSpec on `updateAuditorMetadata`: "active-only ... so a soft-
+        // removed address cannot mutate its historical record post-removal".
+        // The guard prevents an ex-auditor from phishing-redirecting a
+        // metadataUri while their attestations still resolve through the row.
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        vm.prank(governor);
+        auditors.removeAuditor(auditor1);
+
+        vm.prank(auditor1);
+        vm.expectRevert(Errors.AuditorNotActive.selector);
+        auditors.updateAuditorMetadata("ipfs://still-mine");
+    }
+
+    function test_updateMeta_revertWhen_inactiveButNotRemoved() public {
+        // `setAuditorActive(false)` flips active without zeroing weight. The
+        // metadata-update guard must still reject those, otherwise the active
+        // flag becomes a soft-suspended state with a hole.
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        vm.prank(governor);
+        auditors.setAuditorActive(auditor1, false);
+
+        vm.prank(auditor1);
+        vm.expectRevert(Errors.AuditorNotActive.selector);
+        auditors.updateAuditorMetadata("ipfs://x");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // ENUMERATION VIEWS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_views_emptyByDefault() public view {
+        assertEq(auditors.auditorCount(), 0);
+        assertFalse(auditors.isActiveAuditor(auditor1));
+        assertEq(auditors.auditorWeight(auditor1), 0);
+    }
+
+    function test_views_auditorAt_revertsOutOfBounds() public {
+        vm.expectRevert();
+        auditors.auditorAt(0);
+    }
+
+    function test_views_mixingPathsAppendsInOrder() public {
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("A", 100, BlueprintAuditors.AuditorTier.INDEPENDENT));
+        vm.prank(firstPartyAdmin);
+        auditors.admitFirstPartyAuditor(auditor2, "B", 200);
+        vm.prank(governor);
+        auditors.admitAuditor(auditor3, _admitData("C", 300, BlueprintAuditors.AuditorTier.COMMUNITY));
+
+        assertEq(auditors.auditorCount(), 3);
+        assertEq(auditors.auditorAt(0), auditor1);
+        assertEq(auditors.auditorAt(1), auditor2);
+        assertEq(auditors.auditorAt(2), auditor3);
+
+        assertEq(uint8(auditors.getAuditor(auditor1).tier), uint8(BlueprintAuditors.AuditorTier.INDEPENDENT));
+        assertEq(uint8(auditors.getAuditor(auditor2).tier), uint8(BlueprintAuditors.AuditorTier.FIRST_PARTY));
+        assertEq(uint8(auditors.getAuditor(auditor3).tier), uint8(BlueprintAuditors.AuditorTier.COMMUNITY));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // UPGRADE AUTHORIZATION (UUPS)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_upgrade_revertWhen_callerNotGovernor() public {
+        BlueprintAuditors newImpl = new BlueprintAuditors();
+        vm.prank(outsider);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, outsider, GOV_ROLE)
+        );
+        auditors.upgradeToAndCall(address(newImpl), "");
+    }
+
+    function test_upgrade_revertWhen_callerIsAdmin_butNotGovernor() public {
+        // Admin holds DEFAULT_ADMIN_ROLE only; upgrades require GOVERNANCE_ROLE.
+        BlueprintAuditors newImpl = new BlueprintAuditors();
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, GOV_ROLE)
+        );
+        auditors.upgradeToAndCall(address(newImpl), "");
+    }
+
+    function test_upgrade_revertWhen_callerIsFirstPartyAdmin() public {
+        BlueprintAuditors newImpl = new BlueprintAuditors();
+        vm.prank(firstPartyAdmin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, firstPartyAdmin, GOV_ROLE)
+        );
+        auditors.upgradeToAndCall(address(newImpl), "");
+    }
+
+    function test_upgrade_happyPath_governorCanUpgrade() public {
+        BlueprintAuditors newImpl = new BlueprintAuditors();
+        // Set up data before upgrade so we can verify storage continuity.
+        vm.prank(governor);
+        auditors.admitAuditor(auditor1, _admitData("Acme", 500, BlueprintAuditors.AuditorTier.INDEPENDENT));
+
+        vm.prank(governor);
+        auditors.upgradeToAndCall(address(newImpl), "");
+
+        // Data preserved across upgrade.
+        assertEq(auditors.getAuditor(auditor1).weight, 500);
+        assertEq(auditors.auditorCount(), 1);
+        assertTrue(auditors.isActiveAuditor(auditor1));
+    }
+}

--- a/test/mocks/MockBinaryHookBSM.sol
+++ b/test/mocks/MockBinaryHookBSM.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BlueprintServiceManagerBase } from "../../src/BlueprintServiceManagerBase.sol";
+import { Types } from "../../src/libraries/Types.sol";
+
+/// @title MockBinaryHookBSM
+/// @notice Test BSM that records every binary-version hook invocation so tests
+///         can assert msg.sender identity and call ordering.
+/// @dev Inherits `onlyFromTangle` enforcement from the base - this is the same
+///      modifier production BSMs use. Tests pin their assertions to that.
+contract MockBinaryHookBSM is BlueprintServiceManagerBase {
+    struct PublishCall {
+        uint64 blueprintId;
+        uint64 versionId;
+        bytes32 sha256Hash;
+        string binaryUri;
+        bytes32 attestationHash;
+        address senderAtCall;
+    }
+
+    struct AckCall {
+        uint64 serviceId;
+        uint64 versionId;
+        address operator;
+        address senderAtCall;
+    }
+
+    PublishCall[] private _publishCalls;
+    AckCall[] private _ackCalls;
+
+    /// @notice When set, `onBinaryVersionPublished` reverts. Used to assert the
+    ///         hook's revert does NOT roll back the on-chain version row.
+    bool public revertOnPublish;
+    /// @notice When set, `onBinaryVersionPublished` reverts only if attestationHash is zero.
+    bool public requireAttestation;
+    /// @notice When set, `onOperatorBinaryAcked` reverts.
+    bool public revertOnAck;
+    /// @notice Custom revert message for revert-tracking.
+    string public revertReason = "MockBinaryHookBSM: forced revert";
+
+    function setRevertOnPublish(bool v) external {
+        revertOnPublish = v;
+    }
+
+    function setRequireAttestation(bool v) external {
+        requireAttestation = v;
+    }
+
+    function setRevertOnAck(bool v) external {
+        revertOnAck = v;
+    }
+
+    function publishCallCount() external view returns (uint256) {
+        return _publishCalls.length;
+    }
+
+    function ackCallCount() external view returns (uint256) {
+        return _ackCalls.length;
+    }
+
+    function publishCallAt(uint256 i) external view returns (PublishCall memory) {
+        return _publishCalls[i];
+    }
+
+    function ackCallAt(uint256 i) external view returns (AckCall memory) {
+        return _ackCalls[i];
+    }
+
+    function onBinaryVersionPublished(
+        uint64 blueprintId,
+        Types.BinaryVersion calldata version
+    )
+        external
+        override
+        onlyFromTangle
+    {
+        if (revertOnPublish || (requireAttestation && version.attestationHash == bytes32(0))) {
+            revert(revertReason);
+        }
+        _publishCalls.push(
+            PublishCall({
+                blueprintId: blueprintId,
+                versionId: version.versionId,
+                sha256Hash: version.sha256Hash,
+                binaryUri: version.binaryUri,
+                attestationHash: version.attestationHash,
+                senderAtCall: msg.sender
+            })
+        );
+    }
+
+    function onOperatorBinaryAcked(
+        uint64 serviceId,
+        uint64 versionId,
+        address operator
+    )
+        external
+        override
+        onlyFromTangle
+    {
+        if (revertOnAck) {
+            revert(revertReason);
+        }
+        _ackCalls.push(
+            AckCall({ serviceId: serviceId, versionId: versionId, operator: operator, senderAtCall: msg.sender })
+        );
+    }
+}

--- a/test/scenario/UpgradeFlow.t.sol
+++ b/test/scenario/UpgradeFlow.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { UpgradeFlowHarness } from "../support/UpgradeFlowHarness.sol";
+import { MockBinaryHookBSM } from "../mocks/MockBinaryHookBSM.sol";
+import { Types } from "../../src/libraries/Types.sol";
+import { Errors } from "../../src/libraries/Errors.sol";
+
+/// @title UpgradeFlowScenarioTest
+/// @notice End-to-end scenario coverage for the binary-version upgrade flow.
+///         These tests assemble realistic sequences (publish → activate → ack,
+///         deprecate → rollback, BSM-gated publish) to surface integration bugs
+///         that single-mixin tests miss.
+contract UpgradeFlowScenarioTest is UpgradeFlowHarness {
+    bytes32 internal constant HASH_V0 = bytes32(uint256(0x11));
+    bytes32 internal constant HASH_V1 = bytes32(uint256(0x22));
+    bytes32 internal constant HASH_V2 = bytes32(uint256(0x33));
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 1. GENESIS FLOW
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_genesis_allPoliciesResolveToV0() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.prank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+
+        // Default APPROVE.
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+
+        // AUTO without setActive → genesis.
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+
+        // MANUAL → genesis.
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.MANUAL);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 2. AUTO UPGRADE - owner publishes new version, AUTO services follow
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_AUTO_upgradeFollowsActiveVersionImmediately() public {
+        (uint64 bp, uint64 sidAuto) = _createServiceWithSingleOperator(developer, operator1, address(0));
+
+        // Second service on the same blueprint with APPROVE policy; third with MANUAL.
+        _registerOperator(operator2);
+        _registerForBlueprint(operator2, bp);
+        uint64 reqId2 = _requestService(user2, bp, operator2);
+        _approveService(operator2, reqId2);
+        uint64 sidApprove = tangle.serviceCount() - 1;
+
+        _registerOperator(operator3);
+        _registerForBlueprint(operator3, bp);
+        uint64 reqId3 = _requestService(user1, bp, operator3);
+        _approveService(operator3, reqId3);
+        uint64 sidManual = tangle.serviceCount() - 1;
+
+        // Two versions live.
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sidAuto, Types.UpgradePolicy.AUTO);
+        vm.prank(operator3);
+        versions.setServiceUpgradePolicy(sidManual, Types.UpgradePolicy.MANUAL);
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 1);
+
+        assertEq(versions.effectiveBinaryVersion(sidAuto).versionId, 1, "AUTO follows owner");
+        assertEq(versions.effectiveBinaryVersion(sidApprove).versionId, 0, "APPROVE waits for ack");
+        assertEq(versions.effectiveBinaryVersion(sidManual).versionId, 0, "MANUAL pinned");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 3. APPROVE FLOW - operator opts in via ack
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_APPROVE_operatorAckPromotesEffectiveVersion() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        vm.stopPrank();
+
+        // APPROVE is the default; explicit set here for documentation.
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.APPROVE);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 4. AUTO ROLLBACK - owner rolls back from v2 → v0
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_AUTO_rollbackFromV2ToV0Allowed() public {
+        // Documented behaviour: blueprint owner can re-point AUTO at an earlier
+        // version. Off-chain UI is expected to warn against rolling onto a
+        // deprecated row, but the protocol does NOT block it.
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V2, "ipfs://v2", bytes32(0));
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 2);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 2);
+
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 0);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0, "rolled back to genesis");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 5. DEPRECATION + ACK STICKINESS
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_deprecation_ackStickinessAndReAckBlocked() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+
+        vm.prank(developer);
+        versions.deprecateBinaryVersion(bp, 1);
+
+        // Effective version stays at the deprecated row - the operator is on a
+        // build that the owner has flagged obsolete, but did not migrate from.
+        Types.BinaryVersion memory eff = versions.effectiveBinaryVersion(sid);
+        assertEq(eff.versionId, 1);
+        assertTrue(eff.deprecated);
+
+        // Re-acking the deprecated version fails - that's the one-way guard.
+        vm.prank(operator1);
+        vm.expectRevert(Errors.VersionDeprecatedCannotAck.selector);
+        versions.ackBinaryVersion(sid, 1);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 6. MULTI-OPERATOR SERVICE - ack is per-service, not per-operator
+    // ═══════════════════════════════════════════════════════════════════════════
+    //
+    // CURRENT DESIGN NOTE: `_serviceAckedVersionId[serviceId]` is a single uint64
+    // per service. Any active operator of the service may overwrite the ack with
+    // a different version. The behaviour is locked in below so a future change
+    // to per-operator ack semantics surfaces as a test diff rather than a silent
+    // regression. Discussion of whether per-service is the right shape is out of
+    // scope for this branch.
+
+    function test_scenario_multiOperator_lastAckWinsPerService() public {
+        _registerOperator(operator1);
+        _registerOperator(operator2);
+        uint64 bp = _createBlueprint(developer);
+        _registerForBlueprint(operator1, bp);
+        _registerForBlueprint(operator2, bp);
+
+        // Build a Dynamic blueprint membership so we can have 2 operators.
+        address[] memory ops = new address[](2);
+        ops[0] = operator1;
+        ops[1] = operator2;
+        address[] memory callers = new address[](0);
+
+        vm.prank(user1);
+        uint64 reqId = tangle.requestService(bp, ops, "", callers, 0, address(0), 0, Types.ConfidentialityPolicy.Any);
+        _approveService(operator1, reqId);
+        _approveService(operator2, reqId);
+        uint64 sid = tangle.serviceCount() - 1;
+
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V2, "ipfs://v2", bytes32(0));
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 1);
+
+        // op2 can clobber the ack - currently the design choice.
+        vm.prank(operator2);
+        versions.ackBinaryVersion(sid, 2);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 2, "ack is per-service: latest wins");
+
+        // op1 can clobber back the other way.
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 0);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 7. BSM GATE - custom BSM rejects publishes without attestation
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_BSMGate_revertingBSMDoesNotRollBackPublish() public {
+        MockBinaryHookBSM bsm = new MockBinaryHookBSM();
+        bsm.setRequireAttestation(true);
+        uint64 bp = _createBlueprint(developer, address(bsm));
+
+        // Publish v0 without attestation - BSM reverts, but the row is still
+        // persisted (documented design).
+        vm.prank(developer);
+        uint64 vid0 = versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        assertEq(vid0, 0);
+        assertEq(versions.getBinaryVersionCount(bp), 1);
+        assertEq(bsm.publishCallCount(), 0, "BSM rejected publish");
+
+        // Publish v1 with attestation - BSM passes; both rows now present.
+        vm.prank(developer);
+        uint64 vid1 = versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(uint256(0xAA)));
+        assertEq(vid1, 1);
+        assertEq(versions.getBinaryVersionCount(bp), 2);
+        assertEq(bsm.publishCallCount(), 1, "BSM recorded v1");
+
+        // The recorded call has Tangle as msg.sender (not the MBSM).
+        assertEq(bsm.publishCallAt(0).senderAtCall, address(tangleProxy));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 8. ACK on AUTO is harmless but persisted (cross-policy mutation)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_ackUnderAUTODoesNotChangeResolution_butSwitchToAPPROVERevealsIt() public {
+        (uint64 bp, uint64 sid) = _createServiceWithSingleOperator(developer, operator1, address(0));
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V2, "ipfs://v2", bytes32(0));
+        vm.stopPrank();
+
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.AUTO);
+        vm.prank(developer);
+        versions.setActiveBinaryVersion(bp, 2);
+
+        // Under AUTO the ack is moot - effective stays at active=2 even after op acks v1.
+        vm.prank(operator1);
+        versions.ackBinaryVersion(sid, 1);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 2);
+
+        // Switching to APPROVE reveals the persisted ack.
+        vm.prank(operator1);
+        versions.setServiceUpgradePolicy(sid, Types.UpgradePolicy.APPROVE);
+        assertEq(versions.effectiveBinaryVersion(sid).versionId, 1, "ack from AUTO phase now governs");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // 9. DEPRECATE-THEN-PUBLISH - counts stay monotonic
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    function test_scenario_deprecatedRowsDoNotBlockFuturePublishes() public {
+        uint64 bp = _createBlueprint(developer);
+        vm.startPrank(developer);
+        versions.publishBinaryVersion(bp, HASH_V0, "ipfs://v0", bytes32(0));
+        versions.publishBinaryVersion(bp, HASH_V1, "ipfs://v1", bytes32(0));
+        versions.deprecateBinaryVersion(bp, 0);
+        uint64 vid = versions.publishBinaryVersion(bp, HASH_V2, "ipfs://v2", bytes32(0));
+        vm.stopPrank();
+
+        assertEq(vid, 2, "new publishes still get sequential ids");
+        assertEq(versions.getBinaryVersionCount(bp), 3);
+        assertTrue(versions.getBinaryVersion(bp, 0).deprecated);
+        assertFalse(versions.getBinaryVersion(bp, 1).deprecated);
+        assertFalse(versions.getBinaryVersion(bp, 2).deprecated);
+    }
+}

--- a/test/support/UpgradeFlowHarness.sol
+++ b/test/support/UpgradeFlowHarness.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BaseTest } from "../BaseTest.sol";
+import { Tangle } from "../../src/Tangle.sol";
+import { TangleBlueprintsBinaryVersionsFacet } from "../../src/facets/tangle/TangleBlueprintsBinaryVersionsFacet.sol";
+import {
+    TangleBlueprintsBinaryAttestationsFacet
+} from "../../src/facets/tangle/TangleBlueprintsBinaryAttestationsFacet.sol";
+import { BlueprintsBinaryVersions } from "../../src/core/BlueprintsBinaryVersions.sol";
+import { BlueprintsBinaryAttestations } from "../../src/core/BlueprintsBinaryAttestations.sol";
+
+/// @title UpgradeFlowHarness
+/// @notice BaseTest extension that wires the upgrade-flow facets (binary versions,
+///         attestations) into the Tangle router and exposes typed handles so each
+///         test contract avoids casting to the proxy explicitly.
+/// @dev BaseTest does not register the new facets because they are an additive
+///      surface introduced on `feat/blueprint-binary-versions`. The unified
+///      deploy script does register them; this harness mirrors that registration
+///      for unit tests so behaviour matches production routing exactly.
+abstract contract UpgradeFlowHarness is BaseTest {
+    BlueprintsBinaryVersions internal versions;
+    BlueprintsBinaryAttestations internal attestations;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        Tangle router = Tangle(payable(address(tangleProxy)));
+        vm.startPrank(admin);
+        router.registerFacet(address(new TangleBlueprintsBinaryVersionsFacet()));
+        router.registerFacet(address(new TangleBlueprintsBinaryAttestationsFacet()));
+        vm.stopPrank();
+
+        // The proxy dispatches via fallback; cast it to the binary-flow facets so
+        // tests can call publishBinaryVersion / attestBinaryVersion directly.
+        versions = BlueprintsBinaryVersions(payable(address(tangleProxy)));
+        attestations = BlueprintsBinaryAttestations(payable(address(tangleProxy)));
+    }
+
+    /// @notice Register an operator with staking and create a fixed service with
+    ///         a single approved operator, returning the blueprintId and serviceId.
+    function _createServiceWithSingleOperator(
+        address owner,
+        address operator,
+        address manager
+    )
+        internal
+        returns (uint64 blueprintId, uint64 serviceId)
+    {
+        _registerOperator(operator);
+        blueprintId = _createBlueprint(owner, manager);
+
+        _registerForBlueprint(operator, blueprintId);
+        uint64 requestId = _requestService(user1, blueprintId, operator);
+        _approveService(operator, requestId);
+        serviceId = tangle.serviceCount() - 1;
+    }
+}


### PR DESCRIPTION
**Status: DRAFT** — opened so CI starts. Will mark ready once the in-flight security audit, Foundry tests, off-chain integration, CLI commands, dapp UI, and dev docs land on the branch.

## What ships in this PR

Three new Solidity contracts + integration wiring for a versioned binary upgrade flow with permissionless audit attestations and governance-curated auditor identity:

| Contract | Lines | Purpose |
|---|---|---|
| `src/core/BlueprintsBinaryVersions.sol` | 263 | Append-only version registry per blueprint; per-service `UpgradePolicy {APPROVE,AUTO,MANUAL}`; operator ack |
| `src/core/BlueprintsBinaryAttestations.sol` | 160 | Permissionless attestations (`AUDIT/FUZZ/FORMAL/BUG_BOUNTY/SELF`); revoke-by-attester |
| `src/governance/BlueprintAuditors.sol` | 270 | UUPS-upgradeable auditor registry; `GOVERNANCE_ROLE` (TangleTimelock) admits/removes/weights; `FIRST_PARTY_ADMIN_ROLE` fast-tracks FIRST_PARTY tier only |

Plus two facet wrappers, 4 new `Types`, 13 new errors, 5 new storage slots (`__gap` 50→34), 2 new BSM hooks on `IBlueprintServiceManager` with no-op defaults on `BlueprintServiceManagerBase`, MBSM indexer-event plumbing, and `DeployContractsOnly.s.sol` registers the facets + deploys `BlueprintAuditors` as a UUPS proxy.

## Trust model

- **Publisher** = `blueprint.owner`. Publishes versions, marks active, deprecates.
- **Operator** = active operator of a service. Sets `UpgradePolicy`, acks specific versions under APPROVE.
- **Attester** = anyone. Permissionless `attestBinaryVersion`. Revoke is attester-only.
- **Auditor identity / weight** = curated by Tangle governance. Anyone can attest, but only attesters in the on-chain `BlueprintAuditors` registry receive a logo + weight in the dapp's trust-score computation. Composite score is dapp-side; nothing in protocol consensus depends on it.

## Resolution semantics

`effectiveBinaryVersion(serviceId)`:
- `AUTO`    → version[activeVersionId]
- `APPROVE` → version[ackedVersionId] when `> 0`, otherwise version[0] (genesis until opt-in)
- `MANUAL`  → version[0] (pinned to genesis)

Default policy is `APPROVE` (enum 0). A new operator joining a service does not get auto-upgraded — they must opt into `AUTO` or explicitly ack.

Append-only. Deprecation is a one-way flag; existing acks of a later-deprecated version remain readable (ack stickiness) so a running service doesn't get yanked out from under itself.

## BSM dispatch shape

Spec said "MBSM forwards to per-blueprint BSM under try/catch." That would have broken the BSM's `onlyFromTangle` modifier. The actual dispatch is split:

1. Per-blueprint BSM hook (`onBinaryVersionPublished`, `onOperatorBinaryAcked`) → dispatched directly by the version mixin via the existing `_tryCallManager` path so `msg.sender == Tangle` on the BSM side.
2. MBSM → gets a separate indexer-only notification. NOT a forwarder.

Same shape as `BlueprintsCreate.sol`. No surprise to anyone reading existing code.

## Sizes (no-optimizer)

| Contract | Runtime | Margin to EIP-170 |
|---|---|---|
| Tangle | 16,627 | 7,949 |
| TangleBlueprintsBinaryVersionsFacet | 15,848 | 8,728 |
| TangleBlueprintsBinaryAttestationsFacet | 14,575 | 10,001 |
| BlueprintAuditors | 7,838 | 16,738 |

All comfortable. Optimizer will shrink further.

## What's still landing on this branch

- Comprehensive Foundry tests — resolution matrix, BSM hook identity, hook-revert isolation, auditor governance, storage layout regression
- Off-chain integration in `blueprint-manager` (separate repo) — event watcher, sha256-verify-then-swap pipeline, local RPC for ack/status
- `cargo-tangle` CLI commands (separate repo) — `publish-version`, `ack-version`, `set-policy`, `attest`, `trust-score`
- Dapp UI (separate repo) — version timeline + attestation badges + trust-score gauge + publisher/operator/attester forms
- `deploy/register-blueprints.sh` extension to publish v0 through the new flow + dev guide `docs/UPGRADING_BLUEPRINTS.md`
- Critical security audit findings addressed

## Open question for the reviewer

`_serviceAckedVersionId[serviceId]` is one value per service — any active operator can write it. This is a deliberate design choice: a service runs one binary at a time across all its operators. But it does mean operator A can override operator B's ack mid-flight. Worth a brief discussion before unfreezing the design.