### PR TITLE
fix(blueprints): getBlueprintDefinition reflects live sources, not genesis blob

### DIFF
--- a/src/core/BlueprintsManage.sol
+++ b/src/core/BlueprintsManage.sol
@@ -66,7 +66,7 @@ abstract contract BlueprintsManage is Base {
         return _blueprintMasterRevisions[blueprintId];
     }
 
-    /// @notice Retrieve the original blueprint definition
+    /// @notice Retrieve the blueprint definition, with current (post-genesis) sources.
     function getBlueprintDefinition(uint64 blueprintId)
         external
         view
@@ -75,6 +75,11 @@ abstract contract BlueprintsManage is Base {
         bytes storage blob = _blueprintDefinitionBlobs[blueprintId];
         if (blob.length == 0) revert Errors.BlueprintNotFound(blueprintId);
         definition = abi.decode(blob, (Types.BlueprintDefinition));
+        // The blob is the genesis snapshot, but sources are mutable post-genesis
+        // via setBlueprintSources (stored in _blueprintSources). Overlay the live
+        // sources so this view — which the blueprint-manager reads to resolve the
+        // operator binary — reflects the current source set, not the stale blob.
+        definition.sources = _blueprintSources[blueprintId];
     }
 
     /// @notice Update blueprint metadata

--- a/test/blueprints/BlueprintDefinitionStorage.t.sol
+++ b/test/blueprints/BlueprintDefinitionStorage.t.sol
@@ -40,6 +40,31 @@ contract BlueprintDefinitionStorageTest is BaseTest {
         blueprintId = tangle.createBlueprint(def);
     }
 
+    function test_GetBlueprintDefinition_ReflectsLiveSources() public {
+        uint64 id = _createOwned();
+        // Genesis: the definition's sources match the genesis (one container source).
+        Types.BlueprintDefinition memory g = tangle.getBlueprintDefinition(id);
+        assertEq(g.sources.length, 1, "genesis def sources");
+        assertEq(uint256(g.sources[0].kind), uint256(Types.BlueprintSourceKind.Container), "genesis kind");
+
+        Types.BlueprintSource[] memory next = new Types.BlueprintSource[](1);
+        next[0] = _multiArchNativeSource();
+        vm.prank(developer);
+        tangle.setBlueprintSources(id, next);
+
+        // The definition view (what the manager reads) must now reflect the live
+        // sources, not the stale genesis blob — else setBlueprintSources is a no-op
+        // for binary resolution.
+        Types.BlueprintDefinition memory d = tangle.getBlueprintDefinition(id);
+        assertEq(d.sources.length, 1, "def reflects new source count");
+        assertEq(uint256(d.sources[0].kind), uint256(Types.BlueprintSourceKind.Native), "def kind -> Native");
+        assertEq(uint256(d.sources[0].native.fetcher), uint256(Types.BlueprintFetcherKind.Github), "def fetcher");
+        assertEq(d.sources[0].binaries.length, 2, "def per-arch binaries");
+        assertEq(d.sources[0].binaries[1].sha256, bytes32(uint256(0xB0B)), "def binary sha overlaid");
+        // Non-source fields still come from the genesis blob (unchanged).
+        assertEq(d.metadataUri, "ipfs://set-sources", "metadataUri preserved from blob");
+    }
+
     function test_SetBlueprintSources_RepointsToMultiArch() public {
         uint64 id = _createOwned();
         // Genesis: one single-arch container source.


### PR DESCRIPTION
setBlueprintSources (#162) updates the canonical _blueprintSources, but the blueprint-manager reads getBlueprintDefinition() which returned the stale genesis blob — so repointed sources never reached the manager. Overlay live _blueprintSources onto the decoded definition (single source of truth; no compat shim — testnet/alpha, prior behavior was simply wrong for mutable sources). Manager untouched (it reads the full definition for jobs/schemas too). +1 test.