### PR TITLE
fix(bindings): declare the real MSRV (rust-version 1.81 → 1.91)

### DIFF
--- a/bindings/CHANGELOG.md
+++ b/bindings/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV raised to Rust 1.91** (`rust-version`, was `1.81`). The Dependabot
+  security sweep (#198) bumped `alloy` 1.1.2 → 1.8.3 — required to pull the
+  `lru` 0.16 fix (RUSTSEC) via `alloy-provider`, which moves its `lru` pin
+  `^0.13` → `^0.16` — and `alloy` 1.8.3 declares `rustc >= 1.91`. The declared
+  MSRV now matches what the locked dependency graph actually requires; the
+  previous `1.81` no longer built. CI builds on `stable`, which satisfies it.
+
+### Build environment (consequences of the `alloy` 1.8.3 bump — noted, accepted)
+
+- **cmake + a C toolchain are now build-time requirements.** `alloy` 1.8.3
+  pulls `reqwest` 0.13 → `rustls` 0.23.41, whose default crypto provider is
+  `aws-lc-rs` (`aws-lc-sys` compiles a C/C++ crypto library via `cmake`).
+  Minimal build images must install `cmake` and a C compiler.
+- **TLS trust root moved to the OS-native store.** `reqwest` 0.13 replaced the
+  bundled `webpki-roots` Mozilla store with `rustls-platform-verifier`, so RPC
+  over HTTPS now trusts the host OS certificate store (Keychain / `/etc/ssl` /
+  Windows cert store) rather than a pinned root set.
+
 ## [0.18.0] - 2026-07-02
 
 Event-sourced blueprint definitions and operator endpoints: `createBlueprint`

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tnt-core-bindings"
 version = "0.19.0"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.91"
 description = "Rust bindings for TNT Core Solidity contracts (Tangle staking protocol)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tangle-network/tnt-core"

--- a/fixtures/Cargo.toml
+++ b/fixtures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tnt-core-fixtures"
 version = "0.17.1"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.91"
 description = "Local testnet fixture data for TNT Core"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tangle-network/tnt-core"


### PR DESCRIPTION
Follow-up to #198, closing its multi-shot review's sole blocking finding ([review comment](https://github.com/tangle-network/tnt-core/pull/198#issuecomment-4883923685)).

## The bug
#198's security sweep bumped `alloy` 1.1.2 → 1.8.3 — **load-bearing**: the `lru` 0.16 RUSTSEC fix requires `alloy-provider` ≥1.4, which moves its `lru` pin `^0.13` → `^0.16`, which requires `alloy` 1.8.3. And `alloy` 1.8.3 declares `rustc >= 1.91`. But `bindings/Cargo.toml` and `fixtures/Cargo.toml` still declared `rust-version = "1.81"`.

`tnt-core-bindings` is a **published** crate. Advertising `1.81` while the locked graph needs `1.91` means a consumer on Rust 1.81–1.90 hits confusing `rustc X.Y is unsupported` errors from alloy/ruint instead of a clear MSRV error.

I verified the true max MSRV is **1.91** (`cargo metadata` over the locked graph — every `alloy` 1.8.3 sub-crate declares 1.91).

## The fix
- `rust-version` `1.81` → `1.91` in `bindings/Cargo.toml` + `fixtures/Cargo.toml` — the declaration now matches what the graph requires.
- `bindings/CHANGELOG.md` documents the MSRV bump **and** the two build-environment consequences of the required alloy bump, as a conscious record (the reviewer asked these be a deliberate decision, not an accidental `cargo update` side effect):
  - **cmake + a C toolchain** are now build-time requirements (`aws-lc-rs`/`aws-lc-sys` via `reqwest` 0.13 → `rustls` 0.23.41).
  - **TLS trust root** moved from bundled `webpki-roots` to the OS-native store (`rustls-platform-verifier`).

## Why not cap alloy / force `ring`
- **Capping alloy is off the table**: it would reintroduce the `lru` advisory that #198 fixed.
- **Not forcing the `ring` crypto backend** (to drop cmake): alloy 1.8.3 defaults to `aws-lc-rs`; overriding a transitive crypto provider from a downstream crate is fragile (additive Cargo features, controlled by alloy/reqwest), CI already has cmake, and the protocol isn't live. Documenting the requirement is the right call; dropping cmake later is a deliberate alloy-feature change, not a security follow-up.

The other review findings are non-issues on `main`: the JS ones (vitest 3→4, esbuild override) were verified green in #198's own testing, and the remaining LOWs are informational/cosmetic.

## Verification
`cargo +1.91 check -p tnt-core-bindings --locked` → **green** (35s; compiled alloy 1.8.3 + aws-lc-sys 0.42.0 against cmake 3.28.3). Three files changed, no lock change.