### PR TITLE
chore(bindings): republish 0.19.1 with the deployed 0.19 ABI (0.19.0 was stale)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,7 +3808,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/bindings/CHANGELOG.md
+++ b/bindings/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.19.1] - 2026-07-24
+
+Corrective republish of the 0.19 bindings against the **deployed** contract.
+crates.io `0.19.0` was published 2026-07-07, two days before #209 merged, so it
+shipped an intermediate 0.19 ABI that was never deployed. Consumers pinning
+`0.19.0` (including blueprint-sdk) built against contract selectors that do not
+match the live 0.19 deployment; this release corrects that.
+
+### ABI — regenerated against the final 0.19 contract (missing from `0.19.0`)
+
+- **EventDriven per-job billing in the service's settlement asset** (#209): a
+  job settles in a developer-declared per-blueprint asset (native OR ERC20),
+  pinned to the service at activation. New/changed selectors on the
+  settlement-asset payment path (`i_tangle*.rs` regenerated; ~900 lines changed
+  vs `0.19.0`). Required for chains that ban native value transfers (e.g. Tempo).
+
+### Changed (tooling)
 
 - **MSRV raised to Rust 1.91** (`rust-version`, was `1.81`). The Dependabot
   security sweep (#198) bumped `alloy` 1.1.2 → 1.8.3 — required to pull the

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tnt-core-bindings"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 rust-version = "1.91"
 description = "Rust bindings for TNT Core Solidity contracts (Tangle staking protocol)"


### PR DESCRIPTION
The crates.io `tnt-core-bindings 0.19.0` is **stale vs the deployed 0.19 contract** and needs a corrective republish before operators can install from published artifacts instead of git patches.

## Why
- `0.19.0` was published **2026-07-07 22:24**.
- **#209** (EventDriven per-job billing in the service settlement asset) merged **2026-07-09 04:39** and regenerated the ABI (`i_tangle.rs` +879, `i_tangle_full.rs` +921, …).
- So published `0.19.0` ships an **intermediate 0.19 ABI that was never deployed** — its `i_tangle.rs` differs from main by ~900 lines (diffed the extracted crate to confirm).
- Consumers pinning `0.19.0` — **including blueprint-sdk** (`tnt-core-bindings = "0.19"`) — build against selectors that don't match the live 0.19 deployment. The operator worked on Tempo only because it consumed bindings via a git-pin override, which masked the staleness.

## Change
- `bindings/Cargo.toml`: `0.19.0` → `0.19.1` (+ `Cargo.lock`). Carries main's current, deployed-matching ABI, and folds in the MSRV-declaration fix from #211.
- CHANGELOG documents what `0.19.0` was missing (the #209 payments ABI).

## Verification
`cargo publish --dry-run -p tnt-core-bindings --locked` → packages 36 files, compiles clean in isolation on Rust 1.91; upload aborted only by `--dry-run`.

## After merge
Publish `0.19.1` to crates.io, then bump blueprint-sdk's `tnt-core-bindings` dep to `0.19.1` and release it (unblocks the queued blueprint `chore: release` #1470) so operators install the aligned binary.
