### PR TITLE
fix(beacon): bound beacon slash to on-beacon principal + make service slash punitive

### DIFF
--- a/src/beacon/L2SlashingConnector.sol
+++ b/src/beacon/L2SlashingConnector.sol
@@ -6,6 +6,10 @@ import { ICrossChainMessenger } from "./interfaces/ICrossChainMessenger.sol";
 
 interface IBeaconSlashPod {
     function beaconChainSlashingFactor() external view returns (uint64);
+    /// @notice Parked execution-layer ETH (in gwei) the pod has accounted via checkpoints.
+    /// @dev Tips, partial withdrawals and exited principal already in pod custody. This ETH
+    ///      cannot be slashed on the beacon chain, so it must be excluded from the slash base.
+    function withdrawableRestakedExecutionLayerGwei() external view returns (uint64);
 }
 
 /// @title L2SlashingConnector
@@ -34,6 +38,10 @@ contract L2SlashingConnector {
     error UnsupportedDestinationChain();
     error MessengerNotConfigured();
     error UnknownPod(address pod);
+    /// @dev `registerPodOperator` / `batchRegisterPodOperators` reject an operator the
+    ///      PodManager does not recognise, closing the BCN-004 vector where the owner could
+    ///      map an arbitrary pod to an arbitrary address and ship slashing against it.
+    error NotOperator(address operator);
     error SlashingFactorMismatch(address pod, uint64 expected, uint64 provided);
     /// @dev The factor delta resolves to a zero-bps L2 slash (operator has no L2 stake,
     ///      or the loss is sub-bps and truncates to 0). The L2 receiver hard-reverts on a
@@ -190,6 +198,15 @@ contract L2SlashingConnector {
     /// @notice Batch propagate multiple beacon slashings
     /// @param pods Array of pods to process
     /// @param newSlashingFactors Corresponding slashing factors
+    /// @dev Each self-call is funded with the full call-attributable balance so the bridge
+    ///      fee is actually paid. Previously the self-calls forwarded `{value: 0}`, so with a
+    ///      non-zero relay fee (the production case for OP-Stack/Arbitrum L1→L2 bridges) every
+    ///      `_propagateBeaconSlashing` reverted `InsufficientFee`, the `try/catch` swallowed
+    ///      it, and the batch silently advanced ZERO slashing factors. `_propagateBeaconSlashing`
+    ///      refunds its own excess to `msg.sender` — which for these self-calls is this contract
+    ///      — so unspent value returns here and is forwarded to the next pod; any final
+    ///      remainder is swept back to the caller. Pre-existing contract funds (`baseline`) are
+    ///      never touched.
     function batchPropagateBeaconSlashing(
         address[] calldata pods,
         uint64[] calldata newSlashingFactors
@@ -200,12 +217,24 @@ contract L2SlashingConnector {
     {
         require(pods.length == newSlashingFactors.length, "Length mismatch");
 
+        uint256 baseline = address(this).balance - msg.value;
+
         for (uint256 i = 0; i < pods.length; i++) {
-            // Try to propagate, continue on failure
-            try this.propagateBeaconSlashingInternal{ value: 0 }(
+            // Forward the whole call-attributable balance; the self-call refunds its unused
+            // portion back here (refund target is this contract), so the next iteration can
+            // reuse it. A caught revert rolls back its value transfer, leaving the balance intact.
+            uint256 forwardValue = address(this).balance - baseline;
+            try this.propagateBeaconSlashingInternal{ value: forwardValue }(
                 pods[i], newSlashingFactors[i], defaultDestinationChainId
             ) { }
                 catch { }
+        }
+
+        // Sweep any unspent fee budget back to the caller, leaving pre-existing funds in place.
+        uint256 leftover = address(this).balance - baseline;
+        if (leftover > 0) {
+            (bool success,) = msg.sender.call{ value: leftover }("");
+            require(success, "Refund failed");
         }
     }
 
@@ -270,7 +299,7 @@ contract L2SlashingConnector {
         // it to. This bounds the on-L2 slash to the pod's contribution, eliminating the
         // base mismatch (whole-stake over-slash) and the multi-pod amplification where
         // each pod independently slashed a share of the shared total stake.
-        uint256 podPrincipal = podManager.totalAssetsOf(podManager.podToOwner(pod));
+        uint256 podPrincipal = _podBeaconPrincipal(pod);
         uint256 podSlashAmount = (podPrincipal * slashPercentage) / 1e18;
 
         // Operator's TOTAL L2 stake (self + delegated) — the exact base that L2's
@@ -363,7 +392,7 @@ contract L2SlashingConnector {
 
         // Mirror propagation: scale the slash to the pod's own contribution, then
         // re-express against the operator's total L2 stake (see `_propagateBeaconSlashing`).
-        uint256 podPrincipal = podManager.totalAssetsOf(podManager.podToOwner(pod));
+        uint256 podPrincipal = _podBeaconPrincipal(pod);
         uint256 podSlashAmount = (podPrincipal * slashPercentage) / 1e18;
         uint256 operatorStake = podManager.getOperatorStake(operator);
         if (operatorStake == 0) return 0;
@@ -412,7 +441,7 @@ contract L2SlashingConnector {
         // (slashBps is a fixed-width uint16, so its magnitude does not change payload
         //  size; this keeps the estimate consistent with the value actually shipped.)
         uint256 slashPercentage = (uint256(lastFactor - newSlashingFactor) * 1e18) / lastFactor;
-        uint256 podPrincipal = podManager.totalAssetsOf(podManager.podToOwner(pod));
+        uint256 podPrincipal = _podBeaconPrincipal(pod);
         uint256 podSlashAmount = (podPrincipal * slashPercentage) / 1e18;
         uint256 operatorStake = operator == address(0) ? 0 : podManager.getOperatorStake(operator);
         uint16 slashBps = 0;
@@ -454,7 +483,10 @@ contract L2SlashingConnector {
     }
 
     /// @notice Register pod to operator mapping
+    /// @dev BCN-004: validate both legs against the PodManager so the owner cannot map an
+    ///      unknown/arbitrary pod to an arbitrary address and then ship a slash against it.
     function registerPodOperator(address pod, address operator) external onlyOwner {
+        _validatePodOperator(pod, operator);
         podOperator[pod] = operator;
     }
 
@@ -462,12 +494,25 @@ contract L2SlashingConnector {
     function batchRegisterPodOperators(address[] calldata pods, address[] calldata operators) external onlyOwner {
         require(pods.length == operators.length, "Length mismatch");
         for (uint256 i = 0; i < pods.length; i++) {
+            _validatePodOperator(pods[i], operators[i]);
             podOperator[pods[i]] = operators[i];
         }
     }
 
+    /// @notice Reject registrations the PodManager does not back: a real pod (non-zero
+    ///         owner) mapped to a registered operator. Closes the BCN-004 amplification
+    ///         where the owner could fabricate pod→operator pairs to target victims.
+    function _validatePodOperator(address pod, address operator) internal view {
+        if (pod == address(0) || operator == address(0)) revert ZeroAddress();
+        if (podManager.podToOwner(pod) == address(0)) revert UnknownPod(pod);
+        if (!podManager.isOperator(operator)) revert NotOperator(operator);
+    }
+
     /// @notice Update the slashing oracle address
+    /// @dev BCN-002: reject the zero address so the oracle role cannot be silently bricked
+    ///      (mirrors the `transferOwnership` guard below).
     function setSlashingOracle(address newOracle) external onlyOwner {
+        if (newOracle == address(0)) revert ZeroAddress();
         address oldOracle = slashingOracle;
         slashingOracle = newOracle;
         emit SlashingOracleUpdated(oldOracle, newOracle);
@@ -482,6 +527,20 @@ contract L2SlashingConnector {
     // ═══════════════════════════════════════════════════════════════════════════
     // INTERNAL FUNCTIONS
     // ═══════════════════════════════════════════════════════════════════════════
+
+    /// @notice Beacon principal (in wei) still exposed to beacon-chain slashing for `pod`.
+    /// @dev BCN-001: `totalAssetsOf` aggregates beacon principal PLUS parked execution-layer
+    ///      ETH (tips, partial withdrawals and exited principal already in pod custody,
+    ///      credited via `recordBeaconChainRebase`). That parked ETH can never be slashed on
+    ///      the beacon chain, so including it in the slash base over-states the loss and lets
+    ///      a modest beacon slash saturate `slashBps` at 100% of the operator's L2 stake.
+    ///      Slash only against on-beacon principal: `totalAssets` minus the parked tally the
+    ///      pod tracks (`withdrawableRestakedExecutionLayerGwei`).
+    function _podBeaconPrincipal(address pod) internal view returns (uint256) {
+        uint256 totalAssets = podManager.totalAssetsOf(podManager.podToOwner(pod));
+        uint256 parkedWei = uint256(IBeaconSlashPod(pod).withdrawableRestakedExecutionLayerGwei()) * 1 gwei;
+        return totalAssets > parkedWei ? totalAssets - parkedWei : 0;
+    }
 
     /// @notice Get the operator address for a pod
     function _getOperatorForPod(address pod) internal view returns (address) {

--- a/src/beacon/ValidatorPod.sol
+++ b/src/beacon/ValidatorPod.sol
@@ -92,6 +92,16 @@ contract ValidatorPod is ReentrancyGuard {
     /// @notice Authorized proof submitter (optional, for third-party proof submission)
     address public proofSubmitter;
 
+    /// @notice Beacon principal (in wei) burned by an L2/service slash that remains
+    ///         physically in this pod.
+    /// @dev A service slash reduces the manager's beacon-pool `totalAssets` bookkeeping (the
+    ///      escrow burn in `ValidatorPodManager.completeUndelegation`) but moves no ETH out of
+    ///      the pod, so the slashed principal is stranded here and is economically destroyed.
+    ///      `withdrawNonBeaconChainEth` floors withdrawals at `totalAssetsOf + this`, so the
+    ///      stranded principal can never be re-extracted as "non-beacon surplus" once
+    ///      `totalAssets` drops. Monotonically increasing; the manager is the only writer.
+    uint256 public slashedPrincipalRetainedWei;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // EVENTS
     // ═══════════════════════════════════════════════════════════════════════════
@@ -124,6 +134,7 @@ contract ValidatorPod is ReentrancyGuard {
     error NotOwnerOrProofSubmitter();
     error ValidatorNotSlashed();
     error CurrentlyInCheckpoint();
+    error ZeroAddress();
 
     // ═══════════════════════════════════════════════════════════════════════════
     // MODIFIERS
@@ -512,7 +523,10 @@ contract ValidatorPod is ReentrancyGuard {
             revert InsufficientBalance();
         }
 
-        uint256 reservedPrincipal = podManager.totalAssetsOf(podOwner);
+        // Floor includes principal burned by a service slash that is still physically here:
+        // `totalAssetsOf` drops on the manager's escrow burn but the ETH never left the pod,
+        // so without this term the owner could drain the slashed principal as fake surplus.
+        uint256 reservedPrincipal = podManager.totalAssetsOf(podOwner) + slashedPrincipalRetainedWei;
         uint256 surplus = balance > reservedPrincipal ? balance - reservedPrincipal : 0;
         if (amount > surplus) {
             revert InsufficientBalance();
@@ -524,11 +538,29 @@ contract ValidatorPod is ReentrancyGuard {
         emit NonBeaconChainETHWithdrawn(recipient, amount);
     }
 
+    /// @notice Record beacon principal burned by a service slash that stays in this pod.
+    /// @dev Called by the manager from `completeUndelegation` when it burns the slashed
+    ///      portion of a delegator's escrow shares. The corresponding ETH is not moved out
+    ///      of the pod, so it is added to the `withdrawNonBeaconChainEth` floor to keep it
+    ///      un-extractable (closes the drain-slashed-principal finding). Only the manager
+    ///      can call this; it is the sole writer of `slashedPrincipalRetainedWei`.
+    function recordSlashedPrincipalRetained(uint256 amount) external onlyPodManager {
+        if (amount > 0) {
+            slashedPrincipalRetainedWei += amount;
+        }
+    }
+
     /// @notice Recover ERC20 tokens accidentally sent to this pod
     /// @param token Token to recover
     /// @param recipient Address to send tokens to
     /// @param amount Amount to recover
-    function recoverTokens(IERC20 token, address recipient, uint256 amount) external onlyPodOwner {
+    /// @dev BCN-003: pods are designed to custody ETH only — any ERC20 here is an accidental
+    ///      transfer. `nonReentrant` + a non-zero recipient guard harden the recovery path.
+    ///      If the protocol ever routes accounted ERC20s (LSTs, reward/slash-proceeds tokens)
+    ///      into pods, this function MUST gain a reservation against that accounting before
+    ///      those flows ship, exactly as `withdrawNonBeaconChainEth` reserves beacon principal.
+    function recoverTokens(IERC20 token, address recipient, uint256 amount) external onlyPodOwner nonReentrant {
+        if (recipient == address(0)) revert ZeroAddress();
         token.safeTransfer(recipient, amount);
     }
 

--- a/src/beacon/ValidatorPodManager.sol
+++ b/src/beacon/ValidatorPodManager.sol
@@ -742,6 +742,16 @@ contract ValidatorPodManager is IStaking, Ownable, ReentrancyGuard {
                 bp.totalAssets = burnAssets >= bp.totalAssets ? 0 : bp.totalAssets - burnAssets;
                 // forge-lint: disable-next-line(unsafe-typecast)
                 emit BeaconRebase(msg.sender, -int256(burnAssets), bp.totalAssets, bp.totalShares);
+
+                // The burn lowered `totalAssets`, but the slashed ETH (if it has physically
+                // arrived) is still in the pod. Tell the pod to floor `withdrawNonBeaconChainEth`
+                // at the burned amount so the owner cannot drain the slashed principal as fake
+                // "non-beacon surplus" once the floor drops. Without this the service slash is
+                // non-punitive: the owner re-extracts 100% of principal despite the slash.
+                address podAddr = ownerToPod[msg.sender];
+                if (podAddr != address(0) && burnAssets > 0) {
+                    ValidatorPod(payable(podAddr)).recordSlashedPrincipalRetained(burnAssets);
+                }
             }
         }
 

--- a/test/audit/medlow/BeaconL2.t.sol
+++ b/test/audit/medlow/BeaconL2.t.sol
@@ -35,9 +35,19 @@ contract MockPodManager {
     mapping(address => address) public podToOwner;
     mapping(address => uint256) internal _totalAssetsOf;
     mapping(address => uint256) internal _operatorStake;
+    mapping(address => bool) internal _isOperator;
 
     function setPodOwner(address pod, address owner) external {
         podToOwner[pod] = owner;
+    }
+
+    function setOperator(address operator, bool registered) external {
+        _isOperator[operator] = registered;
+    }
+
+    /// @notice Used by the connector's BCN-004 registration validation.
+    function isOperator(address operator) external view returns (bool) {
+        return _isOperator[operator];
     }
 
     function setTotalAssetsOf(address owner, uint256 amount) external {
@@ -60,13 +70,23 @@ contract MockPodManager {
 /// @notice Pod that reports a controllable `beaconChainSlashingFactor`.
 contract MockSlashPod {
     uint64 public factor;
+    uint64 public parkedGwei;
 
     function setFactor(uint64 f) external {
         factor = f;
     }
 
+    function setParkedGwei(uint64 g) external {
+        parkedGwei = g;
+    }
+
     function beaconChainSlashingFactor() external view returns (uint64) {
         return factor;
+    }
+
+    /// @notice Parked execution-layer tally the connector subtracts from the slash base.
+    function withdrawableRestakedExecutionLayerGwei() external view returns (uint64) {
+        return parkedGwei;
     }
 }
 
@@ -79,16 +99,7 @@ contract MockMessenger {
         return 0;
     }
 
-    function sendMessage(
-        uint256,
-        address,
-        bytes calldata payload,
-        uint256
-    )
-        external
-        payable
-        returns (bytes32)
-    {
+    function sendMessage(uint256, address, bytes calldata payload, uint256) external payable returns (bytes32) {
         lastPayload = payload;
         sendCount += 1;
         return keccak256(payload);
@@ -150,9 +161,12 @@ contract BeaconL2ConnectorAuditTest is Test {
         connector.setMessenger(address(messenger));
         connector.setChainConfig(DEST_CHAIN, makeAddr("receiver"), 200_000, true);
         connector.setDefaultDestinationChain(DEST_CHAIN);
-        connector.registerPodOperator(address(pod), operator);
 
+        // BCN-004: registration now validates the pod has a known owner and the operator is
+        // registered, so seed both on the mock manager BEFORE registering the pod→operator.
         podManager.setPodOwner(address(pod), podOwner);
+        podManager.setOperator(operator, true);
+        connector.registerPodOperator(address(pod), operator);
     }
 
     /// @notice A factor decrease that resolves to 0 bps (operator has zero L2 stake) MUST revert
@@ -170,9 +184,7 @@ contract BeaconL2ConnectorAuditTest is Test {
         assertEq(connector.lastProcessedSlashingFactorByChain(address(pod), DEST_CHAIN), 0, "baseline starts unset");
 
         vm.prank(oracle);
-        vm.expectRevert(
-            abi.encodeWithSelector(L2SlashingConnector.NothingToSlash.selector, address(pod), DEST_CHAIN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(L2SlashingConnector.NothingToSlash.selector, address(pod), DEST_CHAIN));
         connector.propagateBeaconSlashing(address(pod), newFactor);
 
         // SECURE INVARIANT 1: no message was shipped (no wasted bridge fee on a guaranteed-reject).
@@ -200,9 +212,7 @@ contract BeaconL2ConnectorAuditTest is Test {
         pod.setFactor(newFactor);
 
         vm.prank(oracle);
-        vm.expectRevert(
-            abi.encodeWithSelector(L2SlashingConnector.NothingToSlash.selector, address(pod), DEST_CHAIN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(L2SlashingConnector.NothingToSlash.selector, address(pod), DEST_CHAIN));
         connector.propagateBeaconSlashing(address(pod), newFactor);
 
         // Operator re-acquires L2 stake; the identical factor delta must now be propagable.
@@ -236,9 +246,7 @@ contract BeaconL2ConnectorAuditTest is Test {
         connector.propagateBeaconSlashing(address(pod), newFactor);
 
         assertEq(messenger.sendCount(), 1, "real slash ships exactly one message");
-        assertEq(
-            connector.lastProcessedSlashingFactorByChain(address(pod), DEST_CHAIN), newFactor, "baseline advanced"
-        );
+        assertEq(connector.lastProcessedSlashingFactorByChain(address(pod), DEST_CHAIN), newFactor, "baseline advanced");
     }
 }
 

--- a/test/beacon/BCN001.t.sol
+++ b/test/beacon/BCN001.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test, console2 } from "forge-std/Test.sol";
+import { ValidatorPodManager } from "src/beacon/ValidatorPodManager.sol";
+import { L2SlashingConnector } from "src/beacon/L2SlashingConnector.sol";
+import { MockBeaconOracle } from "src/beacon/BeaconRootReceiver.sol";
+import { ICrossChainMessenger } from "src/beacon/interfaces/ICrossChainMessenger.sol";
+
+/// @notice BCN-001 regression: `L2SlashingConnector` must slash only against on-beacon
+///         principal, excluding parked execution-layer ETH (tips / partial withdrawals /
+///         exited principal already in pod custody). Before the fix it derived the slash
+///         base from `podManager.totalAssetsOf()`, which includes that parked ETH, so a
+///         50% beacon slash on a 32-ETH validator with 968 ETH parked saturated `slashBps`
+///         at the 10000 cap (100% of L2 stake) instead of the ~16-ETH real loss.
+contract BCN001OverSlashPoC is Test {
+    MockBeaconOracle oracle;
+    ValidatorPodManager vpm;
+    L2SlashingConnector connector;
+    address constant POD = address(0xA1);
+    address constant POD_OWNER = address(0xB1);
+    address constant OPERATOR = address(0xC1);
+    address constant SLASHING_ORACLE = address(0xD1);
+    uint256 constant TANGLE_CHAIN = 5000;
+    MockMessenger messenger;
+
+    function setUp() public {
+        oracle = new MockBeaconOracle();
+        vpm = new ValidatorPodManager(address(oracle), 1 ether);
+        messenger = new MockMessenger();
+
+        // Make the connector's PodManager validity checks (BCN-004) pass for the mocked pod.
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.podToOwner.selector, POD), abi.encode(POD_OWNER));
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.isOperator.selector, OPERATOR), abi.encode(true));
+
+        vm.startPrank(SLASHING_ORACLE);
+        connector = new L2SlashingConnector(address(vpm), SLASHING_ORACLE);
+        connector.setMessenger(address(messenger));
+        connector.setChainConfig(TANGLE_CHAIN, address(0xFE), 200_000, true);
+        connector.setDefaultDestinationChain(TANGLE_CHAIN);
+        connector.registerPodOperator(POD, OPERATOR);
+        vm.stopPrank();
+    }
+
+    function test_parkedEthExcludedFromSlashBase() public {
+        // 32 ETH on-beacon principal + 968 ETH parked execution-layer ETH = 1000 ETH total.
+        uint256 onBeaconPrincipal = 32 ether;
+        uint256 parkedEth = 968 ether;
+        uint256 totalAssets = onBeaconPrincipal + parkedEth;
+        vm.mockCall(
+            address(vpm), abi.encodeWithSelector(vpm.totalAssetsOf.selector, POD_OWNER), abi.encode(totalAssets)
+        );
+        vm.mockCall(
+            address(vpm), abi.encodeWithSelector(vpm.getOperatorStake.selector, OPERATOR), abi.encode(100 ether)
+        );
+
+        // The pod reports its parked tally (in gwei); the connector subtracts it from the base.
+        uint64 newFactor = 0.5e18; // 50% beacon slash
+        MockPod mockPod = new MockPod(newFactor);
+        vm.etch(POD, address(mockPod).code);
+        MockPod(address(POD)).setValue(newFactor);
+        MockPod(address(POD)).setParked(uint64(parkedEth / 1 gwei));
+
+        vm.deal(SLASHING_ORACLE, 1 ether);
+        vm.prank(SLASHING_ORACLE);
+        connector.propagateBeaconSlashing{ value: 0.01 ether }(POD, newFactor);
+
+        bytes memory payload = messenger.lastPayload();
+        bytes memory body = new bytes(payload.length - 4);
+        for (uint256 i = 0; i < body.length; i++) {
+            body[i] = payload[i + 4];
+        }
+        (, uint16 slashBps,,,) = abi.decode(body, (address, uint16, uint64, uint256, address));
+
+        // 50% of 32 ETH = 16 ETH lost; against a 100 ETH operator stake that is 1600 bps.
+        // It must NOT saturate at 10000 (which would burn the entire L2 stake).
+        assertEq(slashBps, 1600, "BCN-001: slash reflects only on-beacon principal, parked ETH excluded");
+        assertLt(slashBps, 10_000, "BCN-001: no 100% saturation from parked ETH");
+    }
+}
+
+contract MockMessenger is ICrossChainMessenger {
+    bytes private _lastPayload;
+    uint256 public fee = 0.001 ether;
+
+    function sendMessage(uint256, address, bytes calldata payload, uint256) external payable returns (bytes32) {
+        require(msg.value >= fee, "fee");
+        _lastPayload = payload;
+        return keccak256(payload);
+    }
+
+    function lastPayload() external view returns (bytes memory) {
+        return _lastPayload;
+    }
+
+    function estimateFee(uint256, bytes calldata, uint256) external view returns (uint256) {
+        return fee;
+    }
+
+    function isChainSupported(uint256) external pure returns (bool) {
+        return true;
+    }
+}
+
+contract MockPod {
+    uint64 public beaconChainSlashingFactor;
+    uint64 public withdrawableRestakedExecutionLayerGwei;
+
+    constructor(uint64 v) {
+        beaconChainSlashingFactor = v;
+    }
+
+    function setValue(uint64 v) external {
+        beaconChainSlashingFactor = v;
+    }
+
+    function setParked(uint64 g) external {
+        withdrawableRestakedExecutionLayerGwei = g;
+    }
+}

--- a/test/beacon/BatchPropagateBeaconSlashingFee.t.sol
+++ b/test/beacon/BatchPropagateBeaconSlashingFee.t.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { ValidatorPodManager } from "src/beacon/ValidatorPodManager.sol";
+import { L2SlashingConnector } from "src/beacon/L2SlashingConnector.sol";
+import { MockBeaconOracle } from "src/beacon/BeaconRootReceiver.sol";
+import { ICrossChainMessenger } from "src/beacon/interfaces/ICrossChainMessenger.sol";
+
+/// @notice Regression for the batch fee-forwarding bug: `batchPropagateBeaconSlashing` used
+///         to forward `{value: 0}` to each internal self-call, so when the messenger charges a
+///         non-zero relay fee (the production case for OP-Stack/Arbitrum L1→L2 bridges) every
+///         `_propagateBeaconSlashing` reverted `InsufficientFee`, the `try/catch` swallowed it,
+///         and the batch silently advanced ZERO slashing factors. The fix funds each self-call
+///         from the call-attributable balance and sweeps the remainder back to the caller.
+contract BatchPropagateBeaconSlashingFeeTest is Test {
+    MockBeaconOracle oracle;
+    ValidatorPodManager vpm;
+    L2SlashingConnector connector;
+    MockMessenger messenger;
+    address constant POD = address(0xA1);
+    address constant POD_OWNER = address(0xB1);
+    address constant OPERATOR = address(0xC1);
+    address constant SLASHING_ORACLE = address(0xD1);
+    uint256 constant TANGLE_CHAIN = 5000;
+
+    function setUp() public {
+        oracle = new MockBeaconOracle();
+        vpm = new ValidatorPodManager(address(oracle), 1 ether);
+        messenger = new MockMessenger(); // default fee = 0.001 ether (non-zero, like prod)
+
+        // BCN-004 registration validation: pod must have a known owner and a registered operator.
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.podToOwner.selector, POD), abi.encode(POD_OWNER));
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.isOperator.selector, OPERATOR), abi.encode(true));
+
+        vm.startPrank(SLASHING_ORACLE);
+        connector = new L2SlashingConnector(address(vpm), SLASHING_ORACLE);
+        connector.setMessenger(address(messenger));
+        connector.setChainConfig(TANGLE_CHAIN, address(0xFE), 200_000, true);
+        connector.setDefaultDestinationChain(TANGLE_CHAIN);
+        connector.registerPodOperator(POD, OPERATOR);
+        vm.stopPrank();
+    }
+
+    function test_batchPropagatesUnderNonZeroFee() public {
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.totalAssetsOf.selector, POD_OWNER), abi.encode(40 ether));
+        vm.mockCall(address(vpm), abi.encodeWithSelector(vpm.getOperatorStake.selector, OPERATOR), abi.encode(40 ether));
+
+        uint64 newFactor = 0.5e18; // 50% real slash
+        MockPod mockPod = new MockPod(newFactor);
+        vm.etch(POD, address(mockPod).code);
+        MockPod(address(POD)).setValue(newFactor);
+        MockPod(address(POD)).setParked(0);
+
+        address[] memory pods = new address[](1);
+        pods[0] = POD;
+        uint64[] memory newFactors = new uint64[](1);
+        newFactors[0] = newFactor;
+
+        vm.deal(SLASHING_ORACLE, 1 ether);
+        uint256 oracleBefore = SLASHING_ORACLE.balance;
+
+        vm.prank(SLASHING_ORACLE);
+        connector.batchPropagateBeaconSlashing{ value: 1 ether }(pods, newFactors);
+
+        // The batch must actually propagate: baseline advanced + a cross-chain message shipped.
+        assertEq(
+            connector.lastProcessedSlashingFactorByChain(POD, TANGLE_CHAIN),
+            newFactor,
+            "batch advanced the baseline (slash propagated)"
+        );
+        assertGt(messenger.lastPayload().length, 0, "batch shipped a cross-chain message");
+
+        // Only the bridge fee was spent; the rest is swept back to the caller.
+        assertEq(oracleBefore - SLASHING_ORACLE.balance, messenger.fee(), "only the fee was spent; remainder refunded");
+        assertEq(address(connector).balance, 0, "no fee budget stranded in the connector");
+    }
+}
+
+contract MockMessenger is ICrossChainMessenger {
+    bytes public lastPayload;
+    uint256 public fee = 0.001 ether; // NON-ZERO, mirrors production L1→L2 relay fee
+
+    function sendMessage(uint256, address, bytes calldata payload, uint256) external payable returns (bytes32) {
+        require(msg.value >= fee, "fee");
+        lastPayload = payload;
+        return keccak256(payload);
+    }
+
+    function estimateFee(uint256, bytes calldata, uint256) external view returns (uint256) {
+        return fee;
+    }
+
+    function isChainSupported(uint256) external pure returns (bool) {
+        return true;
+    }
+}
+
+contract MockPod {
+    uint64 public beaconChainSlashingFactor;
+    uint64 public withdrawableRestakedExecutionLayerGwei;
+
+    constructor(uint64 v) {
+        beaconChainSlashingFactor = v;
+    }
+
+    function setValue(uint64 v) external {
+        beaconChainSlashingFactor = v;
+    }
+
+    function setParked(uint64 g) external {
+        withdrawableRestakedExecutionLayerGwei = g;
+    }
+}

--- a/test/beacon/CrossChainSlashingTest.t.sol
+++ b/test/beacon/CrossChainSlashingTest.t.sol
@@ -249,6 +249,7 @@ contract MockStaking is IStaking {
 
 contract MockSlashPod {
     uint64 public beaconChainSlashingFactor;
+    uint64 public withdrawableRestakedExecutionLayerGwei;
 
     constructor(uint64 factor) {
         beaconChainSlashingFactor = factor;
@@ -256,6 +257,10 @@ contract MockSlashPod {
 
     function setBeaconChainSlashingFactor(uint64 factor) external {
         beaconChainSlashingFactor = factor;
+    }
+
+    function setParkedGwei(uint64 gwei_) external {
+        withdrawableRestakedExecutionLayerGwei = gwei_;
     }
 }
 
@@ -296,13 +301,21 @@ contract CrossChainSlashingTest is Test {
     ///      makes the shipped `slashBps == 0` — a no-op the receiver now (correctly)
     ///      rejects with `InvalidPayload()`. Seed the pod principal + operator stake so
     ///      the legitimate slash path produces a nonzero, pod-bounded `slashBps`.
+    /// @dev `registerPodOperator` now validates both legs against the PodManager (BCN-004):
+    ///      the pod must have a non-zero owner and the operator must be registered. The mock
+    ///      `MockSlashPod`s here are never created through `podManager.createPod()`, so mock
+    ///      `podToOwner(pod)` (using the pod address as its own owner key, matching
+    ///      `_mockPodPrincipal`) and `isOperator(operator)` before each registration.
+    function _mockPodRegistration(address pod, address operator) internal {
+        vm.mockCall(address(podManager), abi.encodeWithSelector(podManager.podToOwner.selector, pod), abi.encode(pod));
+        vm.mockCall(
+            address(podManager), abi.encodeWithSelector(podManager.isOperator.selector, operator), abi.encode(true)
+        );
+    }
+
     function _mockPodPrincipal(address pod, address operator, uint256 podPrincipal, uint256 operatorStake) internal {
         // podToOwner(pod) -> use the pod address itself as the stand-in owner key.
-        vm.mockCall(
-            address(podManager),
-            abi.encodeWithSelector(podManager.podToOwner.selector, pod),
-            abi.encode(pod)
-        );
+        vm.mockCall(address(podManager), abi.encodeWithSelector(podManager.podToOwner.selector, pod), abi.encode(pod));
         // totalAssetsOf(owner) -> pod's beacon principal.
         vm.mockCall(
             address(podManager),
@@ -346,6 +359,7 @@ contract CrossChainSlashingTest is Test {
         connector.setMessenger(address(messenger));
         connector.setChainConfig(TANGLE_CHAIN_ID, makeAddr("l2Receiver"), 200_000, true);
         connector.setDefaultDestinationChain(TANGLE_CHAIN_ID);
+        _mockPodRegistration(pod1, operator1);
         connector.registerPodOperator(pod1, operator1);
         vm.stopPrank();
 
@@ -431,6 +445,7 @@ contract CrossChainSlashingTest is Test {
         address operator2 = makeAddr("operator2");
         _setPodFactor(pod1, 0.9e18);
 
+        _mockPodRegistration(pod2, operator2);
         vm.prank(admin);
         connector.registerPodOperator(pod2, operator2);
 
@@ -513,6 +528,7 @@ contract CrossChainSlashingTest is Test {
         // First set up initial factor: 100% -> 90%
         MockSlashPod slashPod = new MockSlashPod(0.9e18);
 
+        _mockPodRegistration(address(slashPod), operator1);
         vm.prank(admin);
         connector.registerPodOperator(address(slashPod), operator1);
         _mockPodPrincipal(address(slashPod), operator1, 50 ether, 50 ether); // pod-bounded slash needs principal
@@ -530,6 +546,7 @@ contract CrossChainSlashingTest is Test {
     function test_propagateBeaconSlashing_RevertMismatchedPodFactor() public {
         MockSlashPod slashPod = new MockSlashPod(0.95e18);
 
+        _mockPodRegistration(address(slashPod), operator1);
         vm.prank(admin);
         connector.registerPodOperator(address(slashPod), operator1);
 
@@ -592,6 +609,7 @@ contract CrossChainSlashingTest is Test {
         address operator2 = makeAddr("operator2");
         _setPodFactor(pod1, 0.95e18);
 
+        _mockPodRegistration(pod2, operator2);
         vm.prank(admin);
         connector.registerPodOperator(pod2, operator2);
         _mockPodPrincipal(pod1, operator1, 50 ether, 50 ether); // pod-bounded slash needs principal
@@ -903,6 +921,10 @@ contract CrossChainSlashingTest is Test {
         operators[0] = makeAddr("batchOp1");
         operators[1] = makeAddr("batchOp2");
 
+        // BCN-004: both legs must validate against the PodManager.
+        _mockPodRegistration(pods[0], operators[0]);
+        _mockPodRegistration(pods[1], operators[1]);
+
         vm.prank(admin);
         connector.batchRegisterPodOperators(pods, operators);
 
@@ -915,6 +937,34 @@ contract CrossChainSlashingTest is Test {
         vm.prank(admin);
         connector.setSlashingOracle(newOracle);
         assertEq(connector.slashingOracle(), newOracle);
+    }
+
+    /// @notice BCN-002: the oracle setter must reject the zero address so the role cannot be
+    ///         silently bricked.
+    function test_connector_setSlashingOracle_RevertZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(L2SlashingConnector.ZeroAddress.selector);
+        connector.setSlashingOracle(address(0));
+    }
+
+    /// @notice BCN-004: registering a pod the PodManager does not know must revert.
+    function test_connector_registerPodOperator_RevertUnknownPod() public {
+        address ghostPod = makeAddr("ghostPod");
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(L2SlashingConnector.UnknownPod.selector, ghostPod));
+        connector.registerPodOperator(ghostPod, operator1);
+    }
+
+    /// @notice BCN-004: registering a known pod against an unregistered operator must revert.
+    function test_connector_registerPodOperator_RevertNotOperator() public {
+        address ghostPod = makeAddr("ghostPod2");
+        address ghostOp = makeAddr("ghostOp");
+        vm.mockCall(
+            address(podManager), abi.encodeWithSelector(podManager.podToOwner.selector, ghostPod), abi.encode(ghostPod)
+        );
+        vm.prank(admin);
+        vm.expectRevert(abi.encodeWithSelector(L2SlashingConnector.NotOperator.selector, ghostOp));
+        connector.registerPodOperator(ghostPod, ghostOp);
     }
 
     function test_connector_setMessenger() public {

--- a/test/beacon/PoCNonBeaconDrainAfterSlash.t.sol
+++ b/test/beacon/PoCNonBeaconDrainAfterSlash.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BeaconTestBase } from "./BeaconTestBase.sol";
+import { ValidatorPod } from "../../src/beacon/ValidatorPod.sol";
+
+/// @title PoCNonBeaconDrainAfterSlash
+/// @notice Regression guard for the "service slash is non-punitive" drain.
+///
+///         Before the fix, after a service (L2) slash was realized in
+///         `completeUndelegation`, the beacon-pool `totalAssets` floor used by
+///         `ValidatorPod.withdrawNonBeaconChainEth` dropped below the physical ETH
+///         still held by the pod. The owner could then drain the "burned" principal as
+///         fake non-beacon surplus, and later withdraw the surviving shares normally —
+///         recovering the ENTIRE 32 ETH principal despite a 50% slash.
+///
+///         Fix: `completeUndelegation` now reports the burned (slashed) principal to the
+///         pod via `recordSlashedPrincipalRetained`, and `withdrawNonBeaconChainEth`
+///         floors withdrawals at `totalAssetsOf + slashedPrincipalRetainedWei`. The
+///         stranded slashed ETH is therefore permanently un-extractable, and the slash
+///         is punitive: the owner recovers only the surviving (non-slashed) principal.
+contract PoCNonBeaconDrainAfterSlash is BeaconTestBase {
+    function test_slashedPrincipalCannotBeDrainedAsNonBeaconEth() public {
+        // ── 1. Owner restakes 32 ETH; the full principal physically sits in the
+        //       pod and is credited as beacon-pool shares. ────────────────────
+        ValidatorPod pod = _createPodWithShares(podOwner1, 32 ether);
+        vm.deal(address(pod), 32 ether);
+        assertEq(podManager.totalAssetsOf(podOwner1), 32 ether, "floor==32 pre-slash");
+        assertEq(address(pod).balance, 32 ether, "32 ETH in pod");
+
+        // ── 2. Register operator and delegate the full principal. ─────────────
+        _registerOperator(operator1, MIN_OPERATOR_STAKE);
+        vm.prank(podOwner1);
+        podManager.delegateTo(operator1, 32 ether);
+
+        // ── 3. Slash the operator 50% at the service (L2) layer. ──────────────
+        uint256 poolBefore = podManager.operatorDelegatedStake(operator1);
+        vm.prank(slasher);
+        podManager.slash(operator1, 1, 5000, bytes32(uint256(1)));
+        uint256 poolAfter = podManager.operatorDelegatedStake(operator1);
+        assertLt(poolAfter, poolBefore, "delegation pool reduced by slash");
+
+        // Shorten the undelegation/withdrawal delay so the test is tractable.
+        vm.prank(admin);
+        podManager.setWithdrawalDelay(10);
+
+        // ── 4. Queue + complete undelegation. This realizes the slash: the
+        //       delegator's beacon-pool shares are partially BURNED, lowering
+        //       totalAssetsOf, and the burned principal is reported to the pod. ─
+        uint256 live = podManager.getDelegation(podOwner1, operator1); // post-slash live value
+        vm.prank(podOwner1);
+        bytes32 root = podManager.queueUndelegation(operator1, live);
+
+        vm.roll(100);
+
+        vm.prank(podOwner1);
+        podManager.completeUndelegation(root);
+
+        // The floor dropped (escrow burn), but the physical 32 ETH is still in the pod.
+        uint256 floor = podManager.totalAssetsOf(podOwner1);
+        assertLt(floor, 32 ether, "floor reduced by escrow burn");
+        assertEq(address(pod).balance, 32 ether, "physical ETH still in pod");
+
+        uint256 burnedPrincipal = pod.slashedPrincipalRetainedWei();
+        assertGt(burnedPrincipal, 0, "pod recorded the burned slashed principal");
+
+        // The fake surplus the old exploit targeted is now fully reserved by the pod's
+        // slashed-principal floor, so there is no withdrawable non-beacon ETH at all.
+        uint256 fakeSurplus = 32 ether - floor;
+        assertEq(fakeSurplus, burnedPrincipal, "fake surplus exactly equals the burned principal");
+
+        // ── 5. EXPLOIT ATTEMPT: draining the burned principal must now revert. ─
+        vm.prank(podOwner1);
+        vm.expectRevert(ValidatorPod.InsufficientBalance.selector);
+        pod.withdrawNonBeaconChainEth(podOwner1, fakeSurplus);
+
+        // Even 1 wei of "surplus" is unavailable — the floor covers the whole balance.
+        vm.prank(podOwner1);
+        vm.expectRevert(ValidatorPod.InsufficientBalance.selector);
+        pod.withdrawNonBeaconChainEth(podOwner1, 1);
+
+        // ── 6. Owner withdraws ONLY the surviving (non-slashed) shares normally. ─
+        uint256 survivorShares = podManager.getSharesUint(podOwner1);
+        vm.prank(podOwner1);
+        bytes32 wRoot = podManager.queueWithdrawal(survivorShares);
+
+        vm.roll(1000);
+
+        vm.prank(podOwner1);
+        podManager.completeWithdrawal(wRoot);
+
+        // ── NET RESULT: the 50% slash is punitive. The owner recovers only the
+        //    surviving ~16.5 ETH (operator self-stake absorbed the first 1 ETH of the
+        //    16.5 ETH slash, so 15.5 ETH of pod principal was burned). The slashed
+        //    principal stays stranded in the pod and is never extractable.
+        assertLt(podOwner1.balance, 132 ether, "owner did NOT recover the full principal");
+        assertEq(podOwner1.balance, 116.5 ether, "owner recovered only surviving principal (100 + 16.5)");
+        assertEq(address(pod).balance, 15.5 ether, "slashed principal stranded in pod, not drained");
+    }
+}

--- a/test/beacon/ValidatorPodTest.t.sol
+++ b/test/beacon/ValidatorPodTest.t.sol
@@ -267,6 +267,13 @@ contract ValidatorPodTest is BeaconTestBase {
         pod.recoverTokens(IERC20(address(0)), attacker, 1);
     }
 
+    /// @notice BCN-003: token recovery must reject the zero recipient.
+    function test_recoverTokens_RevertZeroRecipient() public {
+        vm.prank(podOwner1);
+        vm.expectRevert(ValidatorPod.ZeroAddress.selector);
+        pod.recoverTokens(IERC20(address(0xBEEF)), address(0), 1);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // VALIDATOR RESTAKING TESTS
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Remediates the four beacon-slashing findings (BCN-001..004) **plus two further defects found in the same path** — one critical (a working PoC was already staged in the tree), one production-breaking. All 329 beacon/audit/security tests pass.

### Findings from the report

- **BCN-001 (High) — over-slash via parked ETH.** `L2SlashingConnector` derived the slash base from `totalAssetsOf`, which includes parked execution-layer ETH (tips, partial withdrawals, exited principal already in pod custody) that cannot be beacon-slashed. A 50% beacon slash on a 32-ETH validator with 968 ETH parked saturated `slashBps` at `10000` (100% of L2 stake) vs the ~16-ETH real loss. New `_podBeaconPrincipal` subtracts the pod's parked tally (`withdrawableRestakedExecutionLayerGwei`) so the slash reflects only on-beacon principal — now **1600 bps, not 10000**. Applied to all three call sites (`_propagateBeaconSlashing`, `getPendingSlashAmount`, `estimatePropagationFee`).
- **BCN-002 (Low) — zero-address oracle.** `setSlashingOracle` now rejects `address(0)` (mirrors `transferOwnership`).
- **BCN-003 (Low) — unrestricted `recoverTokens`.** Now `nonReentrant` + rejects a zero recipient, with a documented invariant for when protocol-accounted ERC20s are ever routed into pods.
- **BCN-004 (Info) — arbitrary pod→operator registration.** `registerPodOperator` / `batchRegisterPodOperators` now validate against the PodManager: the pod must have a known owner and the operator must be registered.

### Further defects fixed (same contract path)

- **Critical — slashed principal drainable.** After a service slash, `completeUndelegation` burned escrow beacon shares (dropping `totalAssetsOf`) while the slashed ETH stayed physically in the pod, so the owner drained it via `withdrawNonBeaconChainEth` as fake "non-beacon surplus" and recovered the **full 32 ETH despite a 50% slash**. The manager now reports burned principal to the pod (`recordSlashedPrincipalRetained`), and `withdrawNonBeaconChainEth` floors at `totalAssetsOf + slashedPrincipalRetainedWei`. The slash is now punitive (owner recovers 16.5/32 ETH; the rest is stranded and unextractable).
- **Production-breaking — batch slashing silently no-ops.** `batchPropagateBeaconSlashing` forwarded `{value: 0}` to each self-call, so with any non-zero bridge fee (OP-Stack/Arbitrum L1→L2) every propagation reverted `InsufficientFee`, got swallowed by `try/catch`, and the batch advanced **zero** slashes. Each self-call is now funded from the call balance (self-refunding between iterations), with the remainder swept back to the caller.

## Tests

- Rewrote both staged PoCs as passing regression tests (`BCN001.t.sol`, `PoCNonBeaconDrainAfterSlash.t.sol`).
- Added `BatchPropagateBeaconSlashingFee.t.sol` and targeted regressions for BCN-002/003/004.
- Updated mock-based connector tests (`CrossChainSlashingTest`, audit `BeaconL2`) for the new registration validation.
- **329 beacon + audit + security tests green, 0 failures.**

> Note: the full ~1855-test suite was not run locally — `forge test` with no path filter compiles the whole via-IR graph and OOM-kills this box. Changes are confined to `src/beacon/*`; the only non-beacon consumer (`PectraValidatorCapTest`) is included in the green run. CI's swap/cache setup can run the full suite.