### PR TITLE
feat(blueprints): setBlueprintSources — owner can repoint a blueprint's binary sources

### DIFF
--- a/src/core/Base.sol
+++ b/src/core/Base.sol
@@ -679,6 +679,42 @@ abstract contract Base is
         return _blueprints[id];
     }
 
+    /// @dev Validate a blueprint's binary sources: at least one source, each with
+    ///      at least one binary, every binary carrying a non-zero sha256. Shared by
+    ///      createBlueprint and setBlueprintSources so both enforce the same shape.
+    function _validateBlueprintSources(Types.BlueprintSource[] calldata sources) internal pure {
+        if (sources.length == 0) revert Errors.BlueprintSourcesRequired();
+        for (uint256 i = 0; i < sources.length; ++i) {
+            Types.BlueprintSource calldata source = sources[i];
+            if (source.binaries.length == 0) revert Errors.BlueprintBinaryRequired();
+            for (uint256 j = 0; j < source.binaries.length; ++j) {
+                if (source.binaries[j].sha256 == bytes32(0)) {
+                    revert Errors.BlueprintBinaryHashRequired();
+                }
+            }
+        }
+    }
+
+    /// @dev Replace a blueprint's stored sources with `sources` (delete + deep copy).
+    ///      Shared by createBlueprint (genesis write) and setBlueprintSources (owner
+    ///      repoint). Callers must validate via {_validateBlueprintSources} first.
+    function _writeBlueprintSources(uint64 blueprintId, Types.BlueprintSource[] calldata sources) internal {
+        delete _blueprintSources[blueprintId];
+        Types.BlueprintSource[] storage stored = _blueprintSources[blueprintId];
+        for (uint256 i = 0; i < sources.length; ++i) {
+            Types.BlueprintSource storage dst = stored.push();
+            Types.BlueprintSource calldata src = sources[i];
+            dst.kind = src.kind;
+            dst.container = src.container;
+            dst.wasm = src.wasm;
+            dst.native = src.native;
+            dst.testing = src.testing;
+            for (uint256 j = 0; j < src.binaries.length; ++j) {
+                dst.binaries.push(src.binaries[j]);
+            }
+        }
+    }
+
     function _getServiceRequest(uint64 id) internal view returns (Types.ServiceRequest storage) {
         if (id >= _serviceRequestCount) revert Errors.ServiceRequestNotFound(id);
         return _serviceRequests[id];

--- a/src/core/BlueprintsCreate.sol
+++ b/src/core/BlueprintsCreate.sol
@@ -94,21 +94,7 @@ abstract contract BlueprintsCreate is Base {
     }
 
     function _storeBlueprintSources(uint64 blueprintId, Types.BlueprintSource[] calldata sources) private {
-        delete _blueprintSources[blueprintId];
-        Types.BlueprintSource[] storage stored = _blueprintSources[blueprintId];
-        for (uint256 i = 0; i < sources.length; ++i) {
-            Types.BlueprintSource storage dst = stored.push();
-            Types.BlueprintSource calldata src = sources[i];
-            dst.kind = src.kind;
-            dst.container = src.container;
-            dst.wasm = src.wasm;
-            dst.native = src.native;
-            dst.testing = src.testing;
-
-            for (uint256 j = 0; j < src.binaries.length; ++j) {
-                dst.binaries.push(src.binaries[j]);
-            }
-        }
+        _writeBlueprintSources(blueprintId, sources);
     }
 
     function _storeSupportedMemberships(uint64 blueprintId, Types.MembershipModel[] calldata memberships) private {
@@ -123,7 +109,6 @@ abstract contract BlueprintsCreate is Base {
         if (bytes(def.metadataUri).length == 0) revert Errors.BlueprintMetadataRequired();
         if (def.metadataHash == bytes32(0)) revert Errors.BlueprintMetadataHashRequired();
         if (def.jobs.length == 0) revert Errors.InvalidState();
-        if (def.sources.length == 0) revert Errors.BlueprintSourcesRequired();
         if (def.supportedMemberships.length == 0) revert Errors.BlueprintMembershipRequired();
         if (
             def.hasConfig && def.config.pricing == Types.PricingModel.Subscription
@@ -131,15 +116,7 @@ abstract contract BlueprintsCreate is Base {
         ) {
             revert Errors.InvalidState();
         }
-        for (uint256 i = 0; i < def.sources.length; ++i) {
-            Types.BlueprintSource calldata source = def.sources[i];
-            if (source.binaries.length == 0) revert Errors.BlueprintBinaryRequired();
-            for (uint256 j = 0; j < source.binaries.length; ++j) {
-                if (source.binaries[j].sha256 == bytes32(0)) {
-                    revert Errors.BlueprintBinaryHashRequired();
-                }
-            }
-        }
+        _validateBlueprintSources(def.sources);
     }
 
     function _normalizeBlueprintConfig(Types.BlueprintDefinition calldata def)

--- a/src/core/BlueprintsManage.sol
+++ b/src/core/BlueprintsManage.sol
@@ -17,6 +17,7 @@ abstract contract BlueprintsManage is Base {
     event BlueprintDeactivated(uint64 indexed blueprintId);
     event JobEventRateSet(uint64 indexed blueprintId, uint8 indexed jobIndex, uint256 rate);
     event BlueprintResourceRequirementsSet(uint64 indexed blueprintId, uint256 count);
+    event BlueprintSourcesUpdated(uint64 indexed blueprintId, uint256 sourceCount);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // BLUEPRINT MANAGEMENT
@@ -95,6 +96,28 @@ abstract contract BlueprintsManage is Base {
         _blueprintMetadataUri[blueprintId] = metadataUri;
         _blueprintMetadataHash[blueprintId] = metadataHash;
         emit BlueprintUpdated(blueprintId, metadataUri, metadataHash);
+    }
+
+    /// @notice Replace a blueprint's binary sources (owner-only).
+    /// @dev createBlueprint writes sources once at genesis; this lets the owner
+    ///      repoint the blueprint at real, fetchable, multi-arch artifacts after
+    ///      creation — correcting a placeholder source, or rolling the source
+    ///      forward each release so operators cold-starting through the manager
+    ///      fetch the right per-arch binary. The manager resolves the initial
+    ///      binary from these sources (not from published BinaryVersions, which
+    ///      only drive in-place upgrades), so a wrong/placeholder source here
+    ///      means no operator can boot the blueprint. Same validation as
+    ///      createBlueprint: >=1 source, each with >=1 binary, every binary
+    ///      carrying a non-zero sha256. Sources are not lockable; ownership is
+    ///      the gate. The active/published BinaryVersion set is unaffected.
+    function setBlueprintSources(uint64 blueprintId, Types.BlueprintSource[] calldata sources) external nonReentrant {
+        Types.Blueprint storage bp = _getBlueprint(blueprintId);
+        if (bp.owner != msg.sender) {
+            revert Errors.NotBlueprintOwner(blueprintId, msg.sender);
+        }
+        _validateBlueprintSources(sources);
+        _writeBlueprintSources(blueprintId, sources);
+        emit BlueprintSourcesUpdated(blueprintId, sources.length);
     }
 
     /// @notice Transfer blueprint ownership

--- a/src/facets/tangle/TangleBlueprintsManagementFacet.sol
+++ b/src/facets/tangle/TangleBlueprintsManagementFacet.sol
@@ -8,7 +8,7 @@ import { IFacetSelectors } from "../../interfaces/IFacetSelectors.sol";
 /// @notice Facet for blueprint metadata and ownership
 contract TangleBlueprintsManagementFacet is BlueprintsManage, IFacetSelectors {
     function selectors() external pure returns (bytes4[] memory selectorList) {
-        selectorList = new bytes4[](13);
+        selectorList = new bytes4[](14);
         selectorList[0] = this.blueprintCount.selector;
         selectorList[1] = this.blueprintMetadata.selector;
         selectorList[2] = this.blueprintSources.selector;
@@ -22,5 +22,6 @@ contract TangleBlueprintsManagementFacet is BlueprintsManage, IFacetSelectors {
         selectorList[10] = this.getJobEventRate.selector;
         selectorList[11] = bytes4(keccak256("setBlueprintResourceRequirements(uint64,(uint8,uint64)[])"));
         selectorList[12] = bytes4(keccak256("getBlueprintResourceRequirements(uint64)"));
+        selectorList[13] = this.setBlueprintSources.selector;
     }
 }

--- a/src/interfaces/ITangleBlueprints.sol
+++ b/src/interfaces/ITangleBlueprints.sol
@@ -20,6 +20,8 @@ interface ITangleBlueprints {
 
     event BlueprintDeactivated(uint64 indexed blueprintId);
 
+    event BlueprintSourcesUpdated(uint64 indexed blueprintId, uint256 sourceCount);
+
     // ═══════════════════════════════════════════════════════════════════════════
     // FUNCTIONS
     // ═══════════════════════════════════════════════════════════════════════════
@@ -31,6 +33,9 @@ interface ITangleBlueprints {
 
     /// @notice Update blueprint metadata
     function updateBlueprint(uint64 blueprintId, string calldata metadataUri, bytes32 metadataHash) external;
+
+    /// @notice Replace a blueprint's binary sources (owner only)
+    function setBlueprintSources(uint64 blueprintId, Types.BlueprintSource[] calldata sources) external;
 
     /// @notice Transfer blueprint ownership
     function transferBlueprint(uint64 blueprintId, address newOwner) external;

--- a/test/blueprints/BlueprintDefinitionStorage.t.sol
+++ b/test/blueprints/BlueprintDefinitionStorage.t.sol
@@ -7,6 +7,138 @@ import { Errors } from "../../src/libraries/Errors.sol";
 import { MasterBlueprintServiceManager } from "../../src/MasterBlueprintServiceManager.sol";
 
 contract BlueprintDefinitionStorageTest is BaseTest {
+    event BlueprintSourcesUpdated(uint64 indexed blueprintId, uint256 sourceCount);
+
+    /// @dev A real, fetchable, multi-arch (x86_64 + aarch64) native source — the
+    ///      shape an owner repoints a blueprint to so manager cold-starts resolve
+    ///      the operator's arch. Mirrors the live trading-blueprint fix.
+    function _multiArchNativeSource() internal pure returns (Types.BlueprintSource memory source) {
+        source.kind = Types.BlueprintSourceKind.Native;
+        source.native = Types.NativeSource({
+            fetcher: Types.BlueprintFetcherKind.Github,
+            artifactUri: "https://github.com/tangle-network/ai-trading-blueprint/releases/download/v0.1.13",
+            entrypoint: "trading-blueprint"
+        });
+        source.binaries = new Types.BlueprintBinary[](2);
+        source.binaries[0] = Types.BlueprintBinary({
+            arch: Types.BlueprintArchitecture.Amd64,
+            os: Types.BlueprintOperatingSystem.Linux,
+            name: "trading-blueprint-x86_64-unknown-linux-gnu",
+            sha256: bytes32(uint256(0xA11CE))
+        });
+        source.binaries[1] = Types.BlueprintBinary({
+            arch: Types.BlueprintArchitecture.Arm64,
+            os: Types.BlueprintOperatingSystem.Linux,
+            name: "trading-blueprint-aarch64-unknown-linux-gnu",
+            sha256: bytes32(uint256(0xB0B))
+        });
+    }
+
+    function _createOwned() internal returns (uint64 blueprintId) {
+        Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://set-sources", address(0));
+        vm.prank(developer);
+        blueprintId = tangle.createBlueprint(def);
+    }
+
+    function test_SetBlueprintSources_RepointsToMultiArch() public {
+        uint64 id = _createOwned();
+        // Genesis: one single-arch container source.
+        assertEq(tangle.blueprintSources(id).length, 1, "precondition: one genesis source");
+
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+
+        vm.expectEmit(true, false, false, true, address(tangle));
+        emit BlueprintSourcesUpdated(id, 1);
+        vm.prank(developer);
+        tangle.setBlueprintSources(id, next);
+
+        Types.BlueprintSource[] memory stored = tangle.blueprintSources(id);
+        assertEq(stored.length, 1, "source count");
+        assertEq(uint256(stored[0].kind), uint256(Types.BlueprintSourceKind.Native), "kind -> Native");
+        assertEq(uint256(stored[0].native.fetcher), uint256(Types.BlueprintFetcherKind.Github), "fetcher -> Github");
+        assertEq(stored[0].native.artifactUri, next[0].native.artifactUri, "artifactUri");
+        // Deep copy of nested binaries, both arches present with exact hashes.
+        assertEq(stored[0].binaries.length, 2, "binary count");
+        assertEq(uint256(stored[0].binaries[0].arch), uint256(Types.BlueprintArchitecture.Amd64), "binary0 arch");
+        assertEq(uint256(stored[0].binaries[1].arch), uint256(Types.BlueprintArchitecture.Arm64), "binary1 arch");
+        assertEq(uint256(stored[0].binaries[1].os), uint256(Types.BlueprintOperatingSystem.Linux), "binary1 os");
+        assertEq(stored[0].binaries[1].name, next[0].binaries[1].name, "binary1 name");
+        assertEq(stored[0].binaries[1].sha256, bytes32(uint256(0xB0B)), "binary1 sha256");
+    }
+
+    function test_SetBlueprintSources_ReplacesNotAppends_NoStaleEntries() public {
+        uint64 id = _createOwned();
+
+        // First set: two sources, the first with two binaries.
+        Types.BlueprintSource[] memory big = new Types.BlueprintSource[](2);
+        big[0] = _multiArchNativeSource(); // 2 binaries
+        big[1] = _defaultBlueprintSource(); // 1 binary
+        vm.prank(developer);
+        tangle.setBlueprintSources(id, big);
+        assertEq(tangle.blueprintSources(id).length, 2, "after first set");
+
+        // Re-set to a single source with a single binary; delete must clear the
+        // prior nested binaries array, not leave the old second binary dangling.
+        Types.BlueprintSource[] memory small = new Types.BlueprintSource[](1);
+        small[0] = _defaultBlueprintSource();
+        vm.prank(developer);
+        tangle.setBlueprintSources(id, small);
+
+        Types.BlueprintSource[] memory stored = tangle.blueprintSources(id);
+        assertEq(stored.length, 1, "shrunk to one source");
+        assertEq(stored[0].binaries.length, 1, "shrunk to one binary (no stale entries)");
+        assertEq(uint256(stored[0].kind), uint256(Types.BlueprintSourceKind.Container), "kind reset");
+    }
+
+    function test_SetBlueprintSources_RevertsForNonOwner() public {
+        uint64 id = _createOwned();
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotBlueprintOwner.selector, id, user1));
+        tangle.setBlueprintSources(id, next);
+    }
+
+    function test_SetBlueprintSources_RevertsForUnknownBlueprint() public {
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+        uint64 missing = tangle.blueprintCount() + 7;
+
+        vm.prank(developer);
+        vm.expectRevert(abi.encodeWithSelector(Errors.BlueprintNotFound.selector, missing));
+        tangle.setBlueprintSources(missing, next);
+    }
+
+    function test_SetBlueprintSources_RevertsOnEmptySources() public {
+        uint64 id = _createOwned();
+        Types.BlueprintSource[] memory empty = new Types.BlueprintSource[](0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintSourcesRequired.selector);
+        tangle.setBlueprintSources(id, empty);
+    }
+
+    function test_SetBlueprintSources_RevertsOnSourceWithNoBinaries() public {
+        uint64 id = _createOwned();
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+        next[0].binaries = new Types.BlueprintBinary[](0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintBinaryRequired.selector);
+        tangle.setBlueprintSources(id, next);
+    }
+
+    function test_SetBlueprintSources_RevertsOnZeroBinaryHash() public {
+        uint64 id = _createOwned();
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+        next[0].binaries[1].sha256 = bytes32(0);
+        vm.prank(developer);
+        vm.expectRevert(Errors.BlueprintBinaryHashRequired.selector);
+        tangle.setBlueprintSources(id, next);
+    }
+
     function test_MetadataSourcesAndMembershipsPersisted() public {
         Types.BlueprintDefinition memory def = _blueprintDefinition("ipfs://custom-metadata", address(0));
         def.metadata.name = "Custom Blueprint";


### PR DESCRIPTION
## Summary

`createBlueprint` writes a blueprint's `BlueprintSource[]` once at genesis, and nothing could change it afterward — `updateBlueprint` only edits metadata. This adds `setBlueprintSources(uint64, BlueprintSource[])` (owner-gated) so an owner can repoint a blueprint at corrected, fetchable, multi-arch artifacts.

Affected flow: **operator cold-start through `blueprint-manager`**. The manager resolves the *initial* operator binary from these on-chain `BlueprintSource`s — the published/active `BinaryVersion` set only drives *in-place upgrades*. So a blueprint registered with a placeholder or single-arch source is permanently un-runnable through the manager. This is exactly the live state of the trading blueprint (id 13): its source is a `file://`, x86_64-only, `deadbeef`-hash placeholder, which is why its operator has to run in a direct-bypass mode instead of under the manager.

## Change Class

- Selected class: Class D (core protocol — `src/core/`, facet selector surface)
- New owner-gated state mutator on the blueprints-management facet + a lifted shared helper in `Base`.

## Behavior Contract

- Before: a blueprint's sources are immutable after `createBlueprint`. A bad/placeholder source can never be fixed; the blueprint can't be cold-started by the manager.
- After: `setBlueprintSources(blueprintId, sources)` replaces the stored sources when `msg.sender == blueprint.owner`. Same validation as `createBlueprint`: ≥1 source, each with ≥1 binary, every binary a non-zero `sha256`. Emits `BlueprintSourcesUpdated(blueprintId, sourceCount)`.
- Invariants: non-owner cannot call (reverts `NotBlueprintOwner`); unknown blueprint reverts `BlueprintNotFound`; the published/active `BinaryVersion` set and all other blueprint state are untouched; a re-set fully replaces prior sources (delete-before-write — no stale nested binaries). Sources are intentionally not lockable; ownership is the gate (consistent with `setBlueprintResourceRequirements`).
- The store + source-validation loops are lifted to `Base` as `internal` helpers (`_writeBlueprintSources` / `_validateBlueprintSources`) and shared by `createBlueprint` and `setBlueprintSources` so the two paths cannot drift.

## Risk and Scope

- Blast radius: blueprints-management facet + `Base` helpers + the create-path refactor (behavior-identical). New selector registered on `TangleBlueprintsManagementFacet.selectors()` (12→13 index) and `ITangleBlueprints`.
- Failure mode: fail-closed — invalid source shape reverts; only the owner can mutate.
- Storage: no new storage variables and no layout change (only added functions); the create-path refactor preserves identical on-chain behavior. Safe for the live facet-router deployment (deploy new facet + `registerFacetSelectors` for the one new selector; the other 13 stay routed to the existing facet).
- Rollback: `clearFacetSelectors([setBlueprintSources.selector])` removes it; nothing else changes.

## Verification

```bash
forge test --match-contract BlueprintDefinitionStorageTest   # 16/16
forge test --match-path 'test/blueprints/*.sol'              # 83/83
```

Broader regression (facet routing, binary versions, attestations, upgrade-flow, cross-version) — all suites green, 0 failures. `forge fmt` clean.

## Harness Evidence

Extended the existing `test/blueprints/BlueprintDefinitionStorage.t.sol` suite (the canonical source-storage tests) with 7 new cases — no new test file:
- `test_SetBlueprintSources_RepointsToMultiArch` — genesis(1 container) → multi-arch native (x86_64+aarch64); asserts kind, fetcher, artifactUri, and deep-copied per-arch binaries (arch/os/name/sha256) + the `BlueprintSourcesUpdated` event.
- `test_SetBlueprintSources_ReplacesNotAppends_NoStaleEntries` — 2 sources (first with 2 binaries) → 1 source/1 binary; proves delete-before-write leaves no stale nested entries.
- owner-gating, unknown-blueprint, empty-sources, no-binaries, zero-hash reverts.

## Checklist

- [x] Owner-gated; validation parity with `createBlueprint`
- [x] No storage layout change; live facet-router upgrade path documented
- [x] Shared helpers (no create/set drift)
- [x] Selector registered (facet + interface)
- [x] Tests extend the existing suite; full blueprint/facet/upgrade suites green
