### PR TITLE
chore(indexer): Tempo (chain 42431) config for the live 0.19 deploy

### DIFF
--- a/indexer/config.tempo.yaml
+++ b/indexer/config.tempo.yaml
@@ -1,0 +1,206 @@
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+# Tempo Moderato (0.19) configuration. Addresses sourced from
+# deployments/tempo/latest.json. Plain-RPC chain (no HyperSync).
+#
+# Contracts NOT deployed on Tempo (no address in the manifest) are declared with
+# `address: []` so the shared src/EventHandlers.ts handlers still compile via
+# codegen while indexing nothing: MasterBlueprintServiceManager,
+# ValidatorPodManager, LiquidDelegationFactory, LiquidDelegationVault. This
+# matches the base config's own pattern for the beacon/liquid contracts.
+name: tangle-indexer-tempo
+# Tempo emits chain-native transactions of type 0x76 that carry NO `input`
+# field. envio's RPC source treats a requested-but-missing tx field as fatal
+# (`input` is not in its nullable-field set), so requesting `input` here aborts
+# the whole indexer at the first block containing a 0x76 tx. Drop it. The only
+# handler that reads `event.transaction?.input` decodes ServiceRequested
+# metadata, and that event does not fire on this deployment; the optional
+# chaining degrades to `undefined` cleanly if it ever does. `hash`/`from` are
+# present on every Tempo tx (0x76 included), so they stay.
+field_selection:
+  transaction_fields:
+    - hash
+    - from
+chains:
+  - id: 42431
+    start_block: 25563852
+    rpc:
+      - url: https://rpc.moderato.tempo.xyz
+    contracts:
+      - name: Tangle
+        address:
+          - "0xff137b9c879c47c28ce389e84501925438ab4cda"
+        handler: src/EventHandlers.ts
+        events:
+          - event: AggregatedResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint256 signerBitmap, bytes output)
+          - event: BlueprintCreated(uint64 indexed blueprintId, address indexed owner, address manager, string metadataUri, bytes32 metadataHash)
+          - event: BlueprintDeactivated(uint64 indexed blueprintId)
+          - event: BlueprintTransferred(uint64 indexed blueprintId, address indexed from, address indexed to)
+          - event: BlueprintTransferProposed(uint64 indexed blueprintId, address indexed from, address indexed pendingOwner)
+          - event: BlueprintTransferCancelled(uint64 indexed blueprintId, address indexed owner)
+          - event: BlueprintSourcesRecorded(uint64 indexed blueprintId, bytes32 indexed sourcesHash, (uint8 kind, (string registry, string image, string tag) container, (uint8 runtime, uint8 fetcher, string artifactUri, string entrypoint) wasm, (uint8 fetcher, string artifactUri, string entrypoint) native, (string cargoPackage, string cargoBin, string basePath) testing, (uint8 arch, uint8 os, string name, bytes32 sha256)[] binaries)[] sources)
+          - event: BlueprintSourcesAcked(uint64 indexed blueprintId, address indexed operator, bytes32 sourcesHash)
+          - event: BlueprintUpdated(uint64 indexed blueprintId, string metadataUri, bytes32 metadataHash)
+          - event: EscrowFunded(uint64 indexed serviceId, address indexed token, uint256 amount)
+          - event: ExitCanceled(uint64 indexed serviceId, address indexed operator)
+          - event: ExitForced(uint64 indexed serviceId, address indexed operator, address indexed forcer)
+          - event: ExitScheduled(uint64 indexed serviceId, address indexed operator, uint64 executeAfter)
+          - event: Initialized(uint64 version)
+          - event: JobCompleted(uint64 indexed serviceId, uint64 indexed callId)
+          - event: JobResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, address indexed operator, bytes output)
+          - event: JobEventRateSet(uint64 indexed blueprintId, uint8 indexed jobIndex, uint256 rate)
+          - event: JobSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, bytes inputs)
+          - event: JobSubmittedFromQuote(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, address[] quotedOperators, uint256 totalPrice, bytes inputs)
+          - event: OperatorJoinedService(uint64 indexed serviceId, address indexed operator, uint16 exposureBps)
+          - event: OperatorLeftService(uint64 indexed serviceId, address indexed operator)
+          - event: OperatorPreRegistered(uint64 indexed blueprintId, address indexed operator)
+          - event: OperatorPreferencesUpdated(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorRegistered(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorUnregistered(uint64 indexed blueprintId, address indexed operator)
+          - event: Paused(address account)
+          - event: PaymentDistributed(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed token, uint256 grossAmount, address developerRecipient, uint256 developerAmount, uint256 protocolAmount, uint256 operatorPoolAmount, uint256 stakerPoolAmount)
+          - event: KeeperRebateAccrued(uint64 indexed serviceId, address indexed keeper, address indexed token, uint256 amount)
+          - event: TntPaymentDiscountApplied(uint64 indexed serviceId, address indexed recipient, address indexed token, uint256 amount)
+          - event: StakerShareRefundedToEscrow(uint64 indexed serviceId, address indexed operator, address indexed token, uint256 amount, bytes reason)
+          - event: SubscriptionBaselineInitialized(uint64 indexed serviceId, uint256 baselineStake, uint256 operatorCount)
+          - event: SubscriptionBillSkippedNoOperators(uint64 indexed serviceId, uint64 period)
+          - event: SubscriptionBillAdjustedByManager(uint64 indexed serviceId, uint256 preAdjustmentAmount, uint256 adjustedAmount, uint16 adjustmentBps)
+          - event: RewardsClaimSkipped(address indexed account, address indexed token)
+          - event: OperatorRewardAccrued(uint64 indexed serviceId, address indexed operator, address indexed token, uint64 blueprintId, uint256 amount)
+          - event: QuoteUsed(address indexed operator, bytes32 indexed quoteHash)
+          - event: RewardsClaimed(address indexed account, address indexed token, uint256 amount)
+          - event: RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+          - event: RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: ServiceActivated(uint64 indexed serviceId, uint64 indexed requestId, uint64 indexed blueprintId, uint8 confidentiality)
+          - event: ServiceApproved(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRejected(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceTerminated(uint64 indexed serviceId)
+          - event: ServiceTerminatedForNonPayment(uint64 indexed serviceId, address indexed triggeredBy, uint64 dueAt, uint64 graceEndsAt, uint256 requiredAmount, uint256 escrowBalance)
+          - event: ServiceExtended(uint64 indexed serviceId, uint64 oldTtl, uint64 newTtl, uint256 payment)
+          - event: SlashCancelled(uint64 indexed slashId, address indexed canceller, string reason)
+          - event: SlashConfigUpdated(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps, uint64 disputeResolutionDeadline, uint256 disputeBond, uint16 maxPendingSlashesPerOperator)
+          - event: DisputeBondCredited(address indexed disputer, uint256 amount)
+          - event: DisputeBondClaimed(address indexed disputer, uint256 amount)
+          - event: SlashDisputed(uint64 indexed slashId, address indexed disputer, string reason)
+          - event: SlashExecuted(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, uint256 actualSlashed)
+          - event: SlashProposed(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, address proposer, uint16 slashBps, uint16 effectiveSlashBps, bytes32 evidence, uint64 executeAfter)
+          - event: SubscriptionBilled(uint64 indexed serviceId, uint256 amount, uint64 period)
+          - event: Unpaused(address account)
+          - event: Upgraded(address indexed implementation)
+      # Not deployed on Tempo (no `mbsm` in latest.json; BlueprintDefinitionRecorded
+      # fires nowhere on-chain). Declared with an empty address so the shared
+      # handler keeps compiling; indexes nothing.
+      - name: MasterBlueprintServiceManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition)
+          - event: BinaryVersionRecorded(uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri)
+          - event: BinaryVersionAttested(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, address indexed attester, uint8 kind, uint8 severityFound, string reportUri)
+          - event: BinaryVersionAttestationRevoked(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri)
+      - name: MultiAssetDelegation
+        address:
+          - "0x9484d07899b98384f1d66bd5b2659f3ed346f89e"
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRegistered(address indexed operator, uint256 stake)
+          - event: OperatorStakeIncreased(address indexed operator, uint256 amount)
+          - event: OperatorUnstakeScheduled(address indexed operator, uint256 amount, uint64 readyRound)
+          - event: OperatorUnstakeExecuted(address indexed operator, uint256 amount)
+          - event: OperatorLeavingScheduled(address indexed operator, uint64 readyRound)
+          - event: OperatorLeft(address indexed operator)
+          - event: OperatorBlueprintAdded(address indexed operator, uint64 indexed blueprintId)
+          - event: OperatorBlueprintRemoved(address indexed operator, uint64 indexed blueprintId)
+          - event: Deposited(address indexed delegator, address indexed token, uint256 amount, uint8 lock)
+          - event: WithdrawScheduled(address indexed delegator, address indexed token, uint256 amount, uint64 readyRound)
+          - event: Withdrawn(address indexed delegator, address indexed token, uint256 amount)
+          - event: Delegated(address indexed delegator, address indexed operator, address indexed token, uint256 amount, uint256 shares, uint8 selectionMode)
+          - event: DelegatorUnstakeScheduled(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 estimatedAmount, uint64 readyRound)
+          - event: DelegatorUnstakeExecuted(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 amount)
+          - event: BlueprintAddedToDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: BlueprintRemovedFromDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: AssetEnabled(address indexed token, uint256 minOperatorStake, uint256 minDelegation)
+          - event: AssetDisabled(address indexed token)
+          - event: RoundAdvanced(uint64 indexed round)
+          - event: Slashed(address indexed operator, uint64 indexed serviceId, uint64 indexed blueprintId, bytes32 assetHash, uint16 slashBps, uint256 operatorSlashed, uint256 delegatorsSlashed, uint256 exchangeRateAfter)
+          - event: SlashRecorded(address indexed operator, uint64 indexed slashId, bytes32 assetHash, uint16 slashBps, uint256 totalSlashed, uint256 exchangeRateBefore, uint256 exchangeRateAfter)
+          - event: OperatorDelegationModeSet(address indexed operator, uint8 mode)
+          - event: OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved)
+          - event: CommissionChangeQueued(uint16 newBps, uint64 executeAfter)
+          - event: CommissionChangeExecuted(uint16 oldBps, uint16 newBps)
+          - event: CommissionChangeCancelled(uint16 cancelledBps)
+          - event: ExpiredLocksHarvested(address indexed delegator, address indexed token, uint256 count, uint256 totalAmount)
+      - name: OperatorStatusRegistry
+        address:
+          - "0xaedaffd260e21b41cb9926370e32d14bef812b48"
+        handler: src/EventHandlers.ts
+        events:
+          - event: HeartbeatReceived(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed operator, uint8 statusCode, uint256 timestamp)
+          - event: OperatorWentOffline(uint64 indexed serviceId, address indexed operator, uint8 missedBeats)
+          - event: OperatorCameOnline(uint64 indexed serviceId, address indexed operator)
+          - event: StatusChanged(uint64 indexed serviceId, address indexed operator, uint8 oldStatus, uint8 newStatus)
+          - event: HeartbeatConfigUpdated(uint64 indexed serviceId, uint64 interval, uint8 maxMissed)
+          - event: MetricReported(uint64 indexed serviceId, address indexed operator, string metricName, uint256 value)
+          - event: SlashingTriggered(uint64 indexed serviceId, address indexed operator, string reason)
+      # Beacon/liquid contracts are not deployed on Tempo — empty address,
+      # handlers still compile, nothing indexed.
+      - name: ValidatorPodManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: PodCreated(address indexed owner, address indexed pod)
+          - event: Delegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: Undelegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: SharesUpdated(address indexed owner, int256 sharesDelta, uint256 newShares, uint256 totalAssets, uint256 totalSharesPool)
+          - event: BeaconRebase(address indexed owner, int256 assetsDelta, uint256 newTotalAssets, uint256 totalSharesPool)
+          - event: OperatorRegistered(address indexed operator)
+          - event: OperatorDeregistered(address indexed operator)
+          - event: OperatorPoolSlashed(address indexed operator, uint256 slashedAssets, uint256 newTotalAssets, uint256 totalShares)
+          - event: WithdrawalQueued(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+          - event: WithdrawalCompleted(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+      - name: LiquidDelegationFactory
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed vault, address indexed operator, address indexed asset, uint64[] blueprintIds, string name, string symbol)
+      - name: LiquidDelegationVault
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)
+          - event: Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)
+          - event: RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
+          - event: OperatorSet(address indexed controller, address indexed operator, bool approved)
+          - event: Transfer(address indexed from, address indexed to, uint256 value)
+      - name: RewardVaults
+        address:
+          - "0x9a1615fdcaaf2f659d78eb0d72fd3759480af7c4"
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed asset, uint256 depositCap)
+          - event: VaultConfigUpdated(address indexed asset, uint256 depositCap)
+          - event: VaultDeactivated(address indexed asset)
+          - event: StakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount, uint8 lock)
+          - event: UnstakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: RewardsDistributed(address indexed asset, address indexed operator, uint256 poolReward, uint256 commission)
+          - event: DelegatorRewardsClaimed(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: OperatorCommissionClaimed(address indexed asset, address indexed operator, uint256 amount)
+          - event: OperatorCommissionUpdated(uint16 newBps)
+          - event: LockDurationsUpdated(uint256 oneMonth, uint256 twoMonths, uint256 threeMonths, uint256 sixMonths)
+      - name: InflationPool
+        address:
+          - "0x3602b76c625464895205466c645feff0d911836f"
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRewardClaimed(address indexed operator, uint256 amount)
+          - event: CustomerRewardClaimed(address indexed customer, uint256 amount)
+          - event: DeveloperRewardClaimed(address indexed developer, uint256 amount)
+      - name: Credits
+        address:
+          - "0x94e8d532c3205346ee048cf6e37d5e7653c353ae"
+        handler: src/EventHandlers.ts
+        events:
+          - event: CreditsClaimed(address indexed account, uint256 amount, bytes32 offchainAccountId)
+address_format: lowercase


### PR DESCRIPTION
Envio config to index the live tnt-core 0.19 deployment on Tempo Moderato (chain 42431). Proven end-to-end: synced from the deploy block (25563852) to head, decoded real 0.19 events (StakingAsset/RewardVault/RoleGranted/Upgraded). Indexes the 6 deployed contracts; the 4 not on Tempo use `address:[]` to keep codegen/handlers intact. Drops the `input` tx-field because Tempo system tx type 0x76 has no `input` (envio treats a requested-missing field as fatal) — a Tempo-RPC tx-shape note, not an ABI mismatch.