### PR TITLE
fix(ci): claim-prover-api Docker build (SP1 v6 toolchain deps)

### DIFF
--- a/packages/migration-claim/sp1/prover-api/Dockerfile
+++ b/packages/migration-claim/sp1/prover-api/Dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.88-slim AS builder
+# rustc >= 1.91: the SP1 host deps raised their MSRV (sp1-build@6.1.0 needs 1.91,
+# p3-baby-bear/p3-koala-bear need 1.89). 1.88 fails the host `cargo build`.
+FROM rust:1.91-slim AS builder
 
 WORKDIR /repo
 RUN apt-get update \

--- a/packages/migration-claim/sp1/prover-api/Dockerfile
+++ b/packages/migration-claim/sp1/prover-api/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.91-slim AS builder
 
 WORKDIR /repo
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ curl git protobuf-compiler \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ curl git protobuf-compiler libprotobuf-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY packages/migration-claim/sp1 ./packages/migration-claim/sp1

--- a/packages/migration-claim/sp1/prover-api/Dockerfile
+++ b/packages/migration-claim/sp1/prover-api/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.91-slim AS builder
 
 WORKDIR /repo
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ curl git \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates g++ curl git protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 COPY packages/migration-claim/sp1 ./packages/migration-claim/sp1


### PR DESCRIPTION
The **Build Docker Images** workflow failed on every push (incl. before recent merges) building `tnt-claim-prover-api`. The SP1 v6 host crates raised their build requirements; the Dockerfile hadn't kept up. Three cascading fixes, each verified by dispatching the workflow on this branch:

1. **rust 1.88 → 1.91** — `cargo build -p tnt-claim-prover-api` errored *"rustc 1.88.0 is not supported"* (`sp1-build@6.1.0` needs 1.91; `p3-baby-bear`/`p3-koala-bear` need 1.89).
2. **+ `protobuf-compiler`** — `sp1-prover-types` build script: *"Could not find protoc"*.
3. **+ `libprotobuf-dev`** — protoc ran but couldn't resolve the well-known includes (`google/protobuf/empty.proto`); `--no-install-recommends` had skipped the dev package.

Final dispatch run: **both images (prover-api + relayer) build and push green.** The guest (`cargo prove`) build and the relayer image were unaffected throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)