### PR TITLE
fix(rewards): decay lock-multiplier boost on expiry in ServiceFeeDistributor (F5)

### DIFF
--- a/src/interfaces/IServiceFeeDistributor.sol
+++ b/src/interfaces/IServiceFeeDistributor.sol
@@ -70,7 +70,10 @@ interface IServiceFeeDistributor {
         uint64[] calldata blueprintIds,
         // Per-blueprint amount deltas (must align with blueprintIds for Fixed mode).
         uint256[] calldata blueprintAmounts,
-        uint16 lockMultiplierBps
+        uint16 lockMultiplierBps,
+        // F5: latest active lock expiry for (delegator, asset); 0 if no active lock. The boost
+        // baked into the position score is decayed to base once this timestamp passes.
+        uint64 lockExpiry
     )
         external;
 

--- a/src/rewards/ServiceFeeDistributor.sol
+++ b/src/rewards/ServiceFeeDistributor.sol
@@ -224,7 +224,8 @@ contract ServiceFeeDistributor is
         Types.BlueprintSelectionMode selectionMode,
         uint64[] calldata blueprintIds,
         uint256[] calldata blueprintAmounts,
-        uint16 lockMultiplierBps
+        uint16 lockMultiplierBps,
+        uint64 lockExpiry
     )
         external
         override
@@ -237,6 +238,10 @@ contract ServiceFeeDistributor is
         _dripOperatorStreams(operator);
 
         bytes32 assetHash = _assetHash(asset);
+
+        // F5: collapse any PRIOR expired lock boost to base before applying this change, so a
+        // stale boost is never carried into the new score (and stops diluting others).
+        _settleExpiredLock(delegator, operator, assetHash);
         if (!_assetKnown[assetHash]) {
             _assetKnown[assetHash] = true;
             _assetByHash[assetHash] = Types.Asset({ kind: asset.kind, token: asset.token });
@@ -253,14 +258,11 @@ contract ServiceFeeDistributor is
         uint256 principalBefore = _positionPrincipal[delegator][operator][assetHash];
         uint256 scoreBefore = _positionScore[delegator][operator][assetHash];
 
-        // KNOWN LIMITATION (F5, tracked for a focused follow-up): `lockMultiplierBps` is baked
-        // into the position score here but this contract receives no lock-expiry, so the boost
-        // does not decay when the lock elapses — a locker keeps an inflated reward share until
-        // they next interact (diluting others). A correct fix requires threading the lock expiry
-        // through `onDelegationChanged` (interface + staking-layer change) and adding lazy
-        // decay-on-expiry to the reward-accumulator math (mirroring `RewardVaults._decayExpiredLock`).
-        // That is deliberately NOT done inline: a rushed change to this O(1) accumulator/debt
-        // accounting risks misallocating live rewards. See the audit batch-2 PR description.
+        // F5: `lockMultiplierBps` boosts the score here, and `lockExpiry` (threaded from the
+        // staking layer) records when that boost ends. `_settleExpiredLock` (called above and on
+        // every reward path) collapses the boost back to base once the lock elapses, so it can no
+        // longer dilute other delegators. Any prior expired boost was already settled at the top
+        // of this function, so `scoreBefore` here is the live (base-or-still-locked) score.
         uint256 scoreDelta;
         uint256 principalAfter;
         uint256 scoreAfter;
@@ -282,6 +284,10 @@ contract ServiceFeeDistributor is
         }
 
         _positionMode[delegator][operator][assetHash] = newMode;
+
+        // F5: record the lock expiry that backs this (possibly boosted) score so the boost can
+        // be decayed to base once every lock elapses.
+        _positionLockExpiry[delegator][operator][assetHash] = lockExpiry;
 
         // Track delegator position for claimAll iteration (only on first interaction)
         if (existingMode == 0) {
@@ -373,6 +379,9 @@ contract ServiceFeeDistributor is
         if (_positionMode[delegator][operator][assetHash] != 2) {
             revert InvalidModeChange();
         }
+
+        // F5: collapse any expired lock boost before rebalancing redistributes the score.
+        _settleExpiredLock(delegator, operator, assetHash);
 
         if (blueprintIds.length != blueprintAmounts.length) {
             revert InvalidBlueprintAmounts();
@@ -821,6 +830,8 @@ contract ServiceFeeDistributor is
         if (mode != 0) {
             // Drip any pending streaming payments to get up-to-date rewards
             _dripOperatorStreams(operator);
+            // F5: decay an expired lock boost before harvesting so future accrual is at base.
+            _settleExpiredLock(msg.sender, operator, assetHash);
             _harvestToken(msg.sender, operator, assetHash, token, mode);
         }
 
@@ -876,6 +887,8 @@ contract ServiceFeeDistributor is
                 uint8 mode = _positionMode[account][operator][assetHash];
                 if (mode == 0) continue;
 
+                // F5: decay an expired lock boost before harvesting so future accrual is at base.
+                _settleExpiredLock(account, operator, assetHash);
                 _harvestToken(account, operator, assetHash, token, mode);
             }
         }
@@ -1052,6 +1065,69 @@ contract ServiceFeeDistributor is
     // INTERNAL
     // ═══════════════════════════════════════════════════════════════════════════
 
+    /// @notice F5: decay an expired lock-multiplier boost on a position back to base (principal).
+    /// @dev Lazy decay, mirroring `RewardVaults._decayExpiredLock`. The boost is only valid while a
+    ///      lock is active; once `_positionLockExpiry` passes, the position must stop earning at the
+    ///      boosted score (which otherwise dilutes everyone else forever). Already-accrued rewards
+    ///      are harvested at the boosted score first (they were genuinely earned while the boost was
+    ///      live, lazily), THEN the score is collapsed to principal and the per-token debt re-synced
+    ///      so future accrual is at base. Callers MUST drip operator streams before calling.
+    ///      No-op when there is no active lock record, the lock has not expired, or there is no
+    ///      boost left to remove. Idempotent.
+    function _settleExpiredLock(address delegator, address operator, bytes32 assetHash) internal {
+        uint64 expiry = _positionLockExpiry[delegator][operator][assetHash];
+        if (expiry == 0 || block.timestamp < expiry) return;
+
+        uint8 mode = _positionMode[delegator][operator][assetHash];
+        uint256 score = _positionScore[delegator][operator][assetHash];
+        uint256 principal = _positionPrincipal[delegator][operator][assetHash];
+
+        // Clear the marker regardless; the boost (if any) is being removed now.
+        _positionLockExpiry[delegator][operator][assetHash] = 0;
+        if (mode == 0 || score <= principal) return;
+
+        // Settle accrued rewards at the boosted score before collapsing it.
+        _harvestAllTokens(delegator, operator, assetHash, mode);
+
+        uint256 boost = score - principal;
+        if (mode == 1) {
+            uint256 cur = totalAllScore[operator][assetHash];
+            totalAllScore[operator][assetHash] = boost > cur ? 0 : cur - boost;
+            _positionScore[delegator][operator][assetHash] = principal;
+        } else {
+            // Fixed mode: scale every per-blueprint score down by principal/score and reduce the
+            // operator/blueprint totals by the removed amount.
+            uint64[] storage bps = _fixedBlueprints[delegator][operator][assetHash];
+            uint256 newAggregate = 0;
+            for (uint256 i = 0; i < bps.length; i++) {
+                uint64 bpId = bps[i];
+                uint256 bScore = _positionFixedScore[delegator][operator][assetHash][bpId];
+                if (bScore == 0) continue;
+                uint256 bNew = (bScore * principal) / score; // rounds down toward base
+                uint256 bDelta = bScore - bNew;
+                _positionFixedScore[delegator][operator][assetHash][bpId] = bNew;
+
+                uint256 cf = totalFixedScore[operator][bpId][assetHash];
+                totalFixedScore[operator][bpId][assetHash] = bDelta > cf ? 0 : cf - bDelta;
+                uint256 cfa = _totalFixedScoreByAsset[operator][assetHash];
+                _totalFixedScoreByAsset[operator][assetHash] = bDelta > cfa ? 0 : cfa - bDelta;
+                newAggregate += bNew;
+            }
+            _positionScore[delegator][operator][assetHash] = newAggregate;
+        }
+
+        // Re-sync per-token debt to the collapsed score so future accrual is at base.
+        _syncDebtsToCurrentAcc(delegator, operator, assetHash, mode);
+    }
+
+    /// @notice Permissionlessly decay a position's expired lock-multiplier boost (F5).
+    /// @dev Lets anyone (e.g. a diluted co-delegator or a keeper) collapse a stale boost even if
+    ///      the locker never interacts again, instead of relying on the locker's next claim/change.
+    function settleExpiredLock(address delegator, address operator, Types.Asset calldata asset) external nonReentrant {
+        _dripOperatorStreams(operator);
+        _settleExpiredLock(delegator, operator, _assetHash(asset));
+    }
+
     function _harvestAllTokens(address delegator, address operator, bytes32 assetHash, uint8 mode) internal {
         // Use per-asset token set for efficiency - only iterates tokens actually distributed for this asset
         EnumerableSet.AddressSet storage set = _operatorAssetRewardTokens[operator][assetHash];
@@ -1071,6 +1147,7 @@ contract ServiceFeeDistributor is
         _positionMode[delegator][operator][assetHash] = 0;
         _positionPrincipal[delegator][operator][assetHash] = 0;
         _positionScore[delegator][operator][assetHash] = 0;
+        _positionLockExpiry[delegator][operator][assetHash] = 0;
 
         uint64[] storage existing = _fixedBlueprints[delegator][operator][assetHash];
         for (uint256 i = existing.length; i > 0; i--) {
@@ -1388,6 +1465,13 @@ contract ServiceFeeDistributor is
     /// @notice Receive ETH for native token distributions from StreamingPaymentManager
     receive() external payable { }
 
-    /// @dev Reserved storage slots for future upgrades (Round 2 storage F-3).
-    uint256[50] private __gap;
+    /// @notice F5: latest active lock expiry per position (delegator => operator => assetHash).
+    /// @dev The lock-multiplier boost baked into the position score is only valid until this
+    ///      timestamp; past it `_settleExpiredLock` collapses the score back to base (principal).
+    ///      0 = no active lock / already settled. Appended at end of storage (gap shrunk 50 -> 49).
+    mapping(address => mapping(address => mapping(bytes32 => uint64))) private _positionLockExpiry;
+
+    /// @dev Reserved storage slots for future upgrades (Round 2 storage F-3). Shrunk 50 -> 49
+    ///      when `_positionLockExpiry` was appended (F5).
+    uint256[49] private __gap;
 }

--- a/src/staking/DelegationManagerLib.sol
+++ b/src/staking/DelegationManagerLib.sol
@@ -541,9 +541,7 @@ abstract contract DelegationManagerLib is OperatorManager {
                         // `dep.amount` / `currentDeposits`, so slashed principal cannot strand
                         // (audit LOW: "slash strands deposit principal").
                         Types.Deposit storage dep = _deposits[msg.sender][assetHash];
-                        _settleDelegatedCostBasis(
-                            msg.sender, assetHash, dep, req.slashFactorSnapshot, amountToReturn
-                        );
+                        _settleDelegatedCostBasis(msg.sender, assetHash, dep, req.slashFactorSnapshot, amountToReturn);
 
                         // Remove delegation if zero shares
                         if (d.shares == 0) {
@@ -888,6 +886,21 @@ abstract contract DelegationManagerLib is OperatorManager {
                 uint16 lockBps = _getLockMultiplierBps(info.multiplier);
                 lockedAmount += info.amount;
                 weightedBpsSum += Math.mulDiv(info.amount, lockBps, 1);
+            }
+        }
+    }
+
+    /// @notice Latest expiry among the delegator's still-active locks for an asset (0 if none).
+    /// @dev F5: the lock multiplier baked into the external ServiceFeeDistributor score is only
+    ///      valid while a lock is active. Once every lock has expired the blended multiplier
+    ///      collapses to base (MULTIPLIER_NONE), so the distributor must decay the boost after this
+    ///      timestamp. The latest active expiry is the point past which NO lock contributes a boost.
+    function _getLatestActiveLockExpiry(address delegator, bytes32 assetHash) internal view returns (uint64 expiry) {
+        Types.LockInfo[] storage locks = _depositLocks[delegator][assetHash];
+        for (uint256 i = 0; i < locks.length; i++) {
+            uint64 e = locks[i].expiryTimestamp;
+            if (e > block.timestamp && e > expiry) {
+                expiry = e;
             }
         }
     }

--- a/src/staking/RewardsManager.sol
+++ b/src/staking/RewardsManager.sol
@@ -98,7 +98,9 @@ abstract contract RewardsManager is DelegationManagerLib {
         // Notify external rewards manager for TNT incentives (if configured)
         _notifyExternalRewardsManager(delegator, operator, asset, amount, isIncrease, lockMultiplierBps);
 
-        // Notify external service-fee distributor for multi-token fee accrual (if configured)
+        // Notify external service-fee distributor for multi-token fee accrual (if configured).
+        // F5: also pass the latest active lock expiry so the distributor can decay the
+        // lock-multiplier boost once every lock elapses (it has no lock data of its own).
         _notifyServiceFeeDistributor(
             delegator,
             operator,
@@ -108,7 +110,8 @@ abstract contract RewardsManager is DelegationManagerLib {
             selectionMode,
             blueprintIds,
             blueprintAmounts,
-            lockMultiplierBps
+            lockMultiplierBps,
+            _getLatestActiveLockExpiry(delegator, assetHash)
         );
     }
 
@@ -224,7 +227,8 @@ abstract contract RewardsManager is DelegationManagerLib {
         Types.BlueprintSelectionMode selectionMode,
         uint64[] memory blueprintIds,
         uint256[] memory blueprintAmounts,
-        uint16 lockMultiplierBps
+        uint16 lockMultiplierBps,
+        uint64 lockExpiry
     )
         internal
     {
@@ -239,7 +243,8 @@ abstract contract RewardsManager is DelegationManagerLib {
                 selectionMode,
                 blueprintIds,
                 blueprintAmounts,
-                lockMultiplierBps
+                lockMultiplierBps,
+                lockExpiry
             ) { }
             catch { }
     }

--- a/test/mocks/MockServiceFeeDistributor.sol
+++ b/test/mocks/MockServiceFeeDistributor.sol
@@ -104,7 +104,8 @@ contract MockServiceFeeDistributor is IServiceFeeDistributor {
         Types.BlueprintSelectionMode,
         uint64[] calldata,
         uint256[] calldata,
-        uint16
+        uint16,
+        uint64
     )
         external
         override

--- a/test/rewards/ServiceFeeDistributor.t.sol
+++ b/test/rewards/ServiceFeeDistributor.t.sol
@@ -690,4 +690,81 @@ contract ServiceFeeDistributorTest is BaseTest {
         assertEq(distributor.tntToken(), address(0), "TNT token should be cleared");
         assertEq(distributor.tntScoreRate(), 0, "TNT score rate should be 0");
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // F5: lock-multiplier boost decays to base once the lock expires
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function _nativeHash() internal pure returns (bytes32) {
+        return keccak256(abi.encode(Types.AssetKind.Native, address(0)));
+    }
+
+    function _nativeAsset() internal pure returns (Types.Asset memory) {
+        return Types.Asset({ kind: Types.AssetKind.Native, token: address(0) });
+    }
+
+    /// @dev A 6-month-locked delegation gets a boosted score. Once the lock expires, the boost
+    ///      must decay back to base (== principal) so it stops diluting other delegators. Before
+    ///      the fix the boost persisted forever. Here we exercise the permissionless poke.
+    function test_F5_PermissionlessSettleDecaysExpiredBoost() public {
+        address locker = makeAddr("f5locker");
+        vm.deal(locker, 100 ether);
+        bytes32 ah = _nativeHash();
+
+        vm.startPrank(locker);
+        staking.depositWithLock{ value: 10 ether }(Types.LockMultiplier.SixMonths);
+        staking.delegate(operator1, 10 ether);
+        vm.stopPrank();
+
+        (uint8 mode, uint256 principal, uint256 score) = distributor.getPosition(locker, operator1, ah);
+        assertEq(mode, 1, "all mode");
+        assertEq(principal, 10 ether, "principal is raw amount");
+        assertGt(score, principal, "6mo lock boosts the score above principal");
+
+        uint256 totalBefore = distributor.totalAllScore(operator1, ah);
+        uint256 boost = score - principal;
+
+        // Past the 6-month lock window.
+        vm.warp(block.timestamp + 181 days);
+
+        // Anyone can poke the decay (here: a keeper / co-delegator, not the locker).
+        vm.prank(makeAddr("keeper"));
+        distributor.settleExpiredLock(locker, operator1, _nativeAsset());
+
+        (, uint256 principalAfter, uint256 scoreAfter) = distributor.getPosition(locker, operator1, ah);
+        assertEq(scoreAfter, principalAfter, "boost decayed to base");
+        assertEq(scoreAfter, 10 ether, "score collapses to principal");
+        assertEq(distributor.totalAllScore(operator1, ah), totalBefore - boost, "operator total reduced by the boost");
+
+        // Idempotent: a second poke is a no-op.
+        vm.prank(makeAddr("keeper2"));
+        distributor.settleExpiredLock(locker, operator1, _nativeAsset());
+        (,, uint256 scoreAgain) = distributor.getPosition(locker, operator1, ah);
+        assertEq(scoreAgain, 10 ether, "second settle is a no-op");
+    }
+
+    /// @dev The boost also decays on the locker's own next interaction (claim path), so a rational
+    ///      claimer self-heals the dilution without needing an external poke.
+    function test_F5_BoostDecaysOnClaim() public {
+        address locker = makeAddr("f5locker2");
+        vm.deal(locker, 100 ether);
+        bytes32 ah = _nativeHash();
+
+        vm.startPrank(locker);
+        staking.depositWithLock{ value: 10 ether }(Types.LockMultiplier.SixMonths);
+        staking.delegate(operator1, 10 ether);
+        vm.stopPrank();
+
+        (, uint256 principal, uint256 score) = distributor.getPosition(locker, operator1, ah);
+        assertGt(score, principal, "boosted while locked");
+
+        vm.warp(block.timestamp + 181 days);
+
+        // Claiming (even with nothing to claim) settles the expired boost.
+        vm.prank(locker);
+        distributor.claimAll(address(payTokenA));
+
+        (,, uint256 scoreAfter) = distributor.getPosition(locker, operator1, ah);
+        assertEq(scoreAfter, principal, "boost decayed to base on claim");
+    }
 }


### PR DESCRIPTION
## Summary

Completes **F5** — the one finding deferred from the batch-2 audit (#184). `ServiceFeeDistributor` baked a lock-multiplier into a position's reward score but had **no lock-expiry**, so the boost persisted forever: a locker kept an inflated share of every future distribution (diluting other delegators) unless they happened to interact again. This implements the proper cross-contract decay the deferral called for.

## Fix (lazy decay, mirrors `RewardVaults._decayExpiredLock`)

1. **Thread the lock expiry** from the staking layer through to the distributor:
   - New `DelegationManagerLib._getLatestActiveLockExpiry(delegator, assetHash)` — the timestamp past which no active lock contributes a boost.
   - `RewardsManager._onDelegationChanged` computes it and passes it via `_notifyServiceFeeDistributor` → the `IServiceFeeDistributor.onDelegationChanged` hook (new `uint64 lockExpiry` arg). The 3 outer call sites are untouched (expiry is computed centrally).
2. **Store it per position** — `_positionLockExpiry` (appended; reserved gap 50→49, upgrade-safe).
3. **`_settleExpiredLock`** harvests accrued (boosted) rewards first — they were genuinely earned while the lock was live (lazy accrual) — then collapses the score back to base (`== principal`, since `MULTIPLIER_NONE == 10000`), reduces the operator/blueprint score totals by the boost, and re-syncs per-token debt so **future** accrual is at base. Handles both **All** and **Fixed** modes.
4. **Runs on every reward path** — `onDelegationChanged`, `onBlueprintsRebalanced`, `claimFor`, `claimAll` — plus a **permissionless `settleExpiredLock(delegator, operator, asset)`** so a diluted co-delegator or keeper can collapse a stale boost even if the locker never returns.

Because already-accrued rewards live in the accumulator and stay correctly owed, no view changes are needed.

## Scope / safety

- `IServiceFeeDistributor` is **not** in the Rust bindings, so no binding regen. `MockServiceFeeDistributor` updated to the new signature.
- Interface/threading change is internal to the protocol; the staking outer call sites are unchanged.

## Tests

- New `ServiceFeeDistributor.t.sol` cases: `test_F5_PermissionlessSettleDecaysExpiredBoost` (6-month lock → boosted score → warp past expiry → poke → score collapses to principal, operator total drops by the boost, idempotent) and `test_F5_BoostDecaysOnClaim` (self-heals on the locker's own claim).
- No regressions across every `onDelegationChanged` path: ServiceFeeDistributor (+invariant, +streaming), Rewards, MultiAssetDelegation, Payments, Integration, EndToEndSubscription, PerAssetExposure, QuotePaymentSplit, RFQPaymentDistribution, DoubleExposure, and the staking delegation suites (DelegationCritical/Flows/EdgeCases/RewardsManager/BlueprintSelection — 135 tests).

> Full ~1855-test suite not run in one shot (full via-IR graph OOMs the box / forge memory cap); coverage run per affected subsystem. CI can run the full suite.