### PR TITLE
fix(audit-2): remediate slashing/jobs/rewards/extensions findings (1 high + 4 med + low)

### DIFF
--- a/src/TangleStorage.sol
+++ b/src/TangleStorage.sol
@@ -515,13 +515,22 @@ abstract contract TangleStorage {
     /// @notice Service ID => operator => last acknowledged version (per operator).
     mapping(uint64 => mapping(address => uint64)) internal _serviceOperatorAckedVersionId;
 
+    /// @notice Slash ID => per-asset security commitments snapshotted at propose time.
+    /// @dev F1: `executeSlash` must slash against the commitments the operator had backing
+    ///      the service WHEN the slash was proposed, not whatever is live at execution. Reading
+    ///      live commitments let an operator self-dispute, leave, and rejoin with a 1-bps
+    ///      commitment to evade ~99.99% of the slash. Captured in `proposeSlash`, consumed
+    ///      (and cleared) in `executeSlash`. Appended at the end of layout; the reserved gap
+    ///      is shrunk by one to preserve total storage size for upgrade safety.
+    mapping(uint64 => Types.AssetSecurityCommitment[]) internal _slashCommitmentSnapshots;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // RESERVED STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades. Standard gap size is 50.
     ///      Slots already consumed: 10 (initial) + 5 (binary versions block) + 5
-    ///      (supply-chain hardening block above). Shrunk 34 -> 29 when that block
-    ///      was appended.
-    uint256[29] private __gap;
+    ///      (supply-chain hardening block above) + 1 (slash commitment snapshot).
+    ///      Shrunk 34 -> 29 -> 28 as those blocks were appended.
+    uint256[28] private __gap;
 }

--- a/src/beacon/L2SlashingReceiver.sol
+++ b/src/beacon/L2SlashingReceiver.sol
@@ -403,6 +403,14 @@ contract L2SlashingReceiver is Initializable, UUPSUpgradeable, OwnableUpgradeabl
             revert InvalidPayload();
         }
 
+        // F10: bound the incoming bps at receipt (defense-in-depth). The L1 connector already
+        // clamps to BPS_DENOMINATOR, but the receiver must not trust an unbounded cross-chain
+        // value: a >100% message would inflate the deferred accumulator beyond what any single
+        // flush can ever realise, overstating booked debt. A single slash can never exceed 100%.
+        if (slashBps > BPS_DENOMINATOR) {
+            revert InvalidPayload();
+        }
+
         // The nonce is consumed exactly once regardless of which branch we take below; the slash
         // can no longer be replayed once banked or applied.
         $.processedNonces[sourceChainId][sender][nonce] = true;

--- a/src/core/JobsSubmission.sol
+++ b/src/core/JobsSubmission.sol
@@ -241,7 +241,13 @@ abstract contract JobsSubmission is Base {
             abi.encodeWithSelector(IBlueprintServiceManager.requiresAggregation.selector, serviceId, jobIndex),
             32
         );
-        if (ok && abi.decode(ret, (bool))) revert Errors.AggregationRequired(serviceId, jobIndex);
+        // F3: FAIL CLOSED. `requiresAggregation` is implemented by the BSM base (defaults to
+        // false), so `!ok` means the hook genuinely failed (revert / OOG / gas-grief). Treating
+        // that as "aggregation not required" let a single operator submit a plain result and
+        // finalize a job that should require a BLS quorum (`_getRequiredResultCount` also
+        // defaults to 1 on hook failure). When we cannot confirm aggregation is NOT required,
+        // assume it IS and block the plain-submission path.
+        if (!ok || abi.decode(ret, (bool))) revert Errors.AggregationRequired(serviceId, jobIndex);
     }
 
     function _validateResultSubmissionState(uint64 serviceId, uint64 callId, Types.JobCall storage job) private view {

--- a/src/core/ServicesLifecycle.sol
+++ b/src/core/ServicesLifecycle.sol
@@ -218,6 +218,22 @@ abstract contract ServicesLifecycle is Base {
         }
         (Types.Service storage svc, Types.Blueprint storage bp) = _loadJoinContext(serviceId);
 
+        // F9: reject duplicate (kind, token) commitments UNCONDITIONALLY. The stored
+        // commitment array is iterated by both slashing (SlashingManager._slashForService) and
+        // billing (PaymentsBilling._accrueOperatorWeights), so a duplicate asset is applied
+        // twice — an over-slash / weight inflation. Previously dedup ran only when the service
+        // had requirements; a service with no requirements accepted duplicates.
+        for (uint256 i = 0; i < commitments.length; i++) {
+            for (uint256 j = i + 1; j < commitments.length; j++) {
+                if (
+                    commitments[i].asset.token == commitments[j].asset.token
+                        && commitments[i].asset.kind == commitments[j].asset.kind
+                ) {
+                    revert Errors.DuplicateAssetCommitment(uint8(commitments[i].asset.kind), commitments[i].asset.token);
+                }
+            }
+        }
+
         Types.AssetSecurityRequirement[] storage requirements = _serviceSecurityRequirements[serviceId];
         if (requirements.length > 0) {
             _validateSecurityCommitments(requirements, commitments);

--- a/src/core/Slashing.sol
+++ b/src/core/Slashing.sol
@@ -100,9 +100,25 @@ abstract contract Slashing is Base {
             cappedSlashBps,
             effectiveExposureBps,
             evidence,
+            // F11: `instant` is hardcoded false on purpose. Instant slashing skips the dispute
+            // window, so the `instantSlashEnabled` config flag (read+enforced in SlashingLib) is
+            // left intentionally unreachable via the public API — there is no entrypoint that
+            // passes `instant=true`. Wiring one is a deliberate governance decision that must
+            // come with a dispute-window-bypass review; it is NOT dead code to silently remove.
             false,
             _resolveDisputeWindow(serviceId, bp.manager)
         );
+
+        // F1: snapshot the operator's per-asset commitments AS OF propose time. `executeSlash`
+        // slashes against this snapshot, not live storage, so an operator cannot self-dispute,
+        // leave, and rejoin with a diluted (1-bps) commitment to evade the slash. The legacy
+        // no-commitment path snapshots an empty array and falls back to blueprint-wide slashing.
+        Types.AssetSecurityCommitment[] storage liveCommit = _serviceSecurityCommitments[serviceId][operator];
+        Types.AssetSecurityCommitment[] storage snap = _slashCommitmentSnapshots[slashId];
+        uint256 commitLen = liveCommit.length;
+        for (uint256 i = 0; i < commitLen; i++) {
+            snap.push(liveCommit[i]);
+        }
 
         // Increment pending slash count to block delegator withdrawals
         _staking.incrementPendingSlash(operator);
@@ -293,7 +309,10 @@ abstract contract Slashing is Base {
 
         Types.Service storage svc = _services[proposal.serviceId];
 
-        actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
+        actualSlashed = _executeSlashOnStaking(slashId, proposal, svc.blueprintId);
+
+        // F1: snapshot consumed; reclaim its storage.
+        delete _slashCommitmentSnapshots[slashId];
 
         SlashingLib.markExecuted(_slashProposals, slashId, actualSlashed);
         _staking.decrementPendingSlash(proposal.operator);
@@ -345,7 +364,10 @@ abstract contract Slashing is Base {
 
             Types.Service storage svc = _services[proposal.serviceId];
 
-            uint256 actualSlashed = _executeSlashOnStaking(proposal, svc.blueprintId);
+            uint256 actualSlashed = _executeSlashOnStaking(slashIds[i], proposal, svc.blueprintId);
+
+            // F1: snapshot consumed; reclaim its storage.
+            delete _slashCommitmentSnapshots[slashIds[i]];
 
             SlashingLib.markExecuted(_slashProposals, slashIds[i], actualSlashed);
             _staking.decrementPendingSlash(proposal.operator);
@@ -479,14 +501,16 @@ abstract contract Slashing is Base {
     /// @dev Internal helper that picks the right slashing API based on whether the
     ///      operator made explicit per-asset commitments to the offending service.
     function _executeSlashOnStaking(
+        uint64 slashId,
         SlashingLib.SlashProposal storage proposal,
         uint64 blueprintId
     )
         internal
         returns (uint256 actualSlashed)
     {
-        Types.AssetSecurityCommitment[] memory commitments =
-            _loadServiceCommitments(proposal.serviceId, proposal.operator);
+        // F1: slash against the commitments snapshotted at propose time, not live storage,
+        // so a mid-window leave/rejoin with a diluted commitment cannot shrink the slash.
+        Types.AssetSecurityCommitment[] memory commitments = _loadSnapshotCommitments(slashId);
 
         if (commitments.length == 0) {
             return _staking.slashForBlueprint(
@@ -503,15 +527,13 @@ abstract contract Slashing is Base {
         );
     }
 
-    function _loadServiceCommitments(
-        uint64 serviceId,
-        address operator
-    )
+    /// @dev Copy the propose-time commitment snapshot for `slashId` into memory (F1).
+    function _loadSnapshotCommitments(uint64 slashId)
         internal
         view
         returns (Types.AssetSecurityCommitment[] memory copy)
     {
-        Types.AssetSecurityCommitment[] storage stored = _serviceSecurityCommitments[serviceId][operator];
+        Types.AssetSecurityCommitment[] storage stored = _slashCommitmentSnapshots[slashId];
         uint256 len = stored.length;
         copy = new Types.AssetSecurityCommitment[](len);
         for (uint256 i = 0; i < len; i++) {

--- a/src/extensions/TokenizedBlueprintBase.sol
+++ b/src/extensions/TokenizedBlueprintBase.sol
@@ -67,7 +67,8 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
         uint256 rewardRate; // Reward per second (for streaming mode)
         uint256 periodFinish; // When current reward period ends (for streaming)
         uint256 pendingRewards; // Undistributed rewards (for instant mode)
-        // ─── appended storage (audit remediation) ────────────────────────────
+        // ─── appended storage (audit remediation)
+        // ────────────────────────────
         // Carries the per-distribution truncation residue of the
         // (amount * 1e18) / totalStaked division so that dust is folded into the
         // next distribution instead of being silently lost. Scaled by 1e18.
@@ -127,12 +128,15 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
     ///      immediately before a known payment and unstake immediately after,
     ///      capturing rewards with zero time-at-risk and diluting honest stakers.
     ///      The withdraw path always enforces this window; the value is the policy
-    ///      knob. Defaults to 0 (disabled) so the base preserves the historical
-    ///      no-lock behavior; production blueprints exposed to instant-mode revenue
-    ///      MUST set a non-zero window via `_setStakeLockDuration` (e.g. 1 day) to
-    ///      close the JIT-reward vector. Streaming mode is intrinsically immune
-    ///      since rewards accrue per-second of time-at-risk.
+    ///      knob. F4: defaults to a non-zero `DEFAULT_STAKE_LOCK_DURATION` (set in the
+    ///      constructor) so the base fails SAFE — a blueprint that forgets to configure a
+    ///      lock is not silently exposed to the JIT-reward vector. Integrators can tune it
+    ///      (including to 0, accepting the risk) via `_setStakeLockDuration`. Streaming mode
+    ///      is intrinsically immune since rewards accrue per-second of time-at-risk.
     uint256 public stakeLockDuration;
+
+    /// @notice Failsafe default stake-lock window applied at construction (F4).
+    uint256 public constant DEFAULT_STAKE_LOCK_DURATION = 1 days;
 
     /// @notice Per-user earliest withdrawal timestamp. Refreshed on every stake.
     mapping(address => uint256) public stakeUnlockTime;
@@ -144,6 +148,10 @@ abstract contract TokenizedBlueprintBase is BlueprintServiceManagerBase, ERC20, 
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {
         // Native ETH is always a reward token
         _addRewardToken(address(0));
+        // F4: fail safe — seed a non-zero stake-lock so instant-mode revenue cannot be
+        // captured just-in-time with zero time-at-risk. Integrators may retune via
+        // `_setStakeLockDuration`.
+        stakeLockDuration = DEFAULT_STAKE_LOCK_DURATION;
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/libraries/SlashingLib.sol
+++ b/src/libraries/SlashingLib.sol
@@ -135,7 +135,12 @@ library SlashingLib {
             instantSlashEnabled: false,
             maxSlashBps: BPS_DENOMINATOR, // 100%
             disputeResolutionDeadline: 14 days,
-            disputeBond: 0, // Defaults to disabled; admin enables via setSlashConfig.
+            // F2: ship a non-zero default so an unconfigured deployment is never free to
+            // self-dispute. A free dispute lets an operator freeze their own delegators'
+            // withdrawals for the whole resolution window at zero cost. Matches the documented
+            // production value (deploy/config/*.json `slashing.disputeBond`); governance can
+            // still tune it via `setSlashConfig`.
+            disputeBond: 0.02 ether,
             // One pending slash already freezes the operator + its delegators, so a small
             // cap suffices; lower default bounds admin cleanup cost on a griefing attempt.
             maxPendingSlashesPerOperator: 8

--- a/src/rewards/InflationPool.sol
+++ b/src/rewards/InflationPool.sol
@@ -415,7 +415,14 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         // Calculate epoch budget based on pool balance
         uint256 epochBudget = calculateEpochBudget();
 
-        // Can only distribute what we have
+        // Can only distribute what we have. NOTE (F6): in normal operation this clamp never
+        // triggers because `calculateEpochBudget()` is derived from `freeBalance()`
+        // (= poolBalance - pendingRewardsLiability) <= poolBalance. It is retained as
+        // defense-in-depth. The only way `freeBalance()` could overstate availability is an
+        // upgrade FROM a pre-`pendingRewardsLiability` deployment carrying unclaimed pending
+        // rewards (liability would read 0). No such prior deployment exists for this codebase
+        // (liability has been tracked from genesis); any future migration that introduces it
+        // MUST seed `pendingRewardsLiability` in a reinitializer before the first distribution.
         uint256 available = poolBalance();
         if (epochBudget > available) {
             epochBudget = available;
@@ -441,14 +448,22 @@ contract InflationPool is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         uint256 developersActual = _distributeDeveloperRewards(developersTarget);
         uint256 stakersActual = _distributeStakerInflation(serviceIds, stakersTarget);
 
-        // Handle undistributed amounts. `stakersTarget` MUST be included: the permissionless
-        // distributeEpoch() entrypoint passes an empty serviceIds, so _distributeStakerInflation
-        // returns 0 and the whole stakersTarget would otherwise be silently consumed by the epoch
-        // advance without ever reaching stakers. Folding it into `undistributed` reallocates it to
-        // the other active categories in the same epoch.
+        // Handle undistributed amounts.
+        //
+        // F7: the staker shortfall is reallocated to the other categories ONLY when staker
+        // distribution was actually attempted (`serviceIds` provided, i.e. the gated
+        // `distributeEpochWithServices`). The permissionless `distributeEpoch()` passes an empty
+        // `serviceIds`, so `_distributeStakerInflation` returns 0; folding that full `stakersTarget`
+        // into `undistributed` would let anyone front-run the keeper and REDIRECT staker inflation
+        // into operator/customer/developer pools (which an attacker can be a member of). Instead we
+        // leave the unspent `stakersTarget` in the pool, where it rolls into a later epoch's budget
+        // and reaches stakers once the keeper supplies services. Genuine shortfalls from categories
+        // that WERE attempted are still reallocated.
         uint256 undistributed = (stakingTarget - stakingActual) + (operatorsTarget - operatorsActual)
-            + (customersTarget - customersActual) + (developersTarget - developersActual)
-            + (stakersTarget - stakersActual);
+            + (customersTarget - customersActual) + (developersTarget - developersActual);
+        if (serviceIds.length > 0) {
+            undistributed += (stakersTarget - stakersActual);
+        }
 
         if (undistributed > 0) {
             bool hasStaking = stakingActual > 0;

--- a/src/rewards/RewardVaults.sol
+++ b/src/rewards/RewardVaults.sol
@@ -486,6 +486,12 @@ contract RewardVaults is
         if (pool.totalStaked < score) revert InsufficientStake();
         pool.totalStaked -= score;
 
+        // F8: prune the operator from the epoch-distribution fan-out list once its pool is
+        // fully unwound, so the loop in `distributeEpochReward` cannot grow without bound.
+        if (pool.totalStaked == 0) {
+            _untrackOperator(asset, operator);
+        }
+
         emit UnstakeRecorded(asset, delegator, operator, amount);
     }
 
@@ -694,6 +700,12 @@ contract RewardVaults is
         if (pool.totalStaked < score) revert InsufficientStake();
         pool.totalStaked -= score;
 
+        // F8: prune the operator from the epoch-distribution fan-out list once its pool is
+        // fully unwound, so the loop in `distributeEpochReward` cannot grow without bound.
+        if (pool.totalStaked == 0) {
+            _untrackOperator(asset, operator);
+        }
+
         // Update delegator debt
         debt.stakedAmount -= amount;
         if (debt.boostedScore >= score) {
@@ -817,6 +829,30 @@ contract RewardVaults is
         if (isAssetOperator[asset][operator]) return;
         isAssetOperator[asset][operator] = true;
         assetOperators[asset].push(operator);
+        assetOperatorIndex[asset][operator] = assetOperators[asset].length; // index + 1
+    }
+
+    /// @notice Remove an operator from `assetOperators[asset]` once its stake fully unwinds (F8).
+    /// @dev Swap-and-pop, mirroring `_untrackDelegatorOperator`. The operator's accumulator state
+    ///      in `operatorPools` is left intact, so a later re-stake re-tracks it safely and any
+    ///      `pendingCommission` remains claimable independently of this membership list.
+    function _untrackOperator(address asset, address operator) internal {
+        uint256 indexPlusOne = assetOperatorIndex[asset][operator];
+        if (indexPlusOne == 0) return;
+
+        address[] storage operators = assetOperators[asset];
+        uint256 index = indexPlusOne - 1;
+        uint256 lastIndex = operators.length - 1;
+
+        if (index != lastIndex) {
+            address lastOperator = operators[lastIndex];
+            operators[index] = lastOperator;
+            assetOperatorIndex[asset][lastOperator] = index + 1;
+        }
+
+        operators.pop();
+        assetOperatorIndex[asset][operator] = 0;
+        isAssetOperator[asset][operator] = false;
     }
 
     function _trackDelegatorOperator(address asset, address delegator, address operator) internal {
@@ -1188,6 +1224,14 @@ contract RewardVaults is
 
     function _authorizeUpgrade(address) internal override onlyRole(UPGRADER_ROLE) { }
 
-    /// @dev Reserved storage slots for future upgrades (Round 2 storage F-3).
-    uint256[50] private __gap;
+    /// @notice Index (+1) of an operator inside `assetOperators[asset]` for O(1) removal (F8).
+    /// @dev Appended at the end of storage (gap shrunk 50 -> 49) to stay upgrade-safe. Lets
+    ///      `_untrackOperator` swap-and-pop an operator whose stake fully unwound, so the
+    ///      epoch-distribution loop over `assetOperators` cannot grow unbounded with dead
+    ///      entries and eventually exceed the block gas limit.
+    mapping(address => mapping(address => uint256)) private assetOperatorIndex;
+
+    /// @dev Reserved storage slots for future upgrades (Round 2 storage F-3). Shrunk 50 -> 49
+    ///      when `assetOperatorIndex` was appended (F8).
+    uint256[49] private __gap;
 }

--- a/src/rewards/ServiceFeeDistributor.sol
+++ b/src/rewards/ServiceFeeDistributor.sol
@@ -253,6 +253,14 @@ contract ServiceFeeDistributor is
         uint256 principalBefore = _positionPrincipal[delegator][operator][assetHash];
         uint256 scoreBefore = _positionScore[delegator][operator][assetHash];
 
+        // KNOWN LIMITATION (F5, tracked for a focused follow-up): `lockMultiplierBps` is baked
+        // into the position score here but this contract receives no lock-expiry, so the boost
+        // does not decay when the lock elapses — a locker keeps an inflated reward share until
+        // they next interact (diluting others). A correct fix requires threading the lock expiry
+        // through `onDelegationChanged` (interface + staking-layer change) and adding lazy
+        // decay-on-expiry to the reward-accumulator math (mirroring `RewardVaults._decayExpiredLock`).
+        // That is deliberately NOT done inline: a rushed change to this O(1) accumulator/debt
+        // accounting risks misallocating live rewards. See the audit batch-2 PR description.
         uint256 scoreDelta;
         uint256 principalAfter;
         uint256 scoreAfter;

--- a/test/EndToEndSlashingTest.t.sol
+++ b/test/EndToEndSlashingTest.t.sol
@@ -389,9 +389,9 @@ contract EndToEndSlashingTest is BaseTest {
         vm.prank(user1);
         uint64 slashId = tangle.proposeSlash(0, operator1, 2000, keccak256("ev"));
 
-        // Operator disputes
+        // Operator disputes (must post the default dispute bond, F2)
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "Invalid evidence");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Invalid evidence");
 
         SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
         assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Disputed));

--- a/test/audit/batch2/AuditBatch2.t.sol
+++ b/test/audit/batch2/AuditBatch2.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { BaseTest } from "../../BaseTest.sol";
+import { Types } from "../../../src/libraries/Types.sol";
+import { Errors } from "../../../src/libraries/Errors.sol";
+import { BlueprintServiceManagerBase } from "../../../src/BlueprintServiceManagerBase.sol";
+
+/// @notice BSM that lets operators leave instantly (no min-commitment, no exit queue), so the
+///         F1 leave/rejoin dilution can be reproduced inside the slash dispute window.
+contract InstantExitBSM is BlueprintServiceManagerBase {
+    function getExitConfig(uint64)
+        external
+        pure
+        override
+        returns (bool useDefault, uint64 minCommitmentDuration, uint64 exitQueueDuration, bool forceExitAllowed)
+    {
+        return (false, 0, 0, false);
+    }
+}
+
+/// @title AuditBatch2Test
+/// @notice Reproductions / regression guards for the second audit batch.
+contract AuditBatch2Test is BaseTest {
+    InstantExitBSM internal bsm;
+    uint64 internal dynBlueprint;
+
+    function setUp() public override {
+        super.setUp();
+
+        bsm = new InstantExitBSM();
+
+        _registerOperator(operator1, 10 ether);
+        _registerOperator(operator2, 10 ether);
+
+        Types.BlueprintConfig memory cfg = Types.BlueprintConfig({
+            membership: Types.MembershipModel.Dynamic,
+            pricing: Types.PricingModel.PayOnce,
+            minOperators: 1,
+            maxOperators: 10,
+            subscriptionRate: 0,
+            subscriptionInterval: 0,
+            eventRate: 0
+        });
+
+        vm.prank(developer);
+        dynBlueprint = tangle.createBlueprint(_blueprintDefinitionWithConfig("ipfs://audit-batch2", address(bsm), cfg));
+
+        _registerForBlueprint(operator1, dynBlueprint);
+        _registerForBlueprint(operator2, dynBlueprint);
+    }
+
+    function _native() internal pure returns (Types.Asset memory) {
+        return Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
+    }
+
+    function _commit(uint16 bps) internal pure returns (Types.AssetSecurityCommitment[] memory c) {
+        c = new Types.AssetSecurityCommitment[](1);
+        c[0] = Types.AssetSecurityCommitment({ asset: _native(), exposureBps: bps });
+    }
+
+    /// @dev Spin up an active dynamic service with operator1 (full 100% native commitment) and
+    ///      operator2 (filler so a later operator1 exit keeps the service above minOperators).
+    function _activeServiceWithFullCommitment() internal returns (uint64 serviceId) {
+        address[] memory ops = new address[](2);
+        ops[0] = operator1;
+        ops[1] = operator2;
+
+        vm.prank(user1);
+        uint64 requestId = tangle.requestService(
+            dynBlueprint, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
+
+        // operator1 backs the native asset at full exposure; operator2 fills the roster.
+        vm.prank(operator1);
+        tangle.approveService(_approveWithCommitments(requestId, _commit(10_000)));
+        vm.prank(operator2);
+        tangle.approveService(_approveWithCommitments(requestId, _commit(10_000)));
+
+        serviceId = tangle.serviceCount() - 1;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // F1 (High): per-asset commitments are snapshotted at propose time
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @dev A 100% slash is proposed while operator1 backs the native asset at full exposure.
+    ///      operator1 then leaves and rejoins with a 1-bps commitment to try to evade the slash.
+    ///      With the snapshot fix, `executeSlash` slashes against the propose-time commitment
+    ///      (full), not the diluted live one — so ~100% of the native stake is removed.
+    function test_F1_SlashUsesCommitmentSnapshotNotDilutedRejoin() public {
+        uint64 serviceId = _activeServiceWithFullCommitment();
+
+        uint256 exposedBefore = staking.getOperatorStakeForAsset(operator1, _native());
+        assertGt(exposedBefore, 0, "operator has native stake");
+
+        // Service owner proposes a 100% slash; snapshot captures the full native commitment.
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 10_000, keccak256("evidence"));
+
+        // Attacker dilutes: leave instantly (BSM exit config) then rejoin with a 1-bps commitment.
+        vm.prank(operator1);
+        tangle.leaveService(serviceId);
+        vm.prank(operator1);
+        tangle.joinServiceWithCommitments(serviceId, 10_000, _commit(1));
+
+        // Past the default 7-day dispute window (+ timestamp buffer).
+        vm.warp(block.timestamp + 7 days + 16);
+        uint256 actualSlashed = tangle.executeSlash(slashId);
+
+        uint256 exposedAfter = staking.getOperatorStakeForAsset(operator1, _native());
+        uint256 removed = exposedBefore - exposedAfter;
+
+        // Snapshot used: ~100% of the exposed native stake is removed. The diluted (1-bps) live
+        // commitment would have removed ~0.01% — assert we are nowhere near that under-slash.
+        assertEq(removed, actualSlashed, "removed == executeSlash return");
+        assertGe(removed, (exposedBefore * 9000) / 10_000, "snapshot slash removes ~full stake, not diluted 1bps");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // F2 (Med): operator self-dispute is no longer free (non-zero default bond)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function test_F2_OperatorSelfDisputeRequiresBond() public {
+        uint64 serviceId = _activeServiceWithFullCommitment();
+
+        vm.prank(user1);
+        uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
+
+        // A free (zero-value) self-dispute is rejected by the non-zero default bond.
+        vm.prank(operator1);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidMsgValue.selector, uint256(0.02 ether), uint256(0)));
+        tangle.disputeSlash(slashId, "free grief");
+
+        // Posting the configured bond succeeds.
+        vm.prank(operator1);
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "bonded dispute");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // F9 (Low): duplicate-asset commitments rejected even with no requirements
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function test_F9_DuplicateAssetCommitmentRejectedWithoutRequirements() public {
+        // Active service (no security requirements on this blueprint).
+        address[] memory ops = new address[](1);
+        ops[0] = operator1;
+        vm.prank(user1);
+        uint64 requestId = tangle.requestService(
+            dynBlueprint, ops, "", new address[](0), 0, address(0), 0, Types.ConfidentialityPolicy.Any
+        );
+        vm.prank(operator1);
+        tangle.approveService(_approve(requestId));
+        uint64 serviceId = tangle.serviceCount() - 1;
+
+        // operator2 joins with two commitments for the SAME native asset → must revert.
+        Types.AssetSecurityCommitment[] memory dup = new Types.AssetSecurityCommitment[](2);
+        dup[0] = Types.AssetSecurityCommitment({ asset: _native(), exposureBps: 5000 });
+        dup[1] = Types.AssetSecurityCommitment({ asset: _native(), exposureBps: 5000 });
+
+        vm.prank(operator2);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.DuplicateAssetCommitment.selector, uint8(Types.AssetKind.Native), address(0))
+        );
+        tangle.joinServiceWithCommitments(serviceId, 10_000, dup);
+    }
+}

--- a/test/audit/medlow/BeaconL2.t.sol
+++ b/test/audit/medlow/BeaconL2.t.sol
@@ -354,6 +354,23 @@ contract BeaconL2ReceiverAuditTest is Test {
         assertEq(receiver.deferredSlashBps(operator), 3000, "overflow remains booked for next flush");
     }
 
+    /// @notice F10: a cross-chain message carrying bps above 100% (BPS_DENOMINATOR) is rejected at
+    ///         receipt (defense-in-depth) and is NEVER banked into the deferred accumulator, so the
+    ///         booked debt cannot be inflated beyond what any flush could realise.
+    function test_receiver_slashBpsAboveDenominator_revertsAndBanksNothing() public {
+        slasher.setSlashable(false); // would otherwise bank into the deferred accumulator
+        uint16 overBps = uint16(receiver.BPS_DENOMINATOR() + 1);
+        bytes memory payload = _slashPayload(operator, overBps, 0.3e18, 1, makeAddr("pod"));
+
+        vm.prank(messenger);
+        vm.expectRevert(L2SlashingReceiver.InvalidPayload.selector);
+        receiver.receiveMessage(SRC_CHAIN, connector, payload);
+
+        // Fully rejected: nothing banked, nonce not consumed (the message can never take effect).
+        assertEq(receiver.deferredSlashBps(operator), 0, "over-100% bps must not be banked");
+        assertFalse(receiver.isNonceProcessed(SRC_CHAIN, connector, 1), "rejected message consumes no nonce");
+    }
+
     /// @notice The deferred path is keyed on `canSlash`: flushing while the operator still has no
     ///         slashable stake reverts (no phantom slash), but the debt is preserved.
     function test_receiver_flushWhileNotSlashable_revertsAndKeepsDebt() public {

--- a/test/audit/medlow/InflationPool.t.sol
+++ b/test/audit/medlow/InflationPool.t.sol
@@ -17,8 +17,12 @@ import { TangleToken } from "../../../src/governance/TangleToken.sol";
 ///  - MEDIUM: epoch budget recounts unclaimed pending rewards -> over-accrual.
 ///            Root fix: pendingRewardsLiability is incremented on accrual / decremented on claim
 ///            so calculateEpochBudget() (via freeBalance()) excludes earmarked tokens.
-///  - LOW: permissionless distributeEpoch() consumes the epoch's stakersTarget without paying it.
-///         Root fix: stakersTarget folded into the `undistributed` reallocation.
+///  - LOW (F7): permissionless distributeEpoch() (empty serviceIds) must NOT reallocate the
+///         epoch's stakersTarget into the other streams — an attacker who is an operator/customer/
+///         developer could front-run the keeper to redirect staker inflation to themselves. Root
+///         fix: the staker shortfall is reallocated ONLY when staker distribution was attempted
+///         (serviceIds provided); otherwise the staker slice is retained in the pool and rolls
+///         into a later epoch.
 ///  - LOW (x3, same root): _distributeStakingRewards split cross-vault by raw deposits (ignoring
 ///         lock-multiplier score) AND transferred TNT before the swallowed notify try/catch,
 ///         stranding tokens on revert. Root fix: weight by totalScore; transfer only after the
@@ -130,11 +134,7 @@ contract InflationPoolAuditMedLowTest is Test {
         uint256 pendingOp = pool.pendingOperatorRewards(operator1);
         assertGt(pendingOp, 0, "operator accrued rewards");
         assertEq(pool.pendingRewardsLiability(), pendingOp, "liability == accrued pending");
-        assertEq(
-            pool.freeBalance(),
-            pool.poolBalance() - pendingOp,
-            "freeBalance excludes earmarked rewards"
-        );
+        assertEq(pool.freeBalance(), pool.poolBalance() - pendingOp, "freeBalance excludes earmarked rewards");
         // The budget is computed off the FREE balance, so it is bounded by it.
         assertLe(pool.calculateEpochBudget(), pool.freeBalance(), "budget bounded by free balance");
     }
@@ -221,7 +221,7 @@ contract InflationPoolAuditMedLowTest is Test {
     ///         epoch's total distribution still consumes the full per-category budget that the
     ///         active streams can absorb, with stakersDistributed == 0 but the staker slice
     ///         folded into staking/operator/customer/developer actuals.
-    function test_PermissionlessDistributeReallocatesStakerSlice() public {
+    function test_PermissionlessDistributeRetainsStakerSlice() public {
         // 50% stakers weight, the rest spread so every other stream is active.
         vm.startPrank(admin);
         pool.setWeights(2000, 1000, 1000, 1000, 5000);
@@ -261,14 +261,17 @@ contract InflationPoolAuditMedLowTest is Test {
         // Stakers got nothing (no config + empty serviceIds)...
         assertEq(e.stakersDistributed, 0, "no staker exposure distribution");
 
-        // ...but the staker slice was REALLOCATED, not dropped: the epoch's total distribution
-        // must materially exceed the non-staker base targets (which sum to only 50% of budget).
+        // F7: ...and the staker slice is NOT reallocated into the other streams. With every
+        // non-staker stream active, those distribute their own targets (the non-staker 50% base)
+        // and nothing more — the staker 50% is retained in the pool and rolls into a later epoch,
+        // so a permissionless front-runner cannot redirect staker inflation to themselves.
         uint256 totalDist = e.stakingDistributed + e.operatorsDistributed + e.customersDistributed
             + e.developersDistributed + e.stakersDistributed;
         uint256 nonStakerBase = budget - stakersTarget; // 50% of budget
-        assertGt(totalDist, nonStakerBase, "staker slice reallocated into other streams");
-        // The reallocation captured most of the staker slice (allow rounding/uncovered dust).
-        assertGe(totalDist, nonStakerBase + (stakersTarget * 9) / 10, "most of staker slice paid out");
+        // Total paid out is bounded by the non-staker base (allow tiny rounding dust); the staker
+        // slice was NOT redirected.
+        assertLe(totalDist, nonStakerBase + 1e9, "staker slice retained, not reallocated");
+        assertLt(totalDist, nonStakerBase + (stakersTarget / 10), "staker slice not redirected to other streams");
     }
 
     // ────────────────────────────────────────────────────────────────────────────
@@ -295,14 +298,14 @@ contract InflationPoolAuditMedLowTest is Test {
 
         uint256 vault0Before = tnt.balanceOf(address(vaults));
         // Track per-vault accounting via rewardsDistributed (third field).
-        (, , uint256 rd0Before) = vaults.vaultStates(address(0));
-        (, , uint256 rd2Before) = vaults.vaultStates(asset2);
+        (,, uint256 rd0Before) = vaults.vaultStates(address(0));
+        (,, uint256 rd2Before) = vaults.vaultStates(asset2);
 
         _warpToEpochEnd();
         pool.distributeEpoch();
 
-        (, , uint256 rd0After) = vaults.vaultStates(address(0));
-        (, , uint256 rd2After) = vaults.vaultStates(asset2);
+        (,, uint256 rd0After) = vaults.vaultStates(address(0));
+        (,, uint256 rd2After) = vaults.vaultStates(asset2);
 
         uint256 reward0 = rd0After - rd0Before;
         uint256 reward2 = rd2After - rd2Before;
@@ -318,9 +321,7 @@ contract InflationPoolAuditMedLowTest is Test {
         assertApproxEqRel(reward2 * score0, reward0 * score2, 0.01e18, "split tracks score ratio");
 
         // TNT actually moved into the vault for the accounted rewards.
-        assertEq(
-            tnt.balanceOf(address(vaults)) - vault0Before, reward0 + reward2, "transferred == accounted"
-        );
+        assertEq(tnt.balanceOf(address(vaults)) - vault0Before, reward0 + reward2, "transferred == accounted");
     }
 
     // ────────────────────────────────────────────────────────────────────────────

--- a/test/audit/medlow/TokenizedExt.t.sol
+++ b/test/audit/medlow/TokenizedExt.t.sol
@@ -84,15 +84,27 @@ contract TokenizedExtAuditTest is Test {
         bp.withdraw(100 ether);
     }
 
-    function test_Finding1_DefaultIsNoLockForBackwardCompat() public {
-        // With the default (0) the historical immediate-withdraw behavior holds,
-        // so the base does not silently break existing unguarded blueprints/tests.
-        assertEq(bp.stakeLockDuration(), 0, "lock disabled by default");
+    function test_Finding1_SecureDefaultLockBlocksJIT() public {
+        // F4: the base now ships a NON-ZERO default stake-lock so a blueprint that forgets to
+        // configure one is not silently exposed to the JIT instant-mode reward-capture vector.
+        // (Previously the default was 0 and immediate withdraw succeeded — the hole.)
+        assertEq(bp.stakeLockDuration(), bp.DEFAULT_STAKE_LOCK_DURATION(), "default == failsafe window");
+        assertGt(bp.stakeLockDuration(), 0, "default lock must be non-zero (fail safe)");
+
         bp.mintToken(honest, 10 ether);
         vm.prank(honest);
         bp.stake(10 ether);
+        uint256 unlock = bp.stakeUnlockTime(honest);
+
+        // Immediate withdrawal is now blocked by default.
         vm.prank(honest);
-        bp.withdraw(10 ether); // must not revert
+        vm.expectRevert(abi.encodeWithSelector(TokenizedBlueprintBase.StakeLocked.selector, unlock));
+        bp.withdraw(10 ether);
+
+        // Once the default window elapses, withdrawal succeeds (lock is a delay, not a freeze).
+        vm.warp(block.timestamp + bp.DEFAULT_STAKE_LOCK_DURATION());
+        vm.prank(honest);
+        bp.withdraw(10 ether);
         assertEq(bp.stakedBalance(honest), 0);
     }
 

--- a/test/extensions/BlueprintExtensions.t.sol
+++ b/test/extensions/BlueprintExtensions.t.sol
@@ -208,6 +208,9 @@ contract TokenizedBlueprintBaseTest is Test {
         assertEq(blueprint.totalStaked(), 40 ether);
         assertEq(blueprint.balanceOf(staker), 60 ether);
 
+        // F4: the base now applies a non-zero default stake-lock; advance past it before withdrawing.
+        vm.warp(block.timestamp + blueprint.stakeLockDuration() + 1);
+
         vm.prank(staker);
         blueprint.withdraw(25 ether);
         assertEq(blueprint.stakedBalance(staker), 15 ether);

--- a/test/tangle/Slashing.t.sol
+++ b/test/tangle/Slashing.t.sol
@@ -139,7 +139,7 @@ contract SlashingTest is BaseTest {
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
 
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "Invalid evidence");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Invalid evidence");
 
         SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
         assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Disputed));
@@ -177,7 +177,7 @@ contract SlashingTest is BaseTest {
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.DisputeWindowPassed.selector, slashId));
-        tangle.disputeSlash(slashId, "Too late");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Too late");
     }
 
     function test_DisputeSlash_RevertIfAlreadyExecuted() public {
@@ -190,7 +190,7 @@ contract SlashingTest is BaseTest {
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.SlashNotPending.selector, slashId));
-        tangle.disputeSlash(slashId, "reason");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "reason");
     }
 
     function test_DisputeSlash_AtExactWindowBoundary() public {
@@ -201,7 +201,7 @@ contract SlashingTest is BaseTest {
         vm.warp(block.timestamp + 7 days - 1);
 
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "At boundary");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "At boundary");
 
         SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
         assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Disputed));
@@ -281,7 +281,7 @@ contract SlashingTest is BaseTest {
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
 
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "disputed");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "disputed");
 
         // Add TIMESTAMP_BUFFER (15s) to account for manipulation protection
         vm.warp(block.timestamp + 7 days + 16);
@@ -351,7 +351,7 @@ contract SlashingTest is BaseTest {
         uint64 slashId = tangle.proposeSlash(serviceId, operator1, 1000, keccak256("evidence"));
 
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "disputed");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "disputed");
 
         vm.prank(admin);
         tangle.cancelSlash(slashId, "Dispute upheld");

--- a/test/tangle/SlashingEdgeCases.t.sol
+++ b/test/tangle/SlashingEdgeCases.t.sol
@@ -186,7 +186,7 @@ contract SlashingEdgeCasesTest is BaseTest {
         vm.warp(block.timestamp + 7 days - 1);
 
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "Last second dispute");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Last second dispute");
 
         SlashingLib.SlashProposal memory proposal = tangle.getSlashProposal(slashId);
         assertEq(uint8(proposal.status), uint8(SlashingLib.SlashStatus.Disputed));
@@ -202,7 +202,7 @@ contract SlashingEdgeCasesTest is BaseTest {
 
         vm.prank(operator1);
         vm.expectRevert(abi.encodeWithSelector(Errors.DisputeWindowPassed.selector, slashId));
-        tangle.disputeSlash(slashId, "Too late");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Too late");
     }
 
     function test_ExecuteAtExactWindowBoundary() public {
@@ -443,7 +443,7 @@ contract SlashingEdgeCasesTest is BaseTest {
         // Both dispute and execute attempted at boundary
         // Dispute should succeed since we're still in window
         vm.prank(operator1);
-        tangle.disputeSlash(slashId, "Last second dispute");
+        tangle.disputeSlash{ value: 0.02 ether }(slashId, "Last second dispute");
 
         // Execute should fail since disputed
         vm.warp(block.timestamp + 1);


### PR DESCRIPTION
## Summary

Second audit batch (11 findings across slashing, jobs, services-lifecycle, rewards/inflation, extensions, beacon-L2). Each finding was **independently validated against the cited code before any fix** — two report-vs-analysis discrepancies were resolved by ground-truthing the exact files named (F3, F5). **9 issues fixed in code; F5 deferred with documentation; F6/F11 are latent/intentional and documented.** Full affected suites (slashing, lifecycle, jobs, rewards, extensions, beacon, integration, upgrade) are green.

## Validity verdicts

| ID | Sev | Verdict | Action |
|----|-----|---------|--------|
| F1 | High | VALID | Snapshot per-asset commitments at propose; execute uses snapshot |
| F2 | Med | VALID | Non-zero default `disputeBond` (0.02 ETH, matches prod config) |
| F3 | Med | VALID | `_ensureAggregationBypass` now fails **closed** on hook failure |
| F4 | Med | VALID | Failsafe non-zero default `stakeLockDuration` (blocks JIT capture) |
| F5 | Med | VALID | **Deferred** — needs interface + staking-layer + accumulator change; documented |
| F6 | Med | latent | Dead clamp; liability-undercount only on a pre-liability upgrade (none exists). Documented |
| F7 | Low | VALID | Permissionless `distributeEpoch` no longer reallocates the staker slice |
| F8 | Low | VALID | Prune `assetOperators[]` on zero stake (swap-and-pop) |
| F9 | Low | VALID | Duplicate-asset commitment dedup made unconditional |
| F10 | Low | VALID | Bound incoming `slashBps <= 10000` at L2 receipt (defense-in-depth) |
| F11 | Info | intentional | `instantSlashEnabled` read+enforced but deliberately unreachable. Documented |

## Fixes

- **F1 (High)** — `executeSlash` read commitments LIVE, so an operator could self-dispute → leave → rejoin with a 1-bps commitment and evade ~99.99% of the slash. Now snapshotted into a dedicated `_slashCommitmentSnapshots` mapping at propose time and consumed at execute. Storage appended at end, gap shrunk 29→28; `SlashProposal` (and its `ITangleSlashing` binding) untouched, so **no Rust binding regen needed**.
- **F2 (Med)** — default `disputeBond` was 0 → free self-dispute freezes delegator withdrawals for the resolution window. Ship a non-zero default matching `deploy/config/*.json`.
- **F3 (Med)** — `_ensureAggregationBypass` only reverted on `ok && requiresAggregation`, failing **open** when the manager hook reverts/gas-griefs → a single operator could finalize a quorum job. Now `!ok || requiresAggregation` reverts. Safe because the BSM base implements `requiresAggregation` (returns false), so `!ok` is a genuine failure.
- **F4 (Med)** — `stakeLockDuration=0` default enabled same-block JIT instant-mode reward capture. Seed a non-zero failsafe default in the constructor.
- **F7 (Low)** — the unspent staker slice was reallocated to other categories on the permissionless empty-`serviceIds` path, letting a front-running operator/customer/dev redirect staker inflation. Now reallocated **only** when staker distribution was attempted; otherwise retained in the pool to roll forward.
- **F8 (Low)** — `assetOperators[]` was append-only and double-iterated in epoch distribution. Added `_untrackOperator` (swap-and-pop) + prune on zero stake; gap shrunk 50→49.
- **F9 (Low)** — duplicate-asset dedup only ran when the service had requirements; duplicates double-slashed/double-billed otherwise. Dedup is now unconditional.
- **F10 (Low)** — clamp incoming `slashBps` at receipt so a malformed cross-chain value can't inflate the deferred accumulator.

## Deferred / documented (no code change)

- **F5 (Med)** — `ServiceFeeDistributor.onDelegationChanged` bakes `lockMultiplierBps` into the position score but gets **no lock expiry**, and the staking layer computes a *blended* multiplier across multiple locks, so a correct decay requires an `onDelegationChanged` interface change + staking-layer expiry threading + lazy decay in the O(1) reward-accumulator math (mirroring `RewardVaults._decayExpiredLock`). Deferred to a focused follow-up to avoid reward-accounting regressions; root cause + plan documented inline.
- **F6 (Med)** — the epoch-budget clamp is effectively dead (`budget ≤ freeBalance ≤ poolBalance`); the liability undercount only bites an upgrade from a pre-`pendingRewardsLiability` deployment, which does not exist here. Documented; any future migration must seed liability in a reinitializer.
- **F11 (Info)** — `instantSlashEnabled` is read & enforced in `SlashingLib`, but `proposeSlash` hardcodes `instant=false`, leaving it intentionally unreachable. Documented as a deliberate control (wiring instant slash needs a dispute-bypass review), not dead code.

## Tests

- New repros: `test/audit/batch2/AuditBatch2.t.sol` (F1 leave/rejoin dilution, F2 bonded self-dispute, F9 duplicate-asset reject) and a `BeaconL2` receiver test for F10.
- Regression guards repurposed for the intended default changes: F4 (default lock blocks JIT) in `TokenizedExt`/`BlueprintExtensions`, F7 (staker slice retained, not reallocated) in `audit/medlow/InflationPool`.
- Updated 10 slashing mechanism tests to post the new default dispute bond.
- Green: `tangle/Slashing*`, `EndToEndSlashingTest`, `SvcLifecycle`, `JobsAgg`, `BLSAggregation`, `PerAssetExposureIntegration`, `DoubleExposureUnderSlashPoC`, `Rewards`, `InflationPool` (+audit), `RewardVaults`, `TokenizedExt`, `BlueprintExtensions`, `BeaconL2`, `Integration`, `MultiAssetDelegation`, `FullStackScenario`, `UpgradeFlow`.

> The full ~1855-test suite was not run in one shot — `forge test` with no path filter OOMs this box (full via-IR graph). Coverage was run per touched subsystem + integration/upgrade; changes are confined to the listed contracts. CI can run the full suite.