### PR TITLE
fix(rewards): permissionless poke to collapse an expired lock-boost in RewardVaults (#199)

### DIFF
--- a/src/rewards/RewardVaults.sol
+++ b/src/rewards/RewardVaults.sol
@@ -1013,10 +1013,25 @@ contract RewardVaults is
     ///      `boostedScore` — diluting honest delegators until the locker chooses to transact. This lets
     ///      any diluted co-delegator or keeper force the collapse. No-op (via `_decayExpiredLock`) when
     ///      the lock is absent, not yet expired, or already at base weight; idempotent.
-    function settleExpiredLock(address asset, address delegator, address operator) external nonReentrant {
+    /// @return applied True if a boost was actually decayed; false on every no-op path, so a keeper
+    ///         learns whether the poke did anything without having to re-read storage.
+    function settleExpiredLock(
+        address asset,
+        address delegator,
+        address operator
+    )
+        external
+        nonReentrant
+        returns (bool applied)
+    {
         DelegatorDebt storage debt = delegatorDebts[asset][delegator][operator];
+        // Cheap short-circuit: for an absent or not-yet-expired lock there is nothing to decay and
+        // `_decayExpiredLock` would return at its first guard anyway. Checking the debt slot (already
+        // needed) first lets us skip the cold `operatorPools[asset][operator]` SLOAD on that common
+        // no-op poke against a non-existent/active position.
+        if (debt.lockExpiry == 0 || block.timestamp < debt.lockExpiry) return false;
         OperatorPool storage pool = operatorPools[asset][operator];
-        _decayExpiredLock(asset, delegator, operator, pool, debt);
+        return _decayExpiredLock(asset, delegator, operator, pool, debt);
     }
 
     /// @notice Effective (decay-aware) boosted score for views, without mutating storage.

--- a/src/rewards/RewardVaults.sol
+++ b/src/rewards/RewardVaults.sol
@@ -1005,6 +1005,20 @@ contract RewardVaults is
         return true;
     }
 
+    /// @notice Permissionlessly collapse a position's expired lock-multiplier boost back to base weight.
+    /// @dev Mirrors `ServiceFeeDistributor.settleExpiredLock`. The lazy `_decayExpiredLock` otherwise
+    ///      only runs on the locker's OWN claim/stake/unstake, so an idle locker keeps earning the
+    ///      (up to 1.6x) boosted share of every epoch after `lockExpiry` — `_distributeToOperatorPool`
+    ///      keeps advancing `accumulatedPerShare` against a `totalStaked` that still carries the stale
+    ///      `boostedScore` — diluting honest delegators until the locker chooses to transact. This lets
+    ///      any diluted co-delegator or keeper force the collapse. No-op (via `_decayExpiredLock`) when
+    ///      the lock is absent, not yet expired, or already at base weight; idempotent.
+    function settleExpiredLock(address asset, address delegator, address operator) external nonReentrant {
+        DelegatorDebt storage debt = delegatorDebts[asset][delegator][operator];
+        OperatorPool storage pool = operatorPools[asset][operator];
+        _decayExpiredLock(asset, delegator, operator, pool, debt);
+    }
+
     /// @notice Effective (decay-aware) boosted score for views, without mutating storage.
     /// @dev Mirrors `_decayExpiredLock`: once the lock has expired the position earns only
     ///      its base weight (`stakedAmount`). View functions must report the same weight a

--- a/test/audit/medlow/RewardVaultsMedLow.t.sol
+++ b/test/audit/medlow/RewardVaultsMedLow.t.sol
@@ -112,6 +112,57 @@ contract RewardVaultsMedLowTest is Test {
         );
     }
 
+    /// @notice FIX (#199): a third party (keeper / diluted co-delegator) can permissionlessly collapse
+    ///         an IDLE locker's expired boost via settleExpiredLock — the locker never transacts again.
+    ///         Before the fix the boost was only collapsible by the locker's OWN claim/stake/unstake, so
+    ///         an idle locker kept siphoning the boosted share of every epoch forever, diluting peers.
+    function test_ExpiredLockCollapsibleByThirdParty_stopsIdleDilution() public {
+        vault.recordDelegate(LOCKER, OPERATOR, ASSET, STAKE, LOCK_6MO_BPS);
+        vault.recordDelegate(PLAIN, OPERATOR, ASSET, STAKE, 0);
+        (,,, uint256 lockExpiry,) = _debt(LOCKER);
+
+        // Warp past expiry. The locker goes IDLE — never claims, stakes, or unstakes again.
+        vm.warp(lockExpiry + 1);
+
+        // The pool still carries the stale 1.6x boost (2600) until someone collapses it.
+        (, uint256 poolBefore,) = vault.operatorPools(ASSET, OPERATOR);
+        assertEq(poolBefore, 2600 ether, "stale boost still in pool pre-poke");
+
+        // ── THIRD PARTY (no role, not the locker) permissionlessly pokes the expired lock. ──
+        vm.prank(GRIEFER);
+        vault.settleExpiredLock(ASSET, LOCKER, OPERATOR);
+
+        // Boost collapsed to base without the locker ever acting.
+        (uint256 stakeAfter, uint256 scoreAfter,, uint256 expiryAfter,) = _debt(LOCKER);
+        assertEq(scoreAfter, stakeAfter, "poke: idle locker's boost collapsed to base");
+        assertEq(scoreAfter, 1000 ether, "poke: base == raw stake");
+        assertEq(expiryAfter, 0, "poke: lock metadata cleared");
+        (, uint256 poolAfter,) = vault.operatorPools(ASSET, OPERATOR);
+        assertEq(poolAfter, 2000 ether, "poke: pool total no longer carries the stale boost");
+
+        // ── Future epoch now splits 50/50: the idle locker no longer dilutes the honest peer. ──
+        vault.distributeRewards(ASSET, OPERATOR, REWARD);
+        uint256 lockerPending = vault.pendingDelegatorRewards(ASSET, LOCKER, OPERATOR);
+        uint256 plainPending = vault.pendingDelegatorRewards(ASSET, PLAIN, OPERATOR);
+        assertApproxEqAbs(lockerPending, REWARD / 2, 1e6, "post-poke: idle locker earns only base share");
+        assertApproxEqAbs(lockerPending, plainPending, 1e6, "post-poke: no dilution - locker == plain peer");
+    }
+
+    /// @notice settleExpiredLock is a safe no-op while the lock is still ACTIVE — a third party cannot
+    ///         use it to strip a delegator's live, still-earned boost.
+    function test_SettleExpiredLock_noopWhileLockActive() public {
+        vault.recordDelegate(LOCKER, OPERATOR, ASSET, STAKE, LOCK_6MO_BPS);
+        (,,, uint256 lockExpiry,) = _debt(LOCKER);
+        assertGt(lockExpiry, block.timestamp, "precondition: lock active");
+
+        vm.prank(GRIEFER);
+        vault.settleExpiredLock(ASSET, LOCKER, OPERATOR);
+
+        (, uint256 scoreAfter,, uint256 expiryAfter,) = _debt(LOCKER);
+        assertEq(scoreAfter, 1600 ether, "active lock: boost intact after no-op poke");
+        assertEq(expiryAfter, lockExpiry, "active lock: expiry unchanged");
+    }
+
     /// @notice A pure view (pendingDelegatorRewards) must report decay-aware accrual:
     ///         once the lock expires the unsettled accrual is valued at base weight, not
     ///         the stale boosted weight, so dashboards do not over-promise.

--- a/test/audit/medlow/RewardVaultsMedLow.t.sol
+++ b/test/audit/medlow/RewardVaultsMedLow.t.sol
@@ -93,7 +93,7 @@ contract RewardVaultsMedLowTest is Test {
         // Decay applied: locker boosted score collapsed to base == raw stake.
         (uint256 lockerStakeAfter, uint256 lockerScoreAfter,, uint256 expiryAfter,) = _debt(LOCKER);
         assertEq(lockerScoreAfter, lockerStakeAfter, "decay: boosted score back to base");
-        assertEq(lockerScoreAfter, 1000 ether, "decay: base == raw stake");
+        assertEq(lockerScoreAfter, STAKE, "decay: base == raw stake");
         assertEq(expiryAfter, 0, "decay: lock metadata cleared");
 
         // Pool total score is now 1000 (locker, decayed) + 1000 (plain) = 2000.
@@ -135,7 +135,7 @@ contract RewardVaultsMedLowTest is Test {
         // Boost collapsed to base without the locker ever acting.
         (uint256 stakeAfter, uint256 scoreAfter,, uint256 expiryAfter,) = _debt(LOCKER);
         assertEq(scoreAfter, stakeAfter, "poke: idle locker's boost collapsed to base");
-        assertEq(scoreAfter, 1000 ether, "poke: base == raw stake");
+        assertEq(scoreAfter, STAKE, "poke: base == raw stake");
         assertEq(expiryAfter, 0, "poke: lock metadata cleared");
         (, uint256 poolAfter,) = vault.operatorPools(ASSET, OPERATOR);
         assertEq(poolAfter, 2000 ether, "poke: pool total no longer carries the stale boost");
@@ -161,6 +161,94 @@ contract RewardVaultsMedLowTest is Test {
         (, uint256 scoreAfter,, uint256 expiryAfter,) = _debt(LOCKER);
         assertEq(scoreAfter, 1600 ether, "active lock: boost intact after no-op poke");
         assertEq(expiryAfter, lockExpiry, "active lock: expiry unchanged");
+    }
+
+    /// @notice The bool return reports whether a decay actually happened, so a keeper learns the
+    ///         poke's effect without re-reading storage (review finding: silent no-op).
+    function test_SettleExpiredLock_returnsAppliedFlag() public {
+        vault.recordDelegate(LOCKER, OPERATOR, ASSET, STAKE, LOCK_6MO_BPS);
+        (,,, uint256 lockExpiry,) = _debt(LOCKER);
+
+        assertFalse(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "active lock: no decay -> false");
+
+        vm.warp(lockExpiry); // decay fires at >= lockExpiry
+        assertTrue(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "expired boost: decay applied -> true");
+
+        assertFalse(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "already collapsed: nothing to decay -> false");
+    }
+
+    /// @notice Poking a never-delegated (asset, delegator, operator) tuple is a safe no-op: returns
+    ///         false, reverts nothing, mutates nothing — exercises the cheap short-circuit (no pool
+    ///         SLOAD) added for the 'lock absent' path (review finding: untested no-op path).
+    function test_SettleExpiredLock_noopLockAbsent() public {
+        address NOBODY = address(0xDEAD);
+        vm.prank(GRIEFER);
+        assertFalse(vault.settleExpiredLock(ASSET, NOBODY, OPERATOR), "absent position: no-op -> false");
+
+        (uint256 stake, uint256 score,, uint256 expiry,) = _debt(NOBODY);
+        assertEq(stake, 0, "absent: no stake");
+        assertEq(score, 0, "absent: no score");
+        assertEq(expiry, 0, "absent: no lock");
+    }
+
+    /// @notice An unlocked position already at base weight decays to nothing: no-op even after a long
+    ///         warp (review finding: 'already at base weight' path untested).
+    function test_SettleExpiredLock_noopAlreadyAtBase() public {
+        vault.recordDelegate(PLAIN, OPERATOR, ASSET, STAKE, 0); // no lock -> already base
+        vm.warp(block.timestamp + 400 days);
+
+        assertFalse(vault.settleExpiredLock(ASSET, PLAIN, OPERATOR), "unlocked base position: no-op -> false");
+        (uint256 stake, uint256 score,,,) = _debt(PLAIN);
+        assertEq(score, stake, "still at base weight");
+    }
+
+    /// @notice Repeated pokes after expiry are idempotent: the first collapses the boost, every
+    ///         subsequent poke is a no-op with score pinned at base (review finding: idempotency untested).
+    function test_SettleExpiredLock_idempotent() public {
+        vault.recordDelegate(LOCKER, OPERATOR, ASSET, STAKE, LOCK_6MO_BPS);
+        (,,, uint256 lockExpiry,) = _debt(LOCKER);
+        vm.warp(lockExpiry + 1);
+
+        assertTrue(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "first poke decays");
+        (uint256 s1, uint256 sc1,, uint256 e1,) = _debt(LOCKER);
+        assertEq(sc1, STAKE, "collapsed to base == raw stake");
+        assertEq(e1, 0, "lock cleared");
+
+        for (uint256 i = 0; i < 3; i++) {
+            assertFalse(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "repeat poke: no-op");
+        }
+        (uint256 s2, uint256 sc2,, uint256 e2,) = _debt(LOCKER);
+        assertEq(sc2, sc1, "score stable across repeated pokes");
+        assertEq(s2, s1, "stake stable");
+        assertEq(e2, 0, "lock stays cleared");
+    }
+
+    /// @notice Fuzz the poke across the expiry boundary [lockExpiry-2 .. +200d]: it decays IFF the
+    ///         lock has reached expiry, lands the position at base, and is idempotent on a second
+    ///         call at every sampled timestamp (review finding: no expiry-boundary fuzz; CLAUDE.md
+    ///         requires fuzz for financial-weight logic).
+    function testFuzz_SettleExpiredLock_expiryBoundary(uint256 tsOffset) public {
+        vault.recordDelegate(LOCKER, OPERATOR, ASSET, STAKE, LOCK_6MO_BPS);
+        (,,, uint256 lockExpiry,) = _debt(LOCKER);
+
+        uint256 ts = bound(tsOffset, lockExpiry - 2, lockExpiry + 200 days);
+        vm.warp(ts);
+
+        bool applied = vault.settleExpiredLock(ASSET, LOCKER, OPERATOR);
+        bool shouldDecay = ts >= lockExpiry; // boosted lock present -> decays at/after expiry
+        assertEq(applied, shouldDecay, "decays iff timestamp reached expiry");
+
+        (uint256 stake, uint256 score,, uint256 expiry,) = _debt(LOCKER);
+        if (shouldDecay) {
+            assertEq(score, stake, "post-expiry: score at base");
+            assertEq(score, STAKE, "post-expiry: base == raw stake");
+            assertEq(expiry, 0, "post-expiry: lock cleared");
+        } else {
+            assertEq(score, (STAKE * LOCK_6MO_BPS) / 10_000, "pre-expiry: boost intact");
+            assertGt(expiry, 0, "pre-expiry: lock still set");
+        }
+
+        assertFalse(vault.settleExpiredLock(ASSET, LOCKER, OPERATOR), "second poke: idempotent no-op at any ts");
     }
 
     /// @notice A pure view (pendingDelegatorRewards) must report decay-aware accrual:


### PR DESCRIPTION
Closes #199.

## What

Adds `settleExpiredLock(address asset, address delegator, address operator)` to `RewardVaults` — a permissionless entry that collapses a position's expired lock-multiplier boost back to base weight. Mirrors the existing `ServiceFeeDistributor.settleExpiredLock` (F5, #185).

## Why

`_decayExpiredLock` only ran on the **locker's own** actions (`_claimDelegatorReward`, `recordDelegate`/`recordStake`/`recordUnstake`). An idle locker who never transacts again keeps a stale `boostedScore` (up to **1.6x** via a 6-month lock) inside `pool.totalStaked`, so `_distributeToOperatorPool` keeps advancing `accumulatedPerShare` against the inflated weight — the idle holder siphons the boosted share of **every future epoch indefinitely**, diluting honest delegators. No third party (keeper, co-delegator, operator, admin) could force the collapse.

Verified against `main` @ `51b392f`:
- All 5 `_decayExpiredLock` call sites are self-actions; no `poke`/`sync`/`forceDecay` existed.
- `_distributeToOperatorPool` (L898) accrues on `pool.totalStaked`, which carries the stale boost.
- **`ServiceFeeDistributor` already has the equivalent poke** (`settleExpiredLock`, added in #185), so only `RewardVaults` was missing it — this brings them to parity.

## Fix

```solidity
function settleExpiredLock(address asset, address delegator, address operator) external nonReentrant {
    DelegatorDebt storage debt = delegatorDebts[asset][delegator][operator];
    OperatorPool storage pool = operatorPools[asset][operator];
    _decayExpiredLock(asset, delegator, operator, pool, debt);
}
```

Reuses the audited `_decayExpiredLock` (harvest-before-resize; a safe no-op while the lock is still active, so it cannot strip a live boost). Purely additive — no signature or storage changes.

## Tests (10/10 pass)

- `test_ExpiredLockCollapsibleByThirdParty_stopsIdleDilution`: a third party with no role collapses an **idle** locker's expired boost (locker never transacts); the next epoch then splits 50/50 between the ex-locker and an unlocked peer — dilution stops.
- `test_SettleExpiredLock_noopWhileLockActive`: a poke against a still-active lock is a no-op (can't strip a live boost).

## Also investigated (the issue's two low notes) — both verified NOT bugs
- **TangleTimelock `_setMinDelay` assembly**: correct. Upgradeable OZ 5.1.0 uses ERC-7201 namespaced storage; its `TimelockControllerStorageLocation` matches the pinned constant and `_minDelay` is at `LOCATION+1`. `test_UpdateDelay_PersistsNewValue` proves the write lands correctly.
- **TangleStorage slot comments**: the real layout is snapshot-pinned (`test_TangleStorage_PinnedSlots` passes). The `(Slot X-Y)` section headers are nominal groupings inconsistent with actual slots — cosmetic only; authoritative guidance already lives in the `__gap` comment.