### PR TITLE
chore(deploy): finalize fixed-supply, 1% inflation, thin-float governance params

### DIFF
--- a/deploy/MAINNET-PARAMETERS.md
+++ b/deploy/MAINNET-PARAMETERS.md
@@ -99,18 +99,47 @@ Done in this change: **lock-expiry timestamp fix** (`Types.LockInfo`, `DepositMa
 - Indexer `expiryBlock` field (`schema.graphql`, `staking.ts` — currently a hardcoded `0n` placeholder, not
   wired to the contract value) → rename to `expiryTimestamp` and re-run `npm run codegen`.
 
+## Finalized monetary + governance decisions (set in config)
+
+These were the big open items; here's the call and why, alternatives noted.
+
+**Supply = true fixed-supply.** The genesis migration mints all four buckets — Substrate ~51.24M / EVM
+~1.13M / Treasury ~41.84M / Foundation ~15.04M — which sum to `MAX_SUPPLY` 109,255,636.92 TNT *exactly*.
+Genesis hits the cap, so the surviving `MINTER_ROLE` is inert and the InflationPool can never mint. This is
+the strongest possible supply guarantee. *Alternative considered:* a ~5% mintable inflation envelope (reserve
+headroom under the cap) — rejected because the snapshot already equals the cap and minimal-dilution is the
+stronger market signal; a fixed cap + treasury-funded security is cleaner than soft inflation.
+
+**Inflation = 1% of supply, treasury-funded (not minted).** `year1FundTnt = 1,092,556.37 TNT` (1% of
+MAX_SUPPLY), transferred from the Treasury bucket into the InflationPool via `fund()`. Because supply is fixed,
+this is emission/redistribution, not monetary inflation. Treasury (41.84M) sustains a flat 1% for ~38 years; a
+declining schedule (Y2 0.8×, Y3 0.6×) stretches it. *Alternatives:* 0.5% (leaner, slower security-stake
+growth) or 2% (faster bootstrap, ~19yr runway). 1% is the balance — meaningful staking yield without draining
+the treasury or signalling high dilution.
+
+**Governance launch values (thin-float-aware).** `votingDelay 1d / votingPeriod 7d / proposalThreshold 100k
+TNT / quorum 4% / timelockDelay 4d`. The non-obvious driver: quorum is `% of getPastTotalSupply` = the full
+109.26M minted at genesis, but most supply is vesting-locked and undelegated at launch (Substrate+EVM unlock
+only 10% at TGE; Treasury 0%, Foundation 30%), so realistic delegatable float is single-digit millions. A high
+quorum would *brick* governance. 4% (~4.37M votes) is reachable with engagement; 100k proposalThreshold is a
+spam floor that isn't paralyzing on thin float. *Alternatives:* quorum 3% if early participation is weak, 6%
+once float deepens (ratchet up via governance as vesting unlocks over 3yr). `proposalThreshold` 200k if you
+expect strong delegation. The real defense against a low-quorum capture proposal is the **CANCELLER guardian
+Safe below**, not a high quorum — wire it.
+
 ## Open decisions (only Drew / governance can ratify)
 
 - **Role addresses:** the four Safes/timelock for `roles.*`.
+- **Finalize the canonical mainnet snapshot:** regenerate `merkle-tree.json` + the EVM/treasury/foundation
+  carveouts, decide the ~3.19M expired-unclaimed decay (policy = 90% decay), pin `merkleRoot` + `programVKey`
+  + `sp1VerifierGateway`, then set `migration.deploy = true`. The four amounts load from those files.
 - **SLASH_ADMIN_ROLE** held by a ≥3/5 multisig with a documented <7d dispute-adjudication SLA (fail-open
   auto-execute makes honest-dispute safety contingent on responsiveness).
-- **CANCELLER_ROLE guardian Safe** on the timelock — as-built only the governor holds it. If a guardian is
-  wired, `quorumPercent` can be 4 instead of 6.
-- **Inflation budget size:** the actual Year-1 fund (recommended ~2.0M TNT / ~1.8% gross) + a declining
-  multi-year schedule, funded from a named treasury reserve. Currently a recommendation in config, not executed.
-- **Genesis allocation amounts** (substrate / evm / treasury / foundation) and the **headroom decision**:
-  ~5% inflation envelope vs true fixed-supply. Pin one and assert it at deploy.
-- **Governance init values** ratification (defaults proposed above).
+- **CANCELLER_ROLE guardian Safe** on the timelock — as-built only the governor holds it. Strongly recommended
+  at launch given the thin votable float (it's the real capture defense). Lets quorum stay low safely.
+- **Execute the treasury pre-funding:** transfer `year1FundTnt` into the InflationPool post-deploy + commit to
+  the multi-year declining schedule from a named treasury reserve.
+- **Governance init values** ratification (set above; ratify or adjust per the alternatives).
 - **Pre-committed weight migration** (staking→stakers, e.g. 3500/1500) once `ServiceFeeDistributor` + keeper +
   live services exist — `stakersBps=0` is correct at genesis but the rail should turn on after launch.
 - **Gated-asset enablement:** stETH/wstETH/EIGEN/WBTC/tBTC/lBTC/USDe are `0x0` placeholders — each needs a real

--- a/deploy/config/base-mainnet.json
+++ b/deploy/config/base-mainnet.json
@@ -148,8 +148,8 @@
     "tntToken": "0x0000000000000000000000000000000000000000",
     "vaultOperatorCommissionBps": 1500,
     "epochLength": 604800,
-    "_todo_inflation": "TODO (Drew/governance ratify): InflationPool does not mint — treasury PRE-FUNDS it via InflationPool.fund(). Recommended Year-1 budget ~2,000,000 TNT (~1.8% of genesis float) with a declining schedule (e.g. Y2 0.7x, Y3 0.5x) funded from a named treasury reserve. year1FundTnt below is the recommendation, not yet executed.",
-    "year1FundTnt": "2000000000000000000000000",
+    "_note_inflation": "FIXED SUPPLY: genesis mints the entire MAX_SUPPLY (109,255,636.92 TNT = sum of the 4 migration buckets), so the InflationPool can never mint — 'inflation' is treasury-funded emission, not new supply. year1FundTnt = 1% of MAX_SUPPLY (1,092,556.37 TNT), pre-funded from the Treasury bucket (41.84M) via InflationPool.fund(). At a flat 1% that reserve lasts ~38yr; a declining schedule (e.g. Y2 0.8x, Y3 0.6x) stretches it further. Funding is a post-deploy treasury action, not done by the deploy script.",
+    "year1FundTnt": "1092556369192129278856109",
     "_note_weights": "Reroute toward the security layer vs genesis design: stakingBps 5000->5500, developersBps 1500->1000 (donor; developer rewards are ADMIN-allowlist gated, not sybil-farmable). stakersBps stays 0 at genesis — the exposure-weighted rail no-ops until ServiceFeeDistributor + keeper + live services exist; pre-commit a governance migration to staking 3500 / stakers 1500 once that path is live.",
     "weights": {
       "stakingBps": 5500,
@@ -188,11 +188,11 @@
   },
   "_note_governance_slashing_payments": "These three blocks are consumed by deploy/deploy-all.sh (the prod orchestrator) AFTER core deploy. governance -> script/DeployGovernance.s.sol (deploy Timelock+Governor, then put the Timelock address in roles.timelock). slashing -> Tangle.setSlashConfig. payments -> Tangle.setPaymentSplit. Without these steps mainnet ships the insecure hardcoded defaults (maxSlashBps=100%, disputeBond=0, keeperBps=0). See deploy/MAINNET-PARAMETERS.md for rationale.",
   "governance": {
-    "_note": "Launch values for a ~50M-float governance token. Conservative-start; relax later via governance. quorumPercent=6 absent an independent CANCELLER_ROLE guardian Safe — wire a guardian and you may lower to 4.",
+    "_note": "Quorum is % of getPastTotalSupply = the full 109.26M minted at genesis, but most supply is vesting-locked/undelegated at launch (substrate+EVM unlock only 10% at TGE; treasury 0%, foundation 30%). Realistic delegatable float at launch is single-digit millions, so a high quorum BRICKS governance. quorumPercent=4 (~4.37M votes) is reachable with engagement; proposalThreshold 100k TNT is a spam floor that isn't paralyzing on thin float. Conservative-start: ratchet quorum up via governance as vesting unlocks over 3yr. STRONGLY pair with an independent CANCELLER_ROLE guardian Safe (see openDecisions) — it is the real defense against a low-quorum capture proposal, not a high quorum. Alternatives: quorum 3% if early participation is weak, or 6% only once float deepens.",
     "votingDelay": 86400,
     "votingPeriod": 604800,
-    "proposalThreshold": "200000000000000000000000",
-    "quorumPercent": 6,
+    "proposalThreshold": "100000000000000000000000",
+    "quorumPercent": 4,
     "timelockDelay": 345600
   },
   "slashing": {
@@ -228,7 +228,9 @@
     "logSummary": true
   },
   "migration": {
-    "_todo_allocations": "TODO (Drew/governance ratify): pin the four genesis allocation amounts so total genesis supply and inflation headroom are explicit. TangleToken.MAX_SUPPLY == migration snapshot total (~109.26M); if allocations sum to it, headroom is 0 and the protocol is true fixed-supply (security budget = whatever treasury pre-funds). Decide explicitly: ~5% inflation envelope vs true fixed-supply, then assert at deploy.",
+    "_decision_headroom": "DECIDED: true fixed-supply. The four buckets sum to TangleToken.MAX_SUPPLY (109,255,636.92 TNT) exactly, so genesis mints the entire cap and the surviving MINTER_ROLE is inert. There is NO ~5% inflation envelope — all rewards (the 1% staking emission + payment-split staker share) are funded from existing TNT (Treasury bucket). This is the strongest supply guarantee; pair it with the written treasury pre-funding schedule (see incentives.year1FundTnt).",
+    "_todo_allocations": "TODO (Drew to finalize the CANONICAL mainnet snapshot, then set deploy=true): the recommended baseline from packages/migration-claim is Substrate ~51.24M / EVM ~1.13M / Treasury ~41.84M / Foundation ~15.04M = 109.26M. Sepolia's numbers differ slightly from the raw merkle-tree.json and ~3.19M expired-unclaimed needs a decay decision (policy in unclaimed-accounts.json = 90% decay). Regenerate the mainnet merkle-tree.json + carveouts, pin merkleRoot + programVKey + sp1VerifierGateway, then the four amounts load from those files. Migration deploy stays OFF until that snapshot + a deploy=true are in.",
+    "deploy": false,
     "emitArtifacts": true,
     "artifactsPath": "deployments/base-mainnet/migration.json",
     "merklePath": "deployments/base-mainnet/merkle-tree.json",


### PR DESCRIPTION
Finalizes the open monetary + governance decisions from `deploy/MAINNET-PARAMETERS.md`, grounded in the actual genesis/migration system (`packages/migration-claim/`).

## Decisions (rationale + alternatives in MAINNET-PARAMETERS.md)

- **True fixed supply.** The genesis migration mints all four buckets — Substrate ~51.24M / EVM ~1.13M / Treasury ~41.84M / Foundation ~15.04M — summing to `MAX_SUPPLY` 109,255,636.92 TNT *exactly*. Genesis hits the cap → MINTER inert, InflationPool can never mint. (Alt considered: ~5% mintable envelope — rejected; the snapshot already equals the cap.)
- **Inflation = 1% of supply, treasury-funded.** `year1FundTnt = 1,092,556.37 TNT` (was a placeholder 2M), transferred from the Treasury bucket into the InflationPool via `fund()` — emission, not minting. Treasury sustains flat 1% for ~38yr. (Alt: 0.5% leaner / 2% faster bootstrap.)
- **Governance (thin-float-aware):** quorum 6→**4%**, proposalThreshold 200k→**100k TNT**. Quorum is %-of-total-supply (109.26M minted at genesis) while most supply is vesting-locked/undelegated at launch — a high quorum would brick governance. Pair with a **CANCELLER guardian Safe** (the real capture defense). votingDelay 1d / votingPeriod 7d / timelock 4d kept. (Alt: quorum 3% if participation weak.)
- **`migration.deploy` pinned `false`** pending the canonical mainnet snapshot (regenerate merkle/carveouts, decide the ~3.19M expired-unclaimed decay, pin merkleRoot+programVKey).

Config-only (`base-mainnet.json` + the decision doc). Weights/payments invariants still sum to 10000. The whitepaper prose updates from the expert review land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)