### PR TITLE
feat(deploy): record every blueprint variant + per-binary publish

### DIFF
--- a/.github/workflows/publish-blueprint-binary.yml
+++ b/.github/workflows/publish-blueprint-binary.yml
@@ -22,6 +22,10 @@ on:
       blueprint_id:
         description: 'On-chain blueprint id (see blueprints.tsv)'
         required: true
+      binary_name:
+        description: 'Binary to publish (multi-blueprint repos, e.g. trading-instance-blueprint). Leave blank for single-binary repos.'
+        required: false
+        default: ''
       network:
         description: 'Deployment network (matches deployments/<network>/latest.json)'
         required: true
@@ -63,10 +67,13 @@ jobs:
           REPO='${{ inputs.blueprint_repo }}'
           TAG='${{ inputs.tag }}'
           TRIPLE='${{ inputs.target }}'
-          # release.yml names assets "<binary>-<triple>.tar.xz". Match by triple
-          # so we don't need to know each repo's binary name here.
+          BIN='${{ inputs.binary_name }}'
+          # release.yml names assets "<binary>-<triple>.tar.xz". For a
+          # multi-blueprint repo, binary_name disambiguates which one maps to
+          # this blueprint id; otherwise match the single asset by triple.
+          SUFFIX="${BIN:+${BIN}-}${TRIPLE}.tar.xz"
           ASSET=$(gh release view "$TAG" --repo "$REPO" --json assets \
-            --jq ".assets[] | select(.name | endswith(\"${TRIPLE}.tar.xz\")) | .name" | head -1)
+            --jq ".assets[] | select(.name | endswith(\"${SUFFIX}\")) | .name" | head -1)
           test -n "$ASSET" || { echo "::error::no asset for $TRIPLE on $REPO@$TAG"; exit 1; }
           gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir dl
           tar -xJf "dl/$ASSET" -C dl

--- a/deploy/register-blueprints.sh
+++ b/deploy/register-blueprints.sh
@@ -376,20 +376,41 @@ for entry in "${REPOS[@]}"; do
             TSUSD_ADDRESS="$TSUSD_ADDRESS" \
             ./deploy/register-blueprint.sh
     ) > "$log" 2>&1; then
-        bp=$(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+|Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
-        bsm=$(grep -oE 'DEPLOY_[A-Z_]*BSM[A-Z_]*=0x[0-9a-fA-F]{40}|(BSM[A-Za-z]*|BSM proxy)[^=:]*[=:][[:space:]]*0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
-        if [ -n "$bp" ]; then
-            # Globals set by publish_v0_binary: BIN_VERSION_ID, BIN_SHA256,
-            # BIN_URI, BIN_ATTEST, BIN_NOTE. Each defaults to '-' when no v0
-            # publish was attempted.
-            publish_v0_binary "$repo" "$repo_path" "$bp"
-            printf '%s\t%s\t%s\tregistered\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-                "$repo" "$bp" "${bsm:-}" \
-                "$BIN_VERSION_ID" "$BIN_SHA256" "$BIN_URI" "$BIN_ATTEST" "$BIN_NOTE" \
-                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                >> "$DEPLOY_MANIFEST"
-            RESULTS+=("$repo: OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID ($BIN_NOTE)")
-            echo "OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID"
+        # Record EVERY blueprint the repo registered, not just the last id.
+        # Multi-blueprint repos (sandbox, trading) emit several
+        # `DEPLOY_<LABEL>BLUEPRINT_ID=<n>` lines; we write one manifest row per
+        # id and pair each with its same-label BSM (`DEPLOY_<LABEL>BSM=0x…`,
+        # falling back to `DEPLOY_BSM` for the unlabelled main blueprint).
+        mapfile -t _id_lines < <(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+' "$log")
+        if [ "${#_id_lines[@]}" -eq 0 ]; then
+            _single=$(grep -oE 'Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
+            [ -n "$_single" ] && _id_lines=("DEPLOY_BLUEPRINT_ID=$_single")
+        fi
+        if [ "${#_id_lines[@]}" -gt 0 ]; then
+            for _line in "${_id_lines[@]}"; do
+                bp="${_line##*=}"
+                _var="${_line%%=*}"                 # DEPLOY_INSTANCE_BLUEPRINT_ID
+                _label="${_var#DEPLOY_}"            # INSTANCE_BLUEPRINT_ID
+                _label="${_label%BLUEPRINT_ID}"     # INSTANCE_  (or "" for main)
+                _label="${_label%_}"                # INSTANCE   (or "")
+                bsm=""
+                if [ -n "$_label" ]; then
+                    bsm=$(grep -oE "DEPLOY_${_label}_?BSM[A-Z_]*=0x[0-9a-fA-F]{40}" "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
+                fi
+                [ -z "$bsm" ] && bsm=$(grep -oE 'DEPLOY_BSM=0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
+                # Globals set by publish_v0_binary: BIN_VERSION_ID, BIN_SHA256,
+                # BIN_URI, BIN_ATTEST, BIN_NOTE (default '-' / no-publish).
+                publish_v0_binary "$repo" "$repo_path" "$bp"
+                _note="$BIN_NOTE"
+                [ -n "$_label" ] && _note="variant=${_label}; $BIN_NOTE"
+                printf '%s\t%s\t%s\tregistered\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                    "$repo" "$bp" "${bsm:-}" \
+                    "$BIN_VERSION_ID" "$BIN_SHA256" "$BIN_URI" "$BIN_ATTEST" "$_note" \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    >> "$DEPLOY_MANIFEST"
+                RESULTS+=("$repo: OK id=$bp${_label:+ ($_label)} bsm=${bsm:-?}")
+                echo "OK id=$bp${_label:+ variant=$_label} bsm=${bsm:-?} bin=$BIN_VERSION_ID"
+            done
         else
             printf '%s\t-\t-\tunknown_output\t-\t-\t-\t-\t-\t%s\n' \
                 "$repo" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/deployments/base-sepolia/blueprints.tsv
+++ b/deployments/base-sepolia/blueprints.tsv
@@ -1,14 +1,18 @@
 repo	blueprint_id	bsm_address	status	binary_version_id	binary_sha256	binary_uri	binary_attestation	note	timestamp
-llm-inference-blueprint	0	0x6a0EF9695aAFeD077202538048c9b933e5D26475	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:50:19Z
-modal-inference-blueprint	1	0x0346DC54f93011BAD0c8514B4fF92349dC2fB0CF	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:51:04Z
-image-gen-inference-blueprint	2	0x8385F3D078b623779B349Ec8B85208145DaaC78C	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:51:38Z
-training-blueprint	3	0x6ae1bB9d0d0ccCfEb539b16e9E87d47092392DCD	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:52:20Z
-vector-store-blueprint	4	0xab9327E81C332315d6F337836aaebb2e0713ecd9	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:52:56Z
-distributed-inference-blueprint	5	0xBc3340b4C7b8DdcaEF5FAFC0dA967b0067825106	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:53:39Z
-voice-inference-blueprint	6	0x46EdE6E0611CF164D84Cb3b364482C5Ba8B2E9f0	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:54:16Z
-avatar-inference-blueprint	7	0xc15387e7734bAa66405c96fb996893d375A2D824	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:54:52Z
-embedding-inference-blueprint	8	0xe3BaA7a4b7d41261A09f0547F80e9CE5cE3de7DB	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:55:29Z
-video-gen-inference-blueprint	9	0x91E3C8f9a84BBC395eCE8deBf69b032912b81D81	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:56:10Z
-ai-agent-sandbox-blueprint	10	0x281d2D1160d80070eBe8989A529b6732C8403625	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-23T00:50:05Z
-ai-trading-blueprint	-	-	failed_rc_1	-	-	-	-	-	2026-05-23T10:52:50Z
-ai-trading-blueprint	16	0xA21F575dA87143ec82D6d183d4e7Af405E9409A4	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-23T10:55:36Z
+llm-inference-blueprint	0	0x6a0EF9695aAFeD077202538048c9b933e5D26475	registered	-	-	-	-	binary=llm-operator; no_v0_published	2026-05-22T23:50:19Z
+modal-inference-blueprint	1	0x0346DC54f93011BAD0c8514B4fF92349dC2fB0CF	registered	-	-	-	-	binary=modal-operator; no_v0_published	2026-05-22T23:51:04Z
+image-gen-inference-blueprint	2	0x8385F3D078b623779B349Ec8B85208145DaaC78C	registered	-	-	-	-	binary=image-gen-operator; no_v0_published	2026-05-22T23:51:38Z
+training-blueprint	3	0x6ae1bB9d0d0ccCfEb539b16e9E87d47092392DCD	registered	-	-	-	-	binary=training-operator; no_v0_published	2026-05-22T23:52:20Z
+vector-store-blueprint	4	0xab9327E81C332315d6F337836aaebb2e0713ecd9	registered	-	-	-	-	binary=vector-store-operator; no_v0_published	2026-05-22T23:52:56Z
+distributed-inference-blueprint	5	0xBc3340b4C7b8DdcaEF5FAFC0dA967b0067825106	registered	-	-	-	-	binary=distributed-inference-operator; no_v0_published	2026-05-22T23:53:39Z
+voice-inference-blueprint	6	0x46EdE6E0611CF164D84Cb3b364482C5Ba8B2E9f0	registered	-	-	-	-	binary=voice-operator; no_v0_published	2026-05-22T23:54:16Z
+avatar-inference-blueprint	7	0xc15387e7734bAa66405c96fb996893d375A2D824	registered	-	-	-	-	binary=avatar-operator; no_v0_published	2026-05-22T23:54:52Z
+embedding-inference-blueprint	8	0xe3BaA7a4b7d41261A09f0547F80e9CE5cE3de7DB	registered	-	-	-	-	binary=embedding-operator; no_v0_published	2026-05-22T23:55:29Z
+video-gen-inference-blueprint	9	0x91E3C8f9a84BBC395eCE8deBf69b032912b81D81	registered	-	-	-	-	binary=video-gen-operator; no_v0_published	2026-05-22T23:56:10Z
+ai-agent-sandbox-blueprint	10	0x281d2D1160d80070eBe8989A529b6732C8403625	registered	-	-	-	-	variant=sandbox; binary=ai-agent-sandbox-blueprint; no_v0_published	2026-05-23T00:50:05Z
+ai-agent-sandbox-blueprint	11	0xDe25dad1757e5Dab5230d44779d7de6ad8181C5C	registered	-	-	-	-	variant=instance; binary=ai-agent-instance-blueprint; no_v0_published	2026-05-23T00:50:07Z
+ai-agent-sandbox-blueprint	12	0x6D6deBfA88260558597Ad912439Ea1949962b3eb	registered	-	-	-	-	variant=tee-instance; binary=ai-agent-tee-instance-blueprint; no_v0_published	2026-05-23T00:50:09Z
+ai-trading-blueprint	13	0xDaBE0ABeA4325aC2Dd35C1FDED303b7b208Dc12E	registered	-	-	-	-	variant=trading; binary=trading-blueprint; no_v0_published	2026-05-23T10:55:36Z
+ai-trading-blueprint	14	0x055F96d7960ed49a82424289E82166D5D80f429d	registered	-	-	-	-	variant=instance; binary=trading-instance-blueprint; no_v0_published	2026-05-23T10:55:38Z
+ai-trading-blueprint	15	0x54Da89CaBbBa9c477180BDd4f2a7aC4952A16e3a	registered	-	-	-	-	variant=tee-instance; binary=trading-tee-instance-blueprint; no_v0_published	2026-05-23T10:55:40Z
+ai-trading-blueprint	16	0x8F982bbF592066c7037526982D19aC131f4933a9	registered	-	-	-	-	variant=validator; binary=trading-validator; no_v0_published	2026-05-23T10:55:42Z


### PR DESCRIPTION
The multi-blueprint repos register their full set on-chain, but the manifest only captured one id each.

**On-chain truth:** `blueprintCount() = 17`. ai-agent-sandbox registered its trio (ids **10** sandbox / **11** instance / **12** tee-instance); ai-trading its quad (**13** trading / **14** instance / **15** tee-instance / **16** validator). All owned by the deployer — verified via `getBlueprint`.

The sweep's parser used `tail -1`, so `blueprints.tsv` recorded 1 of 3–4 per repo and even **mislabelled trading** (it stored id 16 = the *validator* as the main blueprint; the real `trading-blueprint` is id 13).

## Changes
- **`register-blueprints.sh`** — write one manifest row per emitted `DEPLOY_<LABEL>BLUEPRINT_ID`, pairing each with its same-label BSM. Re-runs now record every variant.
- **`blueprints.tsv`** — rebuilt as the complete 17-row manifest from on-chain data, with the operator **binary name + variant** per row (the bin→id map the publish step needs).
- **`publish-blueprint-binary.yml`** — optional `binary_name` input so a multi-blueprint repo publishes the right binary to the right id.

## Net
Registration was already complete for all 17 (the per-repo scripts deploy all variants). This makes the **manifest** complete + correct and lets the publish workflow target each variant — so once `BLUEPRINT_OWNER_KEY` is set, all 17 can be published (10 singles + 3 sandbox + 4 trading), each to its own id.

## Test plan
- [x] `bash -n register-blueprints.sh` + workflow YAML parse clean
- [x] manifest = 17 rows, ids 0–16, BSMs from on-chain