### PR TITLE
feat(indexer): index binary-version attestations (0.19 reportUri is event-only)

### DIFF
--- a/indexer/config.local.yaml
+++ b/indexer/config.local.yaml
@@ -91,6 +91,8 @@ chains:
         events:
           - event: BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition)
           - event: BinaryVersionRecorded(uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri)
+          - event: BinaryVersionAttested(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, address indexed attester, uint8 kind, uint8 severityFound, string reportUri)
+          - event: BinaryVersionAttestationRevoked(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri)
       - name: MultiAssetDelegation
         address:
           - "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"  # updated from broadcast

--- a/indexer/config.yaml
+++ b/indexer/config.yaml
@@ -82,6 +82,8 @@ chains:
         events:
           - event: BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition)
           - event: BinaryVersionRecorded(uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri)
+          - event: BinaryVersionAttested(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, address indexed attester, uint8 kind, uint8 severityFound, string reportUri)
+          - event: BinaryVersionAttestationRevoked(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri)
       - name: MultiAssetDelegation
         address:
           - "0xfeb417fc6d343e0fc88ec9fdb8294bf84d69f0ca"

--- a/indexer/schema.graphql
+++ b/indexer/schema.graphql
@@ -192,6 +192,34 @@ type BinaryVersion {
   binaryUri: String!
   recordedAt: BigInt!
   txHash: String!
+  attestations: [BinaryVersionAttestation!]! @derivedFrom(field: "binaryVersion")
+}
+
+"""
+Permissionless attestation against a specific binary version (0.19+).
+`reportUri` is event-only on-chain (dropped from the Attestation struct), so
+the indexer is the sole source of it. Rows are append-only; revocation flips
+`revoked` and records the reason/timestamp rather than deleting the row.
+"""
+type BinaryVersionAttestation {
+  "blueprintId-versionId-attestationId"
+  id: ID!
+  "Link to the attested BinaryVersion (id = blueprintId-versionId). Null if the version was never recorded on-chain."
+  binaryVersion: BinaryVersion
+  blueprintId: BigInt!
+  versionId: BigInt!
+  attestationId: BigInt!
+  attester: String!
+  "AttestationKind: AUDIT | FUZZ | FORMAL | BUG_BOUNTY | SELF (UNKNOWN if the on-chain enum adds a value the indexer hasn't mapped)."
+  kind: String!
+  "CVSS-style worst severity discovered, in [0,5]: 0=none 1=info 2=low 3=med 4=high 5=critical."
+  severityFound: Int!
+  reportUri: String!
+  revoked: Boolean!
+  revocationReasonUri: String
+  attestedAt: BigInt!
+  revokedAt: BigInt
+  txHash: String!
 }
 
 type ValidatorPod {

--- a/indexer/src/handlers/blueprintManager.ts
+++ b/indexer/src/handlers/blueprintManager.ts
@@ -1,5 +1,5 @@
 import { indexer } from "envio";
-import type { BinaryVersion, BlueprintDefinition } from "envio";
+import type { BinaryVersion, BinaryVersionAttestation, BlueprintDefinition } from "envio";
 import { decodeBlueprintDefinition } from "../lib/blueprintDefinition";
 import {
   getEventId,
@@ -9,7 +9,17 @@ import {
   normalizeAddress,
   toBigInt,
   toHexString,
+  toNumber,
 } from "../lib/handlerUtils";
+
+// Types.AttestationKind — append-only on-chain enum. Keep in sync with
+// src/libraries/Types.sol; unknown ordinals fall through to UNKNOWN so a new
+// on-chain variant never breaks indexing.
+const ATTESTATION_KINDS = ["AUDIT", "FUZZ", "FORMAL", "BUG_BOUNTY", "SELF"] as const;
+const mapAttestationKind = (value: bigint | number | undefined | null): string => {
+  const numeric = typeof value === "bigint" ? Number(value) : value ?? -1;
+  return ATTESTATION_KINDS[numeric] ?? "UNKNOWN";
+};
 import { pointsContext } from "../points/participation";
 import { awardDeveloperBlueprint } from "../points/awards";
 
@@ -83,4 +93,49 @@ indexer.onEvent({ contract: "MasterBlueprintServiceManager", event: "BinaryVersi
     txHash: getTxHash(event),
   } as BinaryVersion;
   context.BinaryVersion.set(version);
+});
+
+indexer.onEvent({ contract: "MasterBlueprintServiceManager", event: "BinaryVersionAttested" }, async ({ event, context }) => {
+  const blueprintId = toBigInt(event.params.blueprintId);
+  const versionId = toBigInt(event.params.versionId);
+  const attestationId = toBigInt(event.params.attestationId);
+  const attestation: BinaryVersionAttestation = {
+    id: `${blueprintId}-${versionId}-${attestationId}`,
+    // reportUri lives only in this event on 0.19+ (dropped from the on-chain
+    // struct), so the indexer is the sole source of it for the dapp.
+    binaryVersion_id: `${blueprintId}-${versionId}`,
+    blueprintId,
+    versionId,
+    attestationId,
+    attester: normalizeAddress(event.params.attester),
+    kind: mapAttestationKind(event.params.kind),
+    severityFound: toNumber(event.params.severityFound),
+    reportUri: event.params.reportUri,
+    revoked: false,
+    revocationReasonUri: undefined,
+    attestedAt: getTimestamp(event),
+    revokedAt: undefined,
+    txHash: getTxHash(event),
+  } as BinaryVersionAttestation;
+  context.BinaryVersionAttestation.set(attestation);
+});
+
+indexer.onEvent({ contract: "MasterBlueprintServiceManager", event: "BinaryVersionAttestationRevoked" }, async ({ event, context }) => {
+  const blueprintId = toBigInt(event.params.blueprintId);
+  const versionId = toBigInt(event.params.versionId);
+  const attestationId = toBigInt(event.params.attestationId);
+  const id = `${blueprintId}-${versionId}-${attestationId}`;
+  const existing = await context.BinaryVersionAttestation.get(id);
+  if (!existing) {
+    // Revocation without a prior attest row is only possible if the attest
+    // event was missed (reorg/gap); log rather than silently drop the reason.
+    context.log.error(`BinaryVersionAttestationRevoked for unknown attestation ${id} (missing BinaryVersionAttested?)`);
+    return;
+  }
+  context.BinaryVersionAttestation.set({
+    ...existing,
+    revoked: true,
+    revocationReasonUri: event.params.reasonUri,
+    revokedAt: getTimestamp(event),
+  });
 });


### PR DESCRIPTION
0.19 removed `reportUri` from the on-chain `Attestation` struct (event-only), and attestations were never indexed. Adds a `BinaryVersionAttestation` entity materialized from `BinaryVersionAttested` (reportUri/kind/severity) + `BinaryVersionAttestationRevoked`, mirroring the existing `BinaryVersionRecorded` indexing. `kind` stored as a readable enum with UNKNOWN fallback. Subscribed on both config files. **codegen + build green.** Unblocks the dapp's attestation UI on 0.19 (reportUri now from the indexer, not the lossy view). The other view→event fields the dapp needs (binaryUri, slash disputeReason/disputedAt/proposedAt) were already event-sourced by #196/#202 — no change needed there.