### PR TITLE
fix(migration): forbid emergencyWithdraw of the migration token

### DIFF
--- a/packages/migration-claim/src/TangleMigration.sol
+++ b/packages/migration-claim/src/TangleMigration.sol
@@ -111,6 +111,7 @@ contract TangleMigration is Ownable, ReentrancyGuard {
     error AdminClaimWindowClosed();
     error InvalidAdminClaimDeadline();
     error EmergencyWithdrawNotAllowed();
+    error EmergencyWithdrawTokenForbidden();
     error ClaimDeadlineNotPassed();
     error NoClaimDeadlineSet();
     error MerkleRootLocked();
@@ -340,10 +341,15 @@ contract TangleMigration is Ownable, ReentrancyGuard {
         emit Paused(_paused);
     }
 
-    /// @notice Emergency withdraw tokens (only after deadline or if paused)
-    /// @param _token Token to withdraw (use address(0) for native)
+    /// @notice Emergency withdraw mis-sent tokens (only after deadline or if paused)
+    /// @dev The migration token itself is intentionally NOT withdrawable here: unclaimed
+    ///      migration funds may only ever exit via the permissionless `sweepUnclaimedToTreasury`
+    ///      to the immutable `treasury`. Allowing the owner to pull `token` would defeat that
+    ///      guarantee and reintroduce owner discretion over user-claimable funds.
+    /// @param _token Token to withdraw (use address(0) for native); must not be the migration token
     /// @param _amount Amount to withdraw
     function emergencyWithdraw(address _token, uint256 _amount) external onlyOwner {
+        if (_token == address(token)) revert EmergencyWithdrawTokenForbidden();
         bool deadlinePassed = claimDeadline != 0 && block.timestamp > claimDeadline;
         if (!paused && !deadlinePassed) revert EmergencyWithdrawNotAllowed();
 

--- a/packages/migration-claim/test/TangleMigration.t.sol
+++ b/packages/migration-claim/test/TangleMigration.t.sol
@@ -736,22 +736,39 @@ contract TangleMigrationTest is Test {
     // EMERGENCY WITHDRAW TEST
     // ═══════════════════════════════════════════════════════════════════════
 
-    function test_EmergencyWithdraw() public {
+    function test_EmergencyWithdraw_RevertsForMigrationToken() public {
+        // Unclaimed migration funds must only ever exit via sweepUnclaimedToTreasury();
+        // the owner cannot pull the migration token here even when paused.
         migration.setPaused(true);
 
         uint256 balance = tnt.balanceOf(address(migration));
-        uint256 ownerBalanceBefore = tnt.balanceOf(owner);
-
+        vm.expectRevert(TangleMigration.EmergencyWithdrawTokenForbidden.selector);
         migration.emergencyWithdraw(address(tnt), balance);
+    }
 
-        assertEq(tnt.balanceOf(address(migration)), 0);
-        assertEq(tnt.balanceOf(owner), ownerBalanceBefore + balance);
+    function test_EmergencyWithdraw_RescuesForeignToken() public {
+        // A foreign token accidentally sent to the contract can still be rescued to owner.
+        TNT foreign = new TNT(owner);
+        foreign.mintInitialSupply(owner, 1000 ether);
+        foreign.transfer(address(migration), 500 ether);
+
+        migration.setPaused(true);
+        uint256 ownerBalanceBefore = foreign.balanceOf(owner);
+
+        migration.emergencyWithdraw(address(foreign), 500 ether);
+
+        assertEq(foreign.balanceOf(address(migration)), 0);
+        assertEq(foreign.balanceOf(owner), ownerBalanceBefore + 500 ether);
     }
 
     function test_EmergencyWithdraw_RevertIfNotPausedOrDeadlinePassed() public {
-        uint256 balance = tnt.balanceOf(address(migration));
+        // Use a foreign token so execution reaches the paused/deadline gate.
+        TNT foreign = new TNT(owner);
+        foreign.mintInitialSupply(owner, 1000 ether);
+        foreign.transfer(address(migration), 500 ether);
+
         vm.expectRevert(TangleMigration.EmergencyWithdrawNotAllowed.selector);
-        migration.emergencyWithdraw(address(tnt), balance);
+        migration.emergencyWithdraw(address(foreign), 500 ether);
     }
 
     function test_EmergencyWithdraw_OnlyOwner() public {


### PR DESCRIPTION
## What

`TangleMigration.emergencyWithdraw` now reverts (`EmergencyWithdrawTokenForbidden`) when `_token` is the migration token. The migration asset can only ever leave the contract via the permissionless `sweepUnclaimedToTreasury` → immutable `treasury`. Foreign-token and ETH rescue is unchanged.

## Why

`emergencyWithdraw(_token, _amount)` is `onlyOwner` and sends to `owner()` (transferable via `Ownable`). It had **no guard against `_token == address(token)`**, so once `paused` or past the claim deadline the owner could pull the **migration token itself** — i.e. unclaimed user allocations — straight to `owner()`.

That bypassed the entire trustless design: `treasury` is `immutable` and `sweepUnclaimedToTreasury()` is callable by **anyone** after the deadline, specifically so unclaimed funds can only land in a fixed treasury and no privileged actor can redirect them. `emergencyWithdraw` silently reintroduced full owner discretion over those same funds.

In production `owner` will be a multisig Safe, which lowers exploitability to "signers collude / Safe compromised" — but the guard makes the **code match the promise** the contract advertises to users, rather than relying on the signers' good behavior. Cheap, no downside.

This is audit finding #7 (graded medium). The originally-proposed remediation ("route emergencyWithdraw to treasury") was rejected because it would break the legitimate rescue of mis-sent foreign tokens; guarding the migration token specifically closes the hole without that cost.

## Tests

Replaced the prior test that withdrew the migration token to owner (the buggy behavior) with:
- `test_EmergencyWithdraw_RevertsForMigrationToken` — migration token is forbidden even when paused
- `test_EmergencyWithdraw_RescuesForeignToken` — a foreign token is still rescuable to owner
- `test_EmergencyWithdraw_RevertIfNotPausedOrDeadlinePassed` — paused/deadline gate still enforced (via a foreign token)

`forge test --match-path test/TangleMigration.t.sol` → **41 passed, 0 failed**.