### PR TITLE
feat(deploy): publish-trading-v0 — one-shot v0 publish for 4 trading blueprints

### DIFF
--- a/.github/workflows/publish-blueprint-binary.yml
+++ b/.github/workflows/publish-blueprint-binary.yml
@@ -22,6 +22,10 @@ on:
       blueprint_id:
         description: 'On-chain blueprint id (see blueprints.tsv)'
         required: true
+      binary_name:
+        description: 'Binary to publish (multi-blueprint repos, e.g. trading-instance-blueprint). Leave blank for single-binary repos.'
+        required: false
+        default: ''
       network:
         description: 'Deployment network (matches deployments/<network>/latest.json)'
         required: true
@@ -63,10 +67,13 @@ jobs:
           REPO='${{ inputs.blueprint_repo }}'
           TAG='${{ inputs.tag }}'
           TRIPLE='${{ inputs.target }}'
-          # release.yml names assets "<binary>-<triple>.tar.xz". Match by triple
-          # so we don't need to know each repo's binary name here.
+          BIN='${{ inputs.binary_name }}'
+          # release.yml names assets "<binary>-<triple>.tar.xz". For a
+          # multi-blueprint repo, binary_name disambiguates which one maps to
+          # this blueprint id; otherwise match the single asset by triple.
+          SUFFIX="${BIN:+${BIN}-}${TRIPLE}.tar.xz"
           ASSET=$(gh release view "$TAG" --repo "$REPO" --json assets \
-            --jq ".assets[] | select(.name | endswith(\"${TRIPLE}.tar.xz\")) | .name" | head -1)
+            --jq ".assets[] | select(.name | endswith(\"${SUFFIX}\")) | .name" | head -1)
           test -n "$ASSET" || { echo "::error::no asset for $TRIPLE on $REPO@$TAG"; exit 1; }
           gh release download "$TAG" --repo "$REPO" --pattern "$ASSET" --dir dl
           tar -xJf "dl/$ASSET" -C dl

--- a/deploy/publish-trading-v0.sh
+++ b/deploy/publish-trading-v0.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Publish v0 (genesis binary version) on-chain for the four ai-trading
+# blueprints registered on Base Sepolia:
+#
+#   13 trading           -> trading-blueprint-x86_64-unknown-linux-gnu.tar.xz
+#   14 instance          -> trading-instance-blueprint-x86_64-unknown-linux-gnu.tar.xz
+#   15 tee-instance      -> trading-tee-instance-blueprint-x86_64-unknown-linux-gnu.tar.xz
+#   16 validator         -> trading-validator-x86_64-unknown-linux-gnu.tar.xz
+#
+# Closes the `no_v0_published` column in deployments/base-sepolia/blueprints.tsv
+# for the trading row(s). Append-only + idempotent — re-running is a no-op if
+# a version is already published (see deploy/publish-binary.sh for the guard).
+#
+# Required env (loaded from the secrets repo, NOT baked here):
+#   PRIVATE_KEY  - blueprint owner key (shared-testnet-deployer; 0x2420…)
+#
+# Optional env (sensible defaults):
+#   TAG          - GitHub release tag to publish (default v0.1.3)
+#   TANGLE_CORE  - default loaded from deployments/base-sepolia/latest.json
+#   RPC_URL      - default https://sepolia.base.org
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="${TAG:-v0.1.3}"
+RPC_URL="${RPC_URL:-https://sepolia.base.org}"
+TANGLE_CORE="${TANGLE_CORE:-$(jq -r '.tangle' "$ROOT_DIR/deployments/base-sepolia/latest.json")}"
+: "${PRIVATE_KEY:?set PRIVATE_KEY (blueprint owner key)}"
+
+REPO="tangle-network/ai-trading-blueprint"
+TGT="x86_64-unknown-linux-gnu"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# id  binary
+publish_pairs=(
+  "13 trading-blueprint"
+  "14 trading-instance-blueprint"
+  "15 trading-tee-instance-blueprint"
+  "16 trading-validator"
+)
+
+for pair in "${publish_pairs[@]}"; do
+  read -r BID BIN <<<"$pair"
+  A="${BIN}-${TGT}.tar.xz"
+  URL="https://github.com/${REPO}/releases/download/${TAG}/${A}"
+  echo
+  echo "=== publishing blueprint $BID ($BIN) from ${TAG} ==="
+  curl -fsSL "$URL" -o "$TMPDIR/$A"
+
+  # sha256 is computed by publish-binary.sh against BINARY_PATH; pass the
+  # tarball itself (operators verify the same artifact they downloaded).
+  TANGLE_CORE="$TANGLE_CORE" \
+  RPC_URL="$RPC_URL" \
+  PRIVATE_KEY="$PRIVATE_KEY" \
+  BLUEPRINT_ID="$BID" \
+  BINARY_PATH="$TMPDIR/$A" \
+  BINARY_URI="$URL" \
+    "$ROOT_DIR/deploy/publish-binary.sh"
+done
+
+echo
+echo "all four ai-trading blueprints published on-chain (or already had v0)."
+echo "verify with:"
+echo "  for id in 13 14 15 16; do"
+echo "    cast call $TANGLE_CORE 'getBinaryVersionCount(uint64)(uint64)' \$id --rpc-url $RPC_URL"
+echo "  done"

--- a/deploy/register-blueprints.sh
+++ b/deploy/register-blueprints.sh
@@ -376,20 +376,41 @@ for entry in "${REPOS[@]}"; do
             TSUSD_ADDRESS="$TSUSD_ADDRESS" \
             ./deploy/register-blueprint.sh
     ) > "$log" 2>&1; then
-        bp=$(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+|Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
-        bsm=$(grep -oE 'DEPLOY_[A-Z_]*BSM[A-Z_]*=0x[0-9a-fA-F]{40}|(BSM[A-Za-z]*|BSM proxy)[^=:]*[=:][[:space:]]*0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
-        if [ -n "$bp" ]; then
-            # Globals set by publish_v0_binary: BIN_VERSION_ID, BIN_SHA256,
-            # BIN_URI, BIN_ATTEST, BIN_NOTE. Each defaults to '-' when no v0
-            # publish was attempted.
-            publish_v0_binary "$repo" "$repo_path" "$bp"
-            printf '%s\t%s\t%s\tregistered\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-                "$repo" "$bp" "${bsm:-}" \
-                "$BIN_VERSION_ID" "$BIN_SHA256" "$BIN_URI" "$BIN_ATTEST" "$BIN_NOTE" \
-                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                >> "$DEPLOY_MANIFEST"
-            RESULTS+=("$repo: OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID ($BIN_NOTE)")
-            echo "OK id=$bp bsm=${bsm:-?} bin=$BIN_VERSION_ID"
+        # Record EVERY blueprint the repo registered, not just the last id.
+        # Multi-blueprint repos (sandbox, trading) emit several
+        # `DEPLOY_<LABEL>BLUEPRINT_ID=<n>` lines; we write one manifest row per
+        # id and pair each with its same-label BSM (`DEPLOY_<LABEL>BSM=0x…`,
+        # falling back to `DEPLOY_BSM` for the unlabelled main blueprint).
+        mapfile -t _id_lines < <(grep -oE 'DEPLOY_[A-Z_]*BLUEPRINT_ID=[0-9]+' "$log")
+        if [ "${#_id_lines[@]}" -eq 0 ]; then
+            _single=$(grep -oE 'Blueprint ID:[[:space:]]*[0-9]+' "$log" | grep -oE '[0-9]+' | tail -1)
+            [ -n "$_single" ] && _id_lines=("DEPLOY_BLUEPRINT_ID=$_single")
+        fi
+        if [ "${#_id_lines[@]}" -gt 0 ]; then
+            for _line in "${_id_lines[@]}"; do
+                bp="${_line##*=}"
+                _var="${_line%%=*}"                 # DEPLOY_INSTANCE_BLUEPRINT_ID
+                _label="${_var#DEPLOY_}"            # INSTANCE_BLUEPRINT_ID
+                _label="${_label%BLUEPRINT_ID}"     # INSTANCE_  (or "" for main)
+                _label="${_label%_}"                # INSTANCE   (or "")
+                bsm=""
+                if [ -n "$_label" ]; then
+                    bsm=$(grep -oE "DEPLOY_${_label}_?BSM[A-Z_]*=0x[0-9a-fA-F]{40}" "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
+                fi
+                [ -z "$bsm" ] && bsm=$(grep -oE 'DEPLOY_BSM=0x[0-9a-fA-F]{40}' "$log" | grep -oE '0x[0-9a-fA-F]{40}' | tail -1)
+                # Globals set by publish_v0_binary: BIN_VERSION_ID, BIN_SHA256,
+                # BIN_URI, BIN_ATTEST, BIN_NOTE (default '-' / no-publish).
+                publish_v0_binary "$repo" "$repo_path" "$bp"
+                _note="$BIN_NOTE"
+                [ -n "$_label" ] && _note="variant=${_label}; $BIN_NOTE"
+                printf '%s\t%s\t%s\tregistered\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                    "$repo" "$bp" "${bsm:-}" \
+                    "$BIN_VERSION_ID" "$BIN_SHA256" "$BIN_URI" "$BIN_ATTEST" "$_note" \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    >> "$DEPLOY_MANIFEST"
+                RESULTS+=("$repo: OK id=$bp${_label:+ ($_label)} bsm=${bsm:-?}")
+                echo "OK id=$bp${_label:+ variant=$_label} bsm=${bsm:-?} bin=$BIN_VERSION_ID"
+            done
         else
             printf '%s\t-\t-\tunknown_output\t-\t-\t-\t-\t-\t%s\n' \
                 "$repo" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/deployments/base-sepolia/blueprints.tsv
+++ b/deployments/base-sepolia/blueprints.tsv
@@ -1,14 +1,18 @@
 repo	blueprint_id	bsm_address	status	binary_version_id	binary_sha256	binary_uri	binary_attestation	note	timestamp
-llm-inference-blueprint	0	0x6a0EF9695aAFeD077202538048c9b933e5D26475	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:50:19Z
-modal-inference-blueprint	1	0x0346DC54f93011BAD0c8514B4fF92349dC2fB0CF	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:51:04Z
-image-gen-inference-blueprint	2	0x8385F3D078b623779B349Ec8B85208145DaaC78C	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:51:38Z
-training-blueprint	3	0x6ae1bB9d0d0ccCfEb539b16e9E87d47092392DCD	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:52:20Z
-vector-store-blueprint	4	0xab9327E81C332315d6F337836aaebb2e0713ecd9	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:52:56Z
-distributed-inference-blueprint	5	0xBc3340b4C7b8DdcaEF5FAFC0dA967b0067825106	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:53:39Z
-voice-inference-blueprint	6	0x46EdE6E0611CF164D84Cb3b364482C5Ba8B2E9f0	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:54:16Z
-avatar-inference-blueprint	7	0xc15387e7734bAa66405c96fb996893d375A2D824	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:54:52Z
-embedding-inference-blueprint	8	0xe3BaA7a4b7d41261A09f0547F80e9CE5cE3de7DB	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:55:29Z
-video-gen-inference-blueprint	9	0x91E3C8f9a84BBC395eCE8deBf69b032912b81D81	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-22T23:56:10Z
-ai-agent-sandbox-blueprint	10	0x281d2D1160d80070eBe8989A529b6732C8403625	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-23T00:50:05Z
-ai-trading-blueprint	-	-	failed_rc_1	-	-	-	-	-	2026-05-23T10:52:50Z
-ai-trading-blueprint	16	0xA21F575dA87143ec82D6d183d4e7Af405E9409A4	registered	-	-	-	-	no_v0_published — re-run when binary path is configured	2026-05-23T10:55:36Z
+llm-inference-blueprint	0	0x6a0EF9695aAFeD077202538048c9b933e5D26475	registered	-	-	-	-	binary=llm-operator; no_v0_published	2026-05-22T23:50:19Z
+modal-inference-blueprint	1	0x0346DC54f93011BAD0c8514B4fF92349dC2fB0CF	registered	-	-	-	-	binary=modal-operator; no_v0_published	2026-05-22T23:51:04Z
+image-gen-inference-blueprint	2	0x8385F3D078b623779B349Ec8B85208145DaaC78C	registered	-	-	-	-	binary=image-gen-operator; no_v0_published	2026-05-22T23:51:38Z
+training-blueprint	3	0x6ae1bB9d0d0ccCfEb539b16e9E87d47092392DCD	registered	-	-	-	-	binary=training-operator; no_v0_published	2026-05-22T23:52:20Z
+vector-store-blueprint	4	0xab9327E81C332315d6F337836aaebb2e0713ecd9	registered	-	-	-	-	binary=vector-store-operator; no_v0_published	2026-05-22T23:52:56Z
+distributed-inference-blueprint	5	0xBc3340b4C7b8DdcaEF5FAFC0dA967b0067825106	registered	-	-	-	-	binary=distributed-inference-operator; no_v0_published	2026-05-22T23:53:39Z
+voice-inference-blueprint	6	0x46EdE6E0611CF164D84Cb3b364482C5Ba8B2E9f0	registered	-	-	-	-	binary=voice-operator; no_v0_published	2026-05-22T23:54:16Z
+avatar-inference-blueprint	7	0xc15387e7734bAa66405c96fb996893d375A2D824	registered	-	-	-	-	binary=avatar-operator; no_v0_published	2026-05-22T23:54:52Z
+embedding-inference-blueprint	8	0xe3BaA7a4b7d41261A09f0547F80e9CE5cE3de7DB	registered	-	-	-	-	binary=embedding-operator; no_v0_published	2026-05-22T23:55:29Z
+video-gen-inference-blueprint	9	0x91E3C8f9a84BBC395eCE8deBf69b032912b81D81	registered	-	-	-	-	binary=video-gen-operator; no_v0_published	2026-05-22T23:56:10Z
+ai-agent-sandbox-blueprint	10	0x281d2D1160d80070eBe8989A529b6732C8403625	registered	-	-	-	-	variant=sandbox; binary=ai-agent-sandbox-blueprint; no_v0_published	2026-05-23T00:50:05Z
+ai-agent-sandbox-blueprint	11	0xDe25dad1757e5Dab5230d44779d7de6ad8181C5C	registered	-	-	-	-	variant=instance; binary=ai-agent-instance-blueprint; no_v0_published	2026-05-23T00:50:07Z
+ai-agent-sandbox-blueprint	12	0x6D6deBfA88260558597Ad912439Ea1949962b3eb	registered	-	-	-	-	variant=tee-instance; binary=ai-agent-tee-instance-blueprint; no_v0_published	2026-05-23T00:50:09Z
+ai-trading-blueprint	13	0xDaBE0ABeA4325aC2Dd35C1FDED303b7b208Dc12E	registered	-	-	-	-	variant=trading; binary=trading-blueprint; no_v0_published	2026-05-23T10:55:36Z
+ai-trading-blueprint	14	0x055F96d7960ed49a82424289E82166D5D80f429d	registered	-	-	-	-	variant=instance; binary=trading-instance-blueprint; no_v0_published	2026-05-23T10:55:38Z
+ai-trading-blueprint	15	0x54Da89CaBbBa9c477180BDd4f2a7aC4952A16e3a	registered	-	-	-	-	variant=tee-instance; binary=trading-tee-instance-blueprint; no_v0_published	2026-05-23T10:55:40Z
+ai-trading-blueprint	16	0x8F982bbF592066c7037526982D19aC131f4933a9	registered	-	-	-	-	variant=validator; binary=trading-validator; no_v0_published	2026-05-23T10:55:42Z


### PR DESCRIPTION
Closes the `no_v0_published` gap (task #92) for blueprint ids 13/14/15/16 on Base Sepolia. Defaults to release tag v0.1.3 (which now ships both x86_64 + aarch64 ai-trading binaries). Idempotent via deploy/publish-binary.sh's append-only guard.