### PR TITLE
feat(deploy): on-chain binary publish + reusable publish workflow (CD-loop publish side)

### DIFF
--- a/.github/workflows/publish-blueprint-binary.yml
+++ b/.github/workflows/publish-blueprint-binary.yml
@@ -38,6 +38,42 @@ on:
         description: 'Set this version active after publishing'
         required: false
         default: 'true'
+  workflow_call:
+    # Reusable entry point: a blueprint repo's release CI calls this after it
+    # publishes a release, so the privileged on-chain publish stays here (the
+    # owner key never leaves tnt-core). Inputs mirror workflow_dispatch; the
+    # shared job below reads inputs.*/secrets.* identically for both triggers.
+    inputs:
+      blueprint_repo:
+        type: string
+        required: true
+      tag:
+        type: string
+        required: true
+      blueprint_id:
+        type: string
+        required: true
+      binary_name:
+        type: string
+        required: false
+        default: ''
+      network:
+        type: string
+        required: false
+        default: 'base-sepolia'
+      target:
+        type: string
+        required: false
+        default: 'x86_64-unknown-linux-gnu'
+      set_active:
+        type: string
+        required: false
+        default: 'true'
+    secrets:
+      PUBLISH_RPC_URL:
+        required: true
+      BLUEPRINT_OWNER_KEY:
+        required: true
 
 permissions:
   contents: read

--- a/deploy/publish-binary.sh
+++ b/deploy/publish-binary.sh
@@ -65,8 +65,17 @@ cast send "$TANGLE_CORE" \
     "$BLUEPRINT_ID" "$sha256" "$BINARY_URI" "$ATTESTATION" \
     --private-key "$PRIVATE_KEY" --rpc-url "$RPC_URL" >/dev/null
 
-new_count="$(cast call "$TANGLE_CORE" 'getBinaryVersionCount(uint64)(uint64)' "$BLUEPRINT_ID" --rpc-url "$RPC_URL")"
-new_count="${new_count%% *}"
+new_count=""
+for _ in 1 2 3 4 5; do
+    new_count="$(cast call "$TANGLE_CORE" 'getBinaryVersionCount(uint64)(uint64)' "$BLUEPRINT_ID" --rpc-url "$RPC_URL" 2>/dev/null | awk '{print $1}')"
+    if [ -n "$new_count" ] && [ "$new_count" -gt 0 ] 2>/dev/null; then
+        break
+    fi
+done
+if [ -z "$new_count" ] || [ "$new_count" -lt 1 ] 2>/dev/null; then
+    echo "ERROR: publish receipt confirmed but getBinaryVersionCount still 0 after retries — investigate manually." >&2
+    exit 1
+fi
 version_id=$(( new_count - 1 ))
 echo "  published version_id=$version_id"
 

--- a/deployments/base-sepolia/blueprints.tsv
+++ b/deployments/base-sepolia/blueprints.tsv
@@ -12,7 +12,7 @@ video-gen-inference-blueprint	9	0x91E3C8f9a84BBC395eCE8deBf69b032912b81D81	regis
 ai-agent-sandbox-blueprint	10	0x281d2D1160d80070eBe8989A529b6732C8403625	registered	-	-	-	-	variant=sandbox; binary=ai-agent-sandbox-blueprint; no_v0_published	2026-05-23T00:50:05Z
 ai-agent-sandbox-blueprint	11	0xDe25dad1757e5Dab5230d44779d7de6ad8181C5C	registered	-	-	-	-	variant=instance; binary=ai-agent-instance-blueprint; no_v0_published	2026-05-23T00:50:07Z
 ai-agent-sandbox-blueprint	12	0x6D6deBfA88260558597Ad912439Ea1949962b3eb	registered	-	-	-	-	variant=tee-instance; binary=ai-agent-tee-instance-blueprint; no_v0_published	2026-05-23T00:50:09Z
-ai-trading-blueprint	13	0xDaBE0ABeA4325aC2Dd35C1FDED303b7b208Dc12E	registered	-	-	-	-	variant=trading; binary=trading-blueprint; no_v0_published	2026-05-23T10:55:36Z
-ai-trading-blueprint	14	0x055F96d7960ed49a82424289E82166D5D80f429d	registered	-	-	-	-	variant=instance; binary=trading-instance-blueprint; no_v0_published	2026-05-23T10:55:38Z
-ai-trading-blueprint	15	0x54Da89CaBbBa9c477180BDd4f2a7aC4952A16e3a	registered	-	-	-	-	variant=tee-instance; binary=trading-tee-instance-blueprint; no_v0_published	2026-05-23T10:55:40Z
-ai-trading-blueprint	16	0x8F982bbF592066c7037526982D19aC131f4933a9	registered	-	-	-	-	variant=validator; binary=trading-validator; no_v0_published	2026-05-23T10:55:42Z
+ai-trading-blueprint	13	0xDaBE0ABeA4325aC2Dd35C1FDED303b7b208Dc12E	registered	-	-	-	-	variant=trading; binary=trading-blueprint; v0=0xf57e46b263d3681e5e948dc7bc2a5b1ee26316575ec2fa4d6acafc2bca1b1a25; release=v0.1.3	2026-05-23T10:55:36Z
+ai-trading-blueprint	14	0x055F96d7960ed49a82424289E82166D5D80f429d	registered	-	-	-	-	variant=instance; binary=trading-instance-blueprint; v0=0xc4e915462a178f71b69458ac794548f67575d94984609899f232131d95a43adc; release=v0.1.3	2026-05-23T10:55:38Z
+ai-trading-blueprint	15	0x54Da89CaBbBa9c477180BDd4f2a7aC4952A16e3a	registered	-	-	-	-	variant=tee-instance; binary=trading-tee-instance-blueprint; v0=0x0ab2be566f902c70048108aa16dd4921d06ee6dd43c04df867d2149b7014cefe; release=v0.1.3	2026-05-23T10:55:40Z
+ai-trading-blueprint	16	0x8F982bbF592066c7037526982D19aC131f4933a9	registered	-	-	-	-	variant=validator; binary=trading-validator; v0=0x1a6dab58a9cd33c15e0b2e42b76011fabec0465c4d7ab345b1fbd3d839982ece; release=v0.1.3	2026-05-23T10:55:42Z

--- a/script/RequestService.s.sol
+++ b/script/RequestService.s.sol
@@ -5,23 +5,24 @@ import { Script, console2 } from "forge-std/Script.sol";
 import { ITangleFull } from "../src/interfaces/ITangle.sol";
 import { Types } from "../src/libraries/Types.sol";
 
-/// @title RequestTradingService
-/// @notice Onboard an operator to a trading blueprint and stand up a live
-/// service in one shot: registerOperator -> requestService -> approveService.
-/// Reliable path when cargo-tangle's bindings are version-skewed vs the
-/// deployed Tangle (this script compiles against tnt-core's own interfaces, so
-/// the selectors always match the deployment).
+/// @title RequestService
+/// @notice Onboard an operator to ANY blueprint and stand up a live service in
+/// one shot: registerOperator -> requestService -> approveService. The target
+/// blueprint is chosen by `BLUEPRINT_ID`, so this is generic protocol ops — not
+/// specific to any one blueprint. Reliable path when cargo-tangle's bindings are
+/// version-skewed vs the deployed Tangle (this script compiles against tnt-core's
+/// own interfaces, so the selectors always match the deployment).
 ///
 /// Env:
 ///   TANGLE_CORE       deployed Tangle (e.g. 0x8299d60f… on Base Sepolia)
-///   BLUEPRINT_ID      uint64 (13 = trading/cloud)
+///   BLUEPRINT_ID      uint64 — the target blueprint to register on / request
 ///   OPERATOR_KEY      operator private key (must already be a staked/active
 ///                     MAD operator; this only registers it on the blueprint)
 ///   OPERATOR_ADDR     operator address
 ///   OPERATOR_PUBKEY   65-byte uncompressed secp256k1 pubkey (0x04‖X‖Y)
 ///   OPERATOR_RPC      operator RPC advertised on-chain (string)
 ///   SERVICE_TTL_SECS  optional, default 604800 (7 days)
-contract RequestTradingService is Script {
+contract RequestService is Script {
     function run() external {
         ITangleFull tangle = ITangleFull(payable(vm.envAddress("TANGLE_CORE")));
         uint64 blueprintId = uint64(vm.envUint("BLUEPRINT_ID"));
@@ -47,7 +48,7 @@ contract RequestTradingService is Script {
         uint64 serviceId = tangle.requestService(
             blueprintId,
             operators,
-            "", // empty config (trading blueprint accepts it; matches CreateServiceForTLV2Test)
+            "", // empty config (blueprints that accept it; matches CreateServiceForTLV2Test)
             permittedCallers,
             ttl,
             address(0), // native payment token

--- a/script/RequestTradingService.s.sol
+++ b/script/RequestTradingService.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Script, console2 } from "forge-std/Script.sol";
+import { ITangleFull } from "../src/interfaces/ITangle.sol";
+import { Types } from "../src/libraries/Types.sol";
+
+/// @title RequestTradingService
+/// @notice Onboard an operator to a trading blueprint and stand up a live
+/// service in one shot: registerOperator -> requestService -> approveService.
+/// Reliable path when cargo-tangle's bindings are version-skewed vs the
+/// deployed Tangle (this script compiles against tnt-core's own interfaces, so
+/// the selectors always match the deployment).
+///
+/// Env:
+///   TANGLE_CORE       deployed Tangle (e.g. 0x8299d60f… on Base Sepolia)
+///   BLUEPRINT_ID      uint64 (13 = trading/cloud)
+///   OPERATOR_KEY      operator private key (must already be a staked/active
+///                     MAD operator; this only registers it on the blueprint)
+///   OPERATOR_ADDR     operator address
+///   OPERATOR_PUBKEY   65-byte uncompressed secp256k1 pubkey (0x04‖X‖Y)
+///   OPERATOR_RPC      operator RPC advertised on-chain (string)
+///   SERVICE_TTL_SECS  optional, default 604800 (7 days)
+contract RequestTradingService is Script {
+    function run() external {
+        ITangleFull tangle = ITangleFull(payable(vm.envAddress("TANGLE_CORE")));
+        uint64 blueprintId = uint64(vm.envUint("BLUEPRINT_ID"));
+        uint256 operatorKey = vm.envUint("OPERATOR_KEY");
+        address operator = vm.envAddress("OPERATOR_ADDR");
+        bytes memory pubkey = vm.envBytes("OPERATOR_PUBKEY");
+        string memory rpc = vm.envString("OPERATOR_RPC");
+        uint64 ttl = uint64(vm.envOr("SERVICE_TTL_SECS", uint256(7 days)));
+
+        // 1. Register the (already-staked) operator on the blueprint.
+        vm.startBroadcast(operatorKey);
+        tangle.registerOperator(blueprintId, pubkey, rpc);
+        vm.stopBroadcast();
+        console2.log("registerOperator OK; blueprint", blueprintId);
+
+        // 2. Request a service with this single operator, empty config, native
+        //    (free) payment, Any confidentiality — mirrors the canonical flow.
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        address[] memory permittedCallers = new address[](0);
+
+        vm.startBroadcast(operatorKey);
+        uint64 serviceId = tangle.requestService(
+            blueprintId,
+            operators,
+            "", // empty config (trading blueprint accepts it; matches CreateServiceForTLV2Test)
+            permittedCallers,
+            ttl,
+            address(0), // native payment token
+            0, // payment amount
+            Types.ConfidentialityPolicy.Any
+        );
+        console2.log("requestService OK; serviceId", serviceId);
+        vm.stopBroadcast();
+
+        // 3. Operator approves -> service becomes active (single-operator).
+        vm.startBroadcast(operatorKey);
+        tangle.approveService(
+            Types.ApprovalParams({
+                requestId: serviceId,
+                securityCommitments: new Types.AssetSecurityCommitment[](0),
+                blsPubkey: [uint256(0), 0, 0, 0],
+                blsPopSignature: [uint256(0), 0],
+                teeCommitments: new Types.TeeAttestationCommitment[](0)
+            })
+        );
+        vm.stopBroadcast();
+        console2.log("approveService OK; service ACTIVE serviceId", serviceId);
+    }
+}


### PR DESCRIPTION
The publish + CD-trigger half of the blueprint upgrade loop. Carries the v0/on-chain publish work plus the new reusability that lets a blueprint repo's release CI auto-publish.

- `deploy/publish-binary.sh` / `publish-trading-v0.sh` / `register-blueprints.sh` — compute sha256 + content-addressed URI, call `publishBinaryVersion` + `setActiveBinaryVersion` (owner key stays here).
- `RequestTradingService` one-shot register+request+approve.
- **New (CD loop):** `.github/workflows/publish-blueprint-binary.yml` gains a `workflow_call` trigger (alongside `workflow_dispatch`), exposing the same inputs + the privileged secrets (`PUBLISH_RPC_URL`, `BLUEPRINT_OWNER_KEY`). This lets `tangle-network/ai-trading-blueprint`'s release CI (PR #133 there) trigger an on-chain publish on every `v*` tag — closing the publish side of the loop. `actionlint`: clean.

Pairs with ai-trading-blueprint#133 (release trigger + operator approval UI) and the already-shipped manager watcher/swap pipeline. Must be on `main` so the cross-repo `gh workflow run --ref main` resolves.