### PR TITLE
chore(indexer): sync to current contracts (dead events + lock field rename)

### DIFF
--- a/indexer/config.local.yaml
+++ b/indexer/config.local.yaml
@@ -108,8 +108,6 @@ chains:
           - event: RoundAdvanced(uint64 indexed round)
           - event: Slashed(address indexed operator, uint64 indexed serviceId, uint64 indexed blueprintId, bytes32 assetHash, uint16 slashBps, uint256 operatorSlashed, uint256 delegatorsSlashed, uint256 exchangeRateAfter)
           - event: SlashRecorded(address indexed operator, uint64 indexed slashId, bytes32 assetHash, uint16 slashBps, uint256 totalSlashed, uint256 exchangeRateBefore, uint256 exchangeRateAfter)
-          - event: RewardDistributed(address indexed operator, uint256 amount)
-          - event: RewardClaimed(address indexed account, uint256 amount)
           - event: OperatorDelegationModeSet(address indexed operator, uint8 mode)
           - event: OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved)
       - name: OperatorStatusRegistry
@@ -151,7 +149,6 @@ chains:
           - event: Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)
           - event: Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)
           - event: RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
-          - event: RewardsHarvested(address indexed caller, uint256 amount)
           - event: OperatorSet(address indexed controller, address indexed operator, bool approved)
           - event: Transfer(address indexed from, address indexed to, uint256 value)
       - name: RewardVaults
@@ -167,7 +164,6 @@ chains:
           - event: RewardsDistributed(address indexed asset, address indexed operator, uint256 poolReward, uint256 commission)
           - event: DelegatorRewardsClaimed(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
           - event: OperatorCommissionClaimed(address indexed asset, address indexed operator, uint256 amount)
-          - event: DecayConfigUpdated(uint256 startBlock, uint256 rateBps)
           - event: OperatorCommissionUpdated(uint16 newBps)
           - event: LockDurationsUpdated(uint256 oneMonth, uint256 twoMonths, uint256 threeMonths, uint256 sixMonths)
       - name: InflationPool

--- a/indexer/config.yaml
+++ b/indexer/config.yaml
@@ -99,8 +99,6 @@ chains:
           - event: RoundAdvanced(uint64 indexed round)
           - event: Slashed(address indexed operator, uint64 indexed serviceId, uint64 indexed blueprintId, bytes32 assetHash, uint16 slashBps, uint256 operatorSlashed, uint256 delegatorsSlashed, uint256 exchangeRateAfter)
           - event: SlashRecorded(address indexed operator, uint64 indexed slashId, bytes32 assetHash, uint16 slashBps, uint256 totalSlashed, uint256 exchangeRateBefore, uint256 exchangeRateAfter)
-          - event: RewardDistributed(address indexed operator, uint256 amount)
-          - event: RewardClaimed(address indexed account, uint256 amount)
           - event: OperatorDelegationModeSet(address indexed operator, uint8 mode)
           - event: OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved)
       - name: OperatorStatusRegistry
@@ -141,7 +139,6 @@ chains:
           - event: Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)
           - event: Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)
           - event: RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
-          - event: RewardsHarvested(address indexed caller, uint256 amount)
           - event: OperatorSet(address indexed controller, address indexed operator, bool approved)
           - event: Transfer(address indexed from, address indexed to, uint256 value)
       - name: RewardVaults
@@ -157,7 +154,6 @@ chains:
           - event: RewardsDistributed(address indexed asset, address indexed operator, uint256 poolReward, uint256 commission)
           - event: DelegatorRewardsClaimed(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
           - event: OperatorCommissionClaimed(address indexed asset, address indexed operator, uint256 amount)
-          - event: DecayConfigUpdated(uint256 startBlock, uint256 rateBps)
           - event: OperatorCommissionUpdated(uint16 newBps)
           - event: LockDurationsUpdated(uint256 oneMonth, uint256 twoMonths, uint256 threeMonths, uint256 sixMonths)
       - name: InflationPool

--- a/indexer/schema.graphql
+++ b/indexer/schema.graphql
@@ -660,7 +660,7 @@ type DepositLock {
   position: DelegatorAssetPosition!
   amount: BigInt!
   duration: LockDuration!
-  expiryBlock: BigInt!
+  expiryTimestamp: BigInt!
 }
 
 """Withdraw request queue mirrored from MultiAssetDelegation.WithdrawScheduled/Withdrawn. readyAtRound matches the contract's executeAfter round."""

--- a/indexer/src/EventHandlers.ts
+++ b/indexer/src/EventHandlers.ts
@@ -11,10 +11,10 @@
  * staking entities), then the block-tick handlers last.
  */
 import "./handlers/blueprintManager";
-import "./handlers/credits";
 import "./handlers/rewardVaults";
 import "./handlers/staking";
 import "./handlers/tangle";
 import "./handlers/validatorPods";
 import "./handlers/liquidDelegation";
+import "./handlers/credits";
 import "./handlers/hourly";

--- a/indexer/src/handlers/liquidDelegation.ts
+++ b/indexer/src/handlers/liquidDelegation.ts
@@ -288,20 +288,6 @@ indexer.onEvent({ contract: "LiquidDelegationVault", event: "Transfer" }, async 
   await handleShareMovement(context, vault, from, to, value, timestamp);
 });
 
-indexer.onEvent({ contract: "LiquidDelegationVault", event: "RewardsHarvested" }, async ({ event, context }) => {
-  const timestamp = getTimestamp(event);
-  const vault = await ensureVaultEntity(context, event.srcAddress);
-  if (!vault) return;
-  const amount = toBigInt(event.params.amount);
-  const updatedVault: LiquidVaultEntity = {
-    ...vault,
-    totalAssets: (vault.totalAssets ?? 0n) + amount,
-    harvestedRewards: (vault.harvestedRewards ?? 0n) + amount,
-    updatedAt: timestamp,
-  } as LiquidVaultEntity;
-  saveVaultEntity(context, updatedVault);
-});
-
 const handleShareMovement = async (
   context: HandlerContext,
   vault: LiquidVaultEntity,

--- a/indexer/src/handlers/rewardVaults.ts
+++ b/indexer/src/handlers/rewardVaults.ts
@@ -131,13 +131,6 @@ indexer.onEvent({ contract: "RewardVaults", event: "OperatorCommissionClaimed" }
   });
 });
 
-indexer.onEvent({ contract: "RewardVaults", event: "DecayConfigUpdated" }, async ({ event, context }) => {
-  recordRewardVaultEvent(context, "DECAY_UPDATED", event, {
-    valueA: toBigInt(event.params.startBlock),
-    valueB: toBigInt(event.params.rateBps),
-  });
-});
-
 indexer.onEvent({ contract: "RewardVaults", event: "OperatorCommissionUpdated" }, async ({ event, context }) => {
   recordRewardVaultEvent(context, "COMMISSION_UPDATED", event, { valueA: BigInt(event.params.newBps) });
 });

--- a/indexer/src/handlers/staking.ts
+++ b/indexer/src/handlers/staking.ts
@@ -21,8 +21,6 @@ import type {
 } from "envio";
 import {
   ZERO_ADDRESS,
-  createStakingRewardClaim,
-  createRewardDistribution,
   ensureAssetPosition,
   ensureDelegationPosition,
   ensureDelegator,
@@ -279,7 +277,7 @@ indexer.onEvent({ contract: "MultiAssetDelegation", event: "Deposited" }, async 
       position_id: position.id,
       amount,
       duration: multiplier,
-      expiryBlock: 0n,
+      expiryTimestamp: 0n,
     } as DepositLock;
     context.DepositLock.set(lock);
   }
@@ -516,22 +514,6 @@ indexer.onEvent({ contract: "MultiAssetDelegation", event: "SlashRecorded" }, as
     txHash: getTxHash(event),
   } as SlashRecord;
   context.SlashRecord.set(record);
-});
-
-indexer.onEvent({ contract: "MultiAssetDelegation", event: "RewardDistributed" }, async ({ event, context }) => {
-  const operator = await ensureOperator(context, event.params.operator, getTimestamp(event));
-  createRewardDistribution(context, "POOL", event, {
-    operator_id: operator.id,
-    amount: toBigInt(event.params.amount),
-  });
-});
-
-indexer.onEvent({ contract: "MultiAssetDelegation", event: "RewardClaimed" }, async ({ event, context }) => {
-  const delegator = await ensureDelegator(context, event.params.account, getTimestamp(event));
-  createStakingRewardClaim(context, "DELEGATOR_CLAIM", event, {
-    delegator_id: delegator.id,
-    amount: toBigInt(event.params.amount),
-  });
 });
 
 indexer.onEvent({ contract: "MultiAssetDelegation", event: "OperatorDelegationModeSet" }, async ({ event, context }) => {


### PR DESCRIPTION
Brings the Envio indexer back in line with the contracts (last synced in #155, before #167/#169). `npm run codegen`, `npm run build`, and `npm run test` all pass.

## What "indexer sync" covered
1. **Removed 4 dead event registrations** + their handlers — verified removed from `src/` (not renamed):
   - `RewardDistributed`, `RewardClaimed` (MultiAssetDelegation), `RewardsHarvested` (LiquidDelegationVault), `DecayConfigUpdated` (RewardVaults).
   - Reward flow now runs through InflationPool's `OperatorRewardClaimed`/`CustomerRewardClaimed`/`DeveloperRewardClaimed` (already indexed and kept).
2. **Renamed `expiryBlock` → `expiryTimestamp`** (`schema.graphql` + staking handler) to match the #169 timestamp-based lock fix. It's a `0n` placeholder (the `Deposited` event carries no expiry) — renamed for consistency with the contract's `LockInfo.expiryTimestamp`.
3. **Kept Credits** — `CreditsClaimed` is real (`packages/credits/src/Credits.sol`, deployed by `FullDeploy`); signature matches. (An earlier pass that only searched `src/` wrongly flagged it; restored.)

No signature drift found on spot-checked high-traffic events (`Deposited`, `Slashed`, `ServiceActivated`, `SubscriptionBilled`).

## Not in this PR — Phase-2 coverage (dapp-driven follow-up)
New #167/#169 events that extend already-indexed entities, for when the dapp needs them queryable: `BlueprintTransferProposed`/`Cancelled`, `BlueprintSourcesUpdated`/`Acked`, `DisputeBondClaimed`/`Credited`, `CommissionChangeQueued`/`Executed`/`Cancelled`, `ServiceTerminatedForNonPayment`, `ServiceExtended`, `ExpiredLocksHarvested`. Each needs a handler (+ maybe a schema field), so it should be scoped to what the dapp surfaces rather than indexing everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)