### PR TITLE
feat(deploy): role-migration script + on-chain blueprint-binary publish CI

### DIFF
--- a/.github/workflows/publish-blueprint-binary.yml
+++ b/.github/workflows/publish-blueprint-binary.yml
@@ -1,0 +1,89 @@
+# Publish a blueprint's released operator binary ON-CHAIN.
+#
+# The per-blueprint repos build + host their binary as a GitHub Release asset
+# (their own release.yml — free, no secrets). This workflow is the privileged
+# half: it takes a published release and records the version on Tangle via
+# publishBinaryVersion. The owner key lives ONLY here (tnt-core secrets), never
+# in the blueprint repos.
+#
+# Manual trigger — pick the blueprint repo, its release tag, and the on-chain
+# blueprint id (from deployments/<network>/blueprints.tsv).
+name: Publish blueprint binary (on-chain)
+
+on:
+  workflow_dispatch:
+    inputs:
+      blueprint_repo:
+        description: 'owner/repo of the blueprint (e.g. tangle-network/llm-inference-blueprint)'
+        required: true
+      tag:
+        description: 'Release tag in that repo (e.g. v0.1.0)'
+        required: true
+      blueprint_id:
+        description: 'On-chain blueprint id (see blueprints.tsv)'
+        required: true
+      network:
+        description: 'Deployment network (matches deployments/<network>/latest.json)'
+        required: true
+        default: 'base-sepolia'
+      target:
+        description: 'Release target triple to publish'
+        required: true
+        default: 'x86_64-unknown-linux-gnu'
+      set_active:
+        description: 'Set this version active after publishing'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry (cast)
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Resolve Tangle core address from the deployment manifest
+        id: addr
+        run: |
+          MANIFEST="deployments/${{ inputs.network }}/latest.json"
+          test -f "$MANIFEST" || { echo "::error::no manifest at $MANIFEST"; exit 1; }
+          TANGLE=$(jq -er '.tangle' "$MANIFEST")
+          echo "tangle=$TANGLE" >> "$GITHUB_OUTPUT"
+          echo "Tangle core ($MANIFEST): $TANGLE"
+
+      - name: Download the released binary asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REPO='${{ inputs.blueprint_repo }}'
+          TAG='${{ inputs.tag }}'
+          TRIPLE='${{ inputs.target }}'
+          # release.yml names assets "<binary>-<triple>.tar.xz". Match by triple
+          # so we don't need to know each repo's binary name here.
+          ASSET=$(gh release view "$TAG" --repo "$REPO" --json assets \
+            --jq ".assets[] | select(.name | endswith(\"${TRIPLE}.tar.xz\")) | .name" | head -1)
+          test -n "$ASSET" || { echo "::error::no asset for $TRIPLE on $REPO@$TAG"; exit 1; }
+          gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir dl
+          tar -xJf "dl/$ASSET" -C dl
+          BIN=$(find dl -maxdepth 1 -type f ! -name '*.tar.xz' | head -1)
+          test -n "$BIN" || { echo "::error::archive had no binary"; exit 1; }
+          echo "BINARY_PATH=$BIN" >> "$GITHUB_ENV"
+          echo "BINARY_URI=https://github.com/$REPO/releases/download/$TAG/$ASSET" >> "$GITHUB_ENV"
+          echo "Asset: $ASSET"
+
+      - name: Publish version on-chain
+        env:
+          TANGLE_CORE: ${{ steps.addr.outputs.tangle }}
+          RPC_URL: ${{ secrets.PUBLISH_RPC_URL }}
+          PRIVATE_KEY: ${{ secrets.BLUEPRINT_OWNER_KEY }}
+          BLUEPRINT_ID: ${{ inputs.blueprint_id }}
+          SET_ACTIVE: ${{ inputs.set_active }}
+        run: |
+          test -n "$RPC_URL" || { echo "::error::set the PUBLISH_RPC_URL secret"; exit 1; }
+          test -n "$PRIVATE_KEY" || { echo "::error::set the BLUEPRINT_OWNER_KEY secret"; exit 1; }
+          bash deploy/publish-binary.sh

--- a/deploy/config/role-migration.base-sepolia.example.json
+++ b/deploy/config/role-migration.base-sepolia.example.json
@@ -1,0 +1,13 @@
+{
+  "network": "base-sepolia",
+  "contracts": {
+    "tangle": "0x8299d60f373f3a4a8c4878e335cb9d840e6e3730",
+    "staking": "0x91b1186f4f31d6e02e481c0af29c7244a3fe417d",
+    "tntToken": "0x62b3407a22e50183b1055e54d70ee21f59bf865b"
+  },
+  "currentAdmin": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "timelock": "0x0000000000000000000000000000000000000000",
+  "multisig": "0x0000000000000000000000000000000000000000",
+  "revokeCurrentAdmin": true,
+  "dryRun": true
+}

--- a/deploy/publish-binary.sh
+++ b/deploy/publish-binary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Publish ONE blueprint's operator binary version on-chain.
+#
+# Closes the `no_v0_published` gap: a blueprint can be registered yet have no
+# runnable binary, so no operator can serve it. This records the version
+# (sha256 + content-addressed URI) via Tangle.publishBinaryVersion and, by
+# default, makes it the active version so AUTO services adopt it immediately.
+#
+# Append-only + idempotent: if the blueprint already has >=1 published version,
+# this is a no-op (bump new releases with `cargo tangle blueprint publish-version`).
+#
+# publishBinaryVersion requires msg.sender == blueprint owner, so PRIVATE_KEY
+# must be the owner key (kept in ONE place — tnt-core CI secrets — never spread
+# across the per-blueprint repos, which only build + host the artifact).
+#
+# Required env:
+#   TANGLE_CORE     — Tangle core proxy address
+#   RPC_URL         — chain RPC
+#   PRIVATE_KEY     — blueprint owner key (0x-prefixed)
+#   BLUEPRINT_ID    — uint64 on-chain blueprint id
+#   BINARY_PATH     — local path to the artifact (used to compute sha256)
+#   BINARY_URI      — content-addressed pointer operators fetch (https:// or ipfs://)
+# Optional env:
+#   ATTESTATION     — bytes32 attestation digest (default 0x0…0)
+#   SET_ACTIVE      — "true" (default) to call setActiveBinaryVersion after publish
+set -euo pipefail
+
+: "${TANGLE_CORE:?set TANGLE_CORE}"
+: "${RPC_URL:?set RPC_URL}"
+: "${PRIVATE_KEY:?set PRIVATE_KEY}"
+: "${BLUEPRINT_ID:?set BLUEPRINT_ID}"
+: "${BINARY_PATH:?set BINARY_PATH}"
+: "${BINARY_URI:?set BINARY_URI}"
+ATTESTATION="${ATTESTATION:-0x0000000000000000000000000000000000000000000000000000000000000000}"
+SET_ACTIVE="${SET_ACTIVE:-true}"
+
+[ -f "$BINARY_PATH" ] || { echo "ERROR: BINARY_PATH not found: $BINARY_PATH" >&2; exit 1; }
+
+echo "== publish-binary =="
+echo "  blueprint:   $BLUEPRINT_ID"
+echo "  tangle:      $TANGLE_CORE"
+echo "  artifact:    $BINARY_PATH"
+echo "  uri:         $BINARY_URI"
+
+# Append-only guard: never double-publish a genesis version.
+count="$(cast call "$TANGLE_CORE" 'getBinaryVersionCount(uint64)(uint64)' "$BLUEPRINT_ID" --rpc-url "$RPC_URL" 2>/dev/null || echo 0)"
+count="${count%% *}" # cast may suffix the decoded type
+if [ -n "$count" ] && [ "$count" != "0" ]; then
+    echo "  already has $count published version(s) — skipping (bump via cargo tangle)."
+    exit 0
+fi
+
+# sha256 of the exact artifact operators will download from BINARY_URI.
+if command -v sha256sum >/dev/null 2>&1; then
+    digest="$(sha256sum "$BINARY_PATH" | awk '{print $1}')"
+else
+    digest="$(shasum -a 256 "$BINARY_PATH" | awk '{print $1}')"
+fi
+sha256="0x${digest}"
+echo "  sha256:      $sha256"
+
+echo "  -> publishBinaryVersion"
+cast send "$TANGLE_CORE" \
+    'publishBinaryVersion(uint64,bytes32,string,bytes32)' \
+    "$BLUEPRINT_ID" "$sha256" "$BINARY_URI" "$ATTESTATION" \
+    --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" >/dev/null
+
+new_count="$(cast call "$TANGLE_CORE" 'getBinaryVersionCount(uint64)(uint64)' "$BLUEPRINT_ID" --rpc-url "$RPC_URL")"
+new_count="${new_count%% *}"
+version_id=$(( new_count - 1 ))
+echo "  published version_id=$version_id"
+
+if [ "$SET_ACTIVE" = "true" ]; then
+    echo "  -> setActiveBinaryVersion($BLUEPRINT_ID, $version_id)"
+    cast send "$TANGLE_CORE" \
+        'setActiveBinaryVersion(uint64,uint64)' \
+        "$BLUEPRINT_ID" "$version_id" \
+        --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" >/dev/null
+    echo "  active version set."
+fi
+
+echo "  done: blueprint $BLUEPRINT_ID -> v$version_id ($sha256)"

--- a/script/MigrateRoles.s.sol
+++ b/script/MigrateRoles.s.sol
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+/// Minimal AccessControl surface — works against any OZ AccessControl proxy.
+interface IAccessControl {
+    function hasRole(bytes32 role, address account) external view returns (bool);
+    function grantRole(bytes32 role, address account) external;
+    function renounceRole(bytes32 role, address account) external;
+}
+
+/// @title MigrateRoles
+/// @notice Standalone, config-driven handoff of privileged roles from a single
+///         bootstrap admin (the deployer EOA) to a timelock + multisig, for
+///         contracts that are ALREADY deployed. This is the operation the
+///         genesis deploy documents but defers (see Base.sol H-5): on
+///         Base Sepolia every role currently sits on one EOA.
+///
+/// Design goals:
+///   - **Configurable**: all addresses + the revoke toggle come from a JSON
+///     config (no recompile to retarget). Per-role destinations are encoded in
+///     one readable table (`_plan`), the single source of truth for the split.
+///   - **Safe**: grants happen before revokes; `DEFAULT_ADMIN_ROLE` is the LAST
+///     thing renounced on each contract (never strand a contract admin-less);
+///     a role is only renounced from the bootstrap admin once a *new* holder
+///     has been granted, and never when the new holder IS the bootstrap admin.
+///   - **Idempotent**: grant/renounce are no-ops when already in the target
+///     state (guarded by `hasRole`), so re-running converges.
+///   - **Auditable**: `dryRun` prints the full plan + current on-chain holders
+///     without sending a single transaction.
+///
+/// Usage:
+///   export PRIVATE_KEY=0x...                 # MUST be the currentAdmin EOA
+///   export MIGRATE_ROLES_CONFIG=deploy/config/role-migration.base-sepolia.json
+///   # dry run (no broadcast needed — prints plan + current holders):
+///   forge script script/MigrateRoles.s.sol:MigrateRoles --rpc-url $RPC_URL
+///   # execute:
+///   forge script script/MigrateRoles.s.sol:MigrateRoles --rpc-url $RPC_URL --broadcast
+contract MigrateRoles is Script {
+    // OZ AccessControl role ids. DEFAULT_ADMIN_ROLE is bytes32(0); the rest are
+    // keccak256 of the role name (identical to the contracts' `public constant`s).
+    bytes32 internal constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 internal constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 internal constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 internal constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 internal constant SLASH_ADMIN_ROLE = keccak256("SLASH_ADMIN_ROLE");
+    bytes32 internal constant ASSET_MANAGER_ROLE = keccak256("ASSET_MANAGER_ROLE");
+    bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    struct Config {
+        string network;
+        address tangle;
+        address staking;
+        address tntToken;
+        address currentAdmin; // the single EOA holding everything today
+        address timelock; // destination for governance/upgrade authority
+        address multisig; // destination for operational authority (pause/slash/assets)
+        bool revokeCurrentAdmin; // when false: grant-only (dual-control), keep EOA
+        bool dryRun; // when true: print plan only, never broadcast
+    }
+
+    // One row of the migration plan: on `target`, move `role` to `newHolder`.
+    struct Move {
+        address target;
+        string contractName;
+        bytes32 role;
+        string roleName;
+        address newHolder;
+        bool isDefaultAdmin; // renounced last, per contract
+    }
+
+    function run() external {
+        Config memory cfg = _loadConfig();
+        uint256 adminKey = vm.envUint("PRIVATE_KEY");
+        address broadcaster = vm.addr(adminKey);
+
+        _printHeader(cfg, broadcaster);
+
+        // Only the current admin can grant/renounce. Refuse to run otherwise so
+        // a wrong key produces a clear error instead of a pile of reverts.
+        require(
+            broadcaster == cfg.currentAdmin,
+            "PRIVATE_KEY must be the currentAdmin EOA from the config"
+        );
+
+        Move[] memory plan = _plan(cfg);
+        _printPlan(cfg, plan);
+
+        if (cfg.dryRun) {
+            console2.log("\n[dry-run] no transactions sent. Set dryRun=false to execute.");
+            return;
+        }
+
+        vm.startBroadcast(adminKey);
+        // 1. Grant every destination first — the new holders must exist before
+        //    we drop the bootstrap admin, or a revoke could strand a role.
+        for (uint256 i = 0; i < plan.length; i++) {
+            _grant(plan[i]);
+        }
+        // 2. Renounce the bootstrap admin from non-DEFAULT_ADMIN roles.
+        if (cfg.revokeCurrentAdmin) {
+            for (uint256 i = 0; i < plan.length; i++) {
+                if (!plan[i].isDefaultAdmin) _renounce(plan[i], cfg.currentAdmin);
+            }
+            // 3. Renounce DEFAULT_ADMIN_ROLE LAST (after every other role on
+            //    that contract is already in its new home).
+            for (uint256 i = 0; i < plan.length; i++) {
+                if (plan[i].isDefaultAdmin) _renounce(plan[i], cfg.currentAdmin);
+            }
+        }
+        vm.stopBroadcast();
+
+        _verify(cfg, plan);
+        console2.log("\nMigration complete.");
+    }
+
+    // ── Plan: the single, readable source of truth for the role split ────────
+    //
+    // timelock = governance + upgrade authority (slow, on-chain reviewable).
+    // multisig = operational authority (pause, slash, asset management).
+    function _plan(Config memory cfg) internal pure returns (Move[] memory) {
+        Move[] memory m = new Move[](11);
+        uint256 n;
+
+        if (cfg.tangle != address(0)) {
+            m[n++] = _move(cfg.tangle, "Tangle", ADMIN_ROLE, "ADMIN_ROLE", cfg.timelock, false);
+            m[n++] = _move(cfg.tangle, "Tangle", UPGRADER_ROLE, "UPGRADER_ROLE", cfg.timelock, false);
+            m[n++] = _move(cfg.tangle, "Tangle", PAUSER_ROLE, "PAUSER_ROLE", cfg.multisig, false);
+            m[n++] = _move(cfg.tangle, "Tangle", SLASH_ADMIN_ROLE, "SLASH_ADMIN_ROLE", cfg.multisig, false);
+            m[n++] = _move(cfg.tangle, "Tangle", DEFAULT_ADMIN_ROLE, "DEFAULT_ADMIN_ROLE", cfg.timelock, true);
+        }
+
+        if (cfg.staking != address(0)) {
+            m[n++] = _move(cfg.staking, "Staking", ADMIN_ROLE, "ADMIN_ROLE", cfg.timelock, false);
+            // NOTE: staking UPGRADER_ROLE — the genesis handoff in FullDeploy
+            // omits this; the EOA holds it on-chain. Included here so the
+            // staking proxy's upgrade authority actually moves to the timelock.
+            m[n++] = _move(cfg.staking, "Staking", UPGRADER_ROLE, "UPGRADER_ROLE", cfg.timelock, false);
+            m[n++] = _move(cfg.staking, "Staking", ASSET_MANAGER_ROLE, "ASSET_MANAGER_ROLE", cfg.multisig, false);
+            m[n++] = _move(cfg.staking, "Staking", DEFAULT_ADMIN_ROLE, "DEFAULT_ADMIN_ROLE", cfg.timelock, true);
+        }
+
+        if (cfg.tntToken != address(0)) {
+            m[n++] = _move(cfg.tntToken, "TntToken", MINTER_ROLE, "MINTER_ROLE", cfg.timelock, false);
+            m[n++] = _move(cfg.tntToken, "TntToken", UPGRADER_ROLE, "UPGRADER_ROLE", cfg.timelock, false);
+            m[n++] = _move(cfg.tntToken, "TntToken", DEFAULT_ADMIN_ROLE, "DEFAULT_ADMIN_ROLE", cfg.timelock, true);
+        }
+
+        // Trim to the populated length.
+        Move[] memory out = new Move[](n);
+        for (uint256 i = 0; i < n; i++) out[i] = m[i];
+        return out;
+    }
+
+    function _move(
+        address target,
+        string memory contractName,
+        bytes32 role,
+        string memory roleName,
+        address newHolder,
+        bool isDefaultAdmin
+    )
+        internal
+        pure
+        returns (Move memory)
+    {
+        return Move(target, contractName, role, roleName, newHolder, isDefaultAdmin);
+    }
+
+    // ── Execution primitives (idempotent + guarded) ─────────────────────────
+
+    function _grant(Move memory mv) internal {
+        if (mv.newHolder == address(0)) return; // no destination configured
+        if (IAccessControl(mv.target).hasRole(mv.role, mv.newHolder)) {
+            _log("  skip grant (already held)", mv, mv.newHolder);
+            return;
+        }
+        IAccessControl(mv.target).grantRole(mv.role, mv.newHolder);
+        _log("  grant", mv, mv.newHolder);
+    }
+
+    function _renounce(Move memory mv, address from) internal {
+        // Never renounce a role that has no new home, or whose new home IS the
+        // account we're renouncing from — that would just strand the role.
+        if (mv.newHolder == address(0) || mv.newHolder == from) return;
+        if (!IAccessControl(mv.target).hasRole(mv.role, from)) return;
+        IAccessControl(mv.target).renounceRole(mv.role, from);
+        _log("  renounce", mv, from);
+    }
+
+    // ── Config loading ──────────────────────────────────────────────────────
+
+    function _loadConfig() internal view returns (Config memory cfg) {
+        string memory path = vm.envString("MIGRATE_ROLES_CONFIG");
+        string memory json = vm.readFile(path);
+        cfg.network = _tryString(json, ".network");
+        cfg.tangle = _tryAddress(json, ".contracts.tangle");
+        cfg.staking = _tryAddress(json, ".contracts.staking");
+        cfg.tntToken = _tryAddress(json, ".contracts.tntToken");
+        cfg.currentAdmin = vm.parseJsonAddress(json, ".currentAdmin");
+        cfg.timelock = _tryAddress(json, ".timelock");
+        cfg.multisig = _tryAddress(json, ".multisig");
+        cfg.revokeCurrentAdmin = vm.parseJsonBool(json, ".revokeCurrentAdmin");
+        cfg.dryRun = _tryBool(json, ".dryRun");
+
+        require(cfg.currentAdmin != address(0), "currentAdmin required");
+        require(cfg.timelock != address(0) || cfg.multisig != address(0), "set timelock and/or multisig");
+        // Don't let a typo'd config quietly hand god-mode back to the EOA.
+        require(cfg.timelock != cfg.currentAdmin, "timelock must differ from currentAdmin");
+        require(cfg.multisig != cfg.currentAdmin, "multisig must differ from currentAdmin");
+    }
+
+    function _tryAddress(string memory json, string memory key) internal view returns (address) {
+        try vm.parseJsonAddress(json, key) returns (address a) {
+            return a;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _tryBool(string memory json, string memory key) internal view returns (bool) {
+        try vm.parseJsonBool(json, key) returns (bool b) {
+            return b;
+        } catch {
+            return false;
+        }
+    }
+
+    function _tryString(string memory json, string memory key) internal view returns (string memory) {
+        try vm.parseJsonString(json, key) returns (string memory s) {
+            return s;
+        } catch {
+            return "";
+        }
+    }
+
+    // ── Logging / verification ───────────────────────────────────────────────
+
+    function _printHeader(Config memory cfg, address broadcaster) internal pure {
+        console2.log("=== Migrate Roles ===");
+        console2.log("Network:", bytes(cfg.network).length == 0 ? "unknown" : cfg.network);
+        console2.log("Broadcaster:", broadcaster);
+        console2.log("Current admin (from):", cfg.currentAdmin);
+        console2.log("Timelock (to):", cfg.timelock);
+        console2.log("Multisig (to):", cfg.multisig);
+        console2.log("Revoke current admin:", cfg.revokeCurrentAdmin);
+        console2.log("Dry run:", cfg.dryRun);
+    }
+
+    function _printPlan(Config memory cfg, Move[] memory plan) internal view {
+        console2.log("\n-- Plan --");
+        for (uint256 i = 0; i < plan.length; i++) {
+            Move memory mv = plan[i];
+            bool held = IAccessControl(mv.target).hasRole(mv.role, cfg.currentAdmin);
+            console2.log(
+                string.concat(
+                    mv.contractName,
+                    ".",
+                    mv.roleName,
+                    held ? " [EOA holds]" : " [EOA absent]"
+                )
+            );
+            console2.log("    -> newHolder:", mv.newHolder);
+        }
+    }
+
+    function _log(string memory action, Move memory mv, address account) internal pure {
+        console2.log(string.concat(action, " ", mv.contractName, ".", mv.roleName));
+        console2.log("      account:", account);
+    }
+
+    /// Post-run assertions: every destination holds its role, and (when
+    /// revoking) the bootstrap admin no longer holds any migrated role.
+    function _verify(Config memory cfg, Move[] memory plan) internal view {
+        console2.log("\n-- Verify --");
+        for (uint256 i = 0; i < plan.length; i++) {
+            Move memory mv = plan[i];
+            if (mv.newHolder != address(0)) {
+                require(
+                    IAccessControl(mv.target).hasRole(mv.role, mv.newHolder),
+                    string.concat("grant failed: ", mv.contractName, ".", mv.roleName)
+                );
+            }
+            if (cfg.revokeCurrentAdmin && mv.newHolder != cfg.currentAdmin) {
+                require(
+                    !IAccessControl(mv.target).hasRole(mv.role, cfg.currentAdmin),
+                    string.concat("renounce failed: ", mv.contractName, ".", mv.roleName)
+                );
+            }
+        }
+        console2.log("  all roles in their target state.");
+    }
+}


### PR DESCRIPTION
Closes two operational gaps on the live deployments.

## 1. Role migration — `script/MigrateRoles.s.sol`
Standalone, config-driven handoff of every privileged role from the single bootstrap EOA to a **timelock + multisig**, for **already-deployed** contracts (the H-5 step `Base.sol` documents but the genesis deploy defers). On Base Sepolia one EOA (`0x2420…`) currently holds `DEFAULT_ADMIN` + `UPGRADER` + `ADMIN` + `PAUSER` + `SLASH_ADMIN` across Tangle, staking, and the TNT token (verified on-chain).

Safety:
- Grants before revokes; `DEFAULT_ADMIN_ROLE` renounced **last** per contract; only renounces a role once a new holder exists, never when the new holder is the EOA; idempotent (`hasRole`-guarded).
- `dryRun` prints the full plan + current holders with **zero transactions**.
- Also migrates **staking `UPGRADER_ROLE`** — which the in-deploy handoff omits (the EOA holds it on-chain).
- Config example prefilled with live Base Sepolia addresses (timelock/multisig left `0x0` for the operator to fill).

```
export PRIVATE_KEY=0x<currentAdmin>
export MIGRATE_ROLES_CONFIG=deploy/config/role-migration.base-sepolia.example.json
forge script script/MigrateRoles.s.sol:MigrateRoles --rpc-url $RPC_URL          # dry-run plan
forge script script/MigrateRoles.s.sol:MigrateRoles --rpc-url $RPC_URL --broadcast
```

## 2. Binary publishing — close `no_v0_published`
Blueprints are registered but have no runnable binary, so no operator can serve them. The per-blueprint repos already build + host their binary as a GitHub Release asset (their own `release.yml`, free, no secrets). This adds the **privileged on-chain half**:
- `deploy/publish-binary.sh` — single-blueprint publisher: sha256 → `publishBinaryVersion` → `setActiveBinaryVersion`; append-only/idempotent.
- `.github/workflows/publish-blueprint-binary.yml` — manual dispatch: pick a blueprint repo + release tag + on-chain id; it downloads the release asset, resolves the Tangle address from the deployment manifest, and records the version. **The blueprint-owner key lives only in tnt-core secrets** (`BLUEPRINT_OWNER_KEY`, `PUBLISH_RPC_URL`) — never spread across the blueprint repos.

## Test plan
- [x] `forge build script/MigrateRoles.s.sol` compiles
- [x] `bash -n deploy/publish-binary.sh` + workflow YAML parse clean
- [ ] dry-run `MigrateRoles` against Base Sepolia (operator sets real timelock/multisig first)
- [ ] dispatch `publish-blueprint-binary` for llm-inference once a v0 tag is cut