### PR TITLE
fix(migration): bind vesting delegatee to beneficiary to stop front-run capture

### DIFF
--- a/packages/migration-claim/script/DeployTangleMigration.s.sol
+++ b/packages/migration-claim/script/DeployTangleMigration.s.sol
@@ -194,8 +194,7 @@ contract DeployTangleMigration is Script {
             address treasuryVesting = treasuryVestingFactory.getOrCreateVesting(
                 configuredTnt,
                 treasuryRecipient,
-                uint64(block.timestamp),
-                treasuryRecipient // delegatee
+                uint64(block.timestamp)
             );
             require(tntToken.transfer(treasuryVesting, treasuryAmount), "Treasury vesting transfer failed");
 
@@ -223,8 +222,7 @@ contract DeployTangleMigration is Script {
             address foundationVesting = foundationVestingFactory.getOrCreateVesting(
                 configuredTnt,
                 foundationRecipient,
-                uint64(block.timestamp),
-                foundationRecipient // delegatee
+                uint64(block.timestamp)
             );
             require(tntToken.transfer(foundationVesting, foundationVested), "Foundation vesting transfer failed");
 

--- a/packages/migration-claim/src/TangleMigration.sol
+++ b/packages/migration-claim/src/TangleMigration.sol
@@ -409,12 +409,13 @@ contract TangleMigration is Ownable, ReentrancyGuard {
             // forge-lint: disable-next-line(unsafe-typecast)
             uint64 startTimestamp = uint64(block.timestamp);
 
-            // Create vesting contract with recipient as beneficiary and delegatee
+            // Create vesting contract with recipient as beneficiary. The factory forces the voting
+            // delegatee to the beneficiary (recipient), so a front-run pre-creation cannot redirect
+            // the vested voting power.
             vestingContract = vestingFactory.getOrCreateVesting(
                 address(token),
                 recipient,
-                startTimestamp,
-                recipient // delegatee - voting power goes to recipient
+                startTimestamp
             );
 
             token.safeTransfer(vestingContract, vestedAmount);

--- a/packages/migration-claim/src/lockups/TNTVestingFactory.sol
+++ b/packages/migration-claim/src/lockups/TNTVestingFactory.sol
@@ -51,13 +51,18 @@ contract TNTVestingFactory {
     /// @param token The ERC20 token to vest
     /// @param beneficiary The address that can withdraw vested tokens
     /// @param startTimestamp When the vesting schedule begins
-    /// @param delegatee Initial voting power delegatee (typically beneficiary)
     /// @return vesting The address of the vesting contract
+    /// @dev The clone's voting-power delegatee is forced to `beneficiary`. The delegatee is NOT part
+    ///      of the CREATE2 salt, so accepting a caller-supplied delegatee let a front-runner pre-create
+    ///      the victim's clone at the predicted address with an attacker delegatee; the get-or-create
+    ///      path then skips initialization and merely funds the hijacked clone, redirecting the
+    ///      beneficiary's vested voting power. Binding the delegatee to `beneficiary` removes that
+    ///      degree of freedom: any pre-created clone is byte-identical to the one this call would
+    ///      create, so front-running is a harmless no-op. The beneficiary may re-delegate afterward.
     function getOrCreateVesting(
         address token,
         address beneficiary,
-        uint64 startTimestamp,
-        address delegatee
+        uint64 startTimestamp
     ) external returns (address vesting) {
         bytes32 salt = _computeSalt(token, beneficiary, startTimestamp);
         vesting = implementation.predictDeterministicAddress(salt, address(this));
@@ -70,7 +75,7 @@ contract TNTVestingFactory {
                 startTimestamp,
                 cliffDuration,
                 vestingDuration,
-                delegatee
+                beneficiary
             );
             emit VestingCreated(vesting, token, beneficiary, startTimestamp, cliffDuration, vestingDuration);
         }

--- a/packages/migration-claim/test/exploit/Exploit_MigrationClaim_VestingDelegateeFrontRun.t.sol
+++ b/packages/migration-claim/test/exploit/Exploit_MigrationClaim_VestingDelegateeFrontRun.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Votes} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";
+
+import {TangleMigration} from "../../src/TangleMigration.sol";
+import {MockZKVerifier} from "../../src/MockZKVerifier.sol";
+import {TNTVestingFactory} from "../../src/lockups/TNTVestingFactory.sol";
+import {TNTLinearVesting} from "../../src/lockups/TNTLinearVesting.sol";
+
+/// @notice Minimal ERC20Votes token so that `IVotes(token).delegate(...)` inside
+///         TNTLinearVesting.initialize actually moves on-chain voting power.
+///         The production TangleToken is an ERC20Votes token; the package's TNT.sol
+///         is a plain ERC20 (delegate is a try/catch no-op there), so we reproduce
+///         the votes-enabled behavior the migration is meant to run against.
+contract VotesTNT is ERC20, ERC20Permit, ERC20Votes {
+    constructor() ERC20("Votes TNT", "vTNT") ERC20Permit("Votes TNT") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    // ─── required multiple-inheritance overrides ───
+    function _update(address from, address to, uint256 value) internal override(ERC20, ERC20Votes) {
+        super._update(from, to, value);
+    }
+
+    function nonces(address owner_) public view override(ERC20Permit, Nonces) returns (uint256) {
+        return super.nonces(owner_);
+    }
+}
+
+/// @title Exploit: permissionless getOrCreateVesting captures a claimant's vesting voting power
+/// @notice Demonstrates that a front-runner can pre-create the victim's vesting clone at the
+///         deterministically-predicted address and initialize it with an ATTACKER-chosen
+///         delegatee. The migration's _executeClaim then finds the clone already deployed,
+///         skips initialization, and just funds it — so all of the victim's vested voting
+///         power ends up delegated to the attacker.
+contract Exploit_MigrationClaim_VestingDelegateeFrontRun is Test {
+    TangleMigration public migration;
+    VotesTNT public tnt;
+    MockZKVerifier public mockVerifier;
+
+    address public owner;
+    address public victim;     // the legitimate recipient of the claim
+    address public attacker;   // the front-runner
+    address public treasury;
+
+    // Mirror TangleMigration.t.sol single-leaf merkle setup.
+    bytes32 constant TEST_PUBKEY = bytes32(0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d);
+    uint256 constant TEST_AMOUNT = 1000 ether;
+
+    bytes32 public merkleRoot;
+    bytes32[] public merkleProof;
+
+    function setUp() public {
+        owner = address(this);
+        victim = makeAddr("victim");
+        attacker = makeAddr("attacker");
+        treasury = makeAddr("treasury");
+
+        // Deploy votes-enabled token and fund this contract.
+        tnt = new VotesTNT();
+        tnt.mint(owner, 100000 ether);
+
+        mockVerifier = new MockZKVerifier();
+
+        // Single-leaf merkle tree: leaf == root, empty proof.
+        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(TEST_PUBKEY, TEST_AMOUNT))));
+        merkleRoot = leaf;
+        merkleProof = new bytes32[](0);
+
+        migration = new TangleMigration(
+            address(tnt),
+            merkleRoot,
+            address(mockVerifier),
+            owner,
+            treasury
+        );
+
+        // Fund migration contract so it can pay out claims.
+        tnt.transfer(address(migration), 10000 ether);
+    }
+
+    /// @notice Regression for the front-run fix: getOrCreateVesting no longer accepts a caller-supplied
+    ///         delegatee — it forces delegatee == beneficiary — so a front-runner pre-creating the
+    ///         victim's clone cannot redirect the vested voting power. The pre-created clone is
+    ///         byte-identical to the one the migration would create, making the front-run a no-op.
+    function test_Regression_FrontRunCannotCaptureVestingVotingPower() public {
+        TNTVestingFactory factory = migration.vestingFactory();
+
+        // startTimestamp the migration WILL use == uint64(block.timestamp).
+        // forge-lint: disable-next-line(unsafe-typecast)
+        uint64 startTimestamp = uint64(block.timestamp);
+
+        address predicted = factory.predictVestingAddress(address(tnt), victim, startTimestamp);
+        assertEq(predicted.code.length, 0, "precondition: vesting not yet deployed");
+
+        // ── Attacker front-runs and pre-creates the victim's clone. The delegatee is no longer a
+        //    caller-controlled parameter; the factory forces it to the beneficiary (victim). ──
+        vm.prank(attacker);
+        address created = factory.getOrCreateVesting(address(tnt), victim, startTimestamp);
+        assertEq(created, predicted, "front-run still lands at the predicted address");
+
+        TNTLinearVesting vesting = TNTLinearVesting(created);
+        assertTrue(vesting.initialized(), "vesting initialized by the front-run create");
+        assertEq(vesting.beneficiary(), victim, "beneficiary is the victim");
+        // FIX: even though the attacker created the clone, voting power is delegated to the victim.
+        assertEq(tnt.delegates(created), victim, "delegatee forced to beneficiary at creation");
+
+        // ── Victim's claim executes; getOrCreateVesting finds the existing clone and just funds it. ──
+        vm.prank(victim);
+        migration.claimWithZKProof(TEST_PUBKEY, TEST_AMOUNT, merkleProof, "", victim);
+
+        uint256 unlockedAmount = (TEST_AMOUNT * migration.unlockedBps()) / 10_000;
+        uint256 vestedAmount = TEST_AMOUNT - unlockedAmount;
+
+        assertEq(tnt.balanceOf(created), vestedAmount, "vested tokens funded into the clone");
+
+        // ── INVARIANT HELD: all vested voting power belongs to the victim, none to the attacker. ──
+        assertEq(tnt.delegates(created), victim, "voting power delegated to the victim, not the attacker");
+        assertEq(tnt.getVotes(victim), vestedAmount, "victim holds all of their vested voting power");
+        assertEq(tnt.getVotes(attacker), 0, "attacker captured no voting power");
+    }
+}

--- a/script/FullDeploy.s.sol
+++ b/script/FullDeploy.s.sol
@@ -1644,7 +1644,7 @@ contract FullDeploy is DeployV2 {
             // Create vesting contract for 100% of treasury allocation
             TNTVestingFactory treasuryVestingFactory = new TNTVestingFactory(180 days, 912 days);
             address treasuryVesting = treasuryVestingFactory.getOrCreateVesting(
-                address(tnt), treasuryRecipient, uint64(block.timestamp), treasuryRecipient
+                address(tnt), treasuryRecipient, uint64(block.timestamp)
             );
             tnt.safeTransfer(treasuryVesting, migration.treasuryAmount);
             migration.treasuryRecipient = treasuryRecipient;
@@ -1665,7 +1665,7 @@ contract FullDeploy is DeployV2 {
             // 70% to vesting contract
             TNTVestingFactory foundationVestingFactory = new TNTVestingFactory(180 days, 912 days);
             address foundationVesting = foundationVestingFactory.getOrCreateVesting(
-                address(tnt), foundationRecipient, uint64(block.timestamp), foundationRecipient
+                address(tnt), foundationRecipient, uint64(block.timestamp)
             );
             tnt.safeTransfer(foundationVesting, foundationVested);
         }


### PR DESCRIPTION
## What

`TNTVestingFactory.getOrCreateVesting` no longer accepts a caller-supplied `delegatee`; it forces `delegatee == beneficiary`. Deploy scripts and `FullDeploy` updated to the 3-arg signature.

## Why

The `delegatee` was **not part of the CREATE2 salt** (`keccak256(token, beneficiary, startTimestamp)`). Since `getOrCreateVesting` is permissionless, a front-runner could pre-create a claimant's vesting clone at the deterministically-predicted address with an **attacker delegatee**. The migration's `_executeClaim` then found the clone already deployed, skipped initialization, and merely funded it — redirecting the beneficiary's **vested voting power** to the attacker (for an `ERC20Votes` token such as the production `TangleToken`).

Tokens were never at risk — `beneficiary` is salt-bound, so the attacker can't steal the vested tokens. Only governance voting power was redirected, and only until the beneficiary noticed and re-delegated. Real medium-severity governance griefing, especially at TGE scale across many claimants.

Binding the delegatee to `beneficiary` removes the attacker-controlled degree of freedom: any pre-created clone is now byte-identical to the one the migration would create, so a front-run is a harmless no-op. The beneficiary may still re-delegate afterward via the vesting contract.

## How found

Red-team exploit PoC. The PoC is retained as a passing regression test: the attacker pre-creates the clone, but after the victim's claim the attacker holds **0 votes** and the beneficiary holds **all** of the vested voting power.

## Verification

- `packages/migration-claim`: **42/42 tests pass** (`forge test`), including the new regression.
- Main repo compiles clean with the `FullDeploy` 3-arg fix.

## Scope note

The two `getOrCreateVesting` deploy-script call sites (treasury / foundation vesting) already passed `delegatee == recipient`, so dropping the argument is behavior-preserving.