### PR TITLE
ci(bindings): fail a PR that changes the ABI without bumping the bindings version

### DIFF
--- a/.github/workflows/bindings-guard.yml
+++ b/.github/workflows/bindings-guard.yml
@@ -1,0 +1,72 @@
+# Bindings publish guard.
+#
+# The failure this exists to prevent (it happened, and it silently broke
+# operators): `bindings/` was regenerated when the contracts changed, but
+# `bindings/Cargo.toml`'s version stayed the same. crates.io already had that
+# version, so the published crate kept an ABI that no longer matched the
+# deployed contract — `tnt-core-bindings 0.19.0` was published 2026-07-07 and
+# #209 changed the ABI on 2026-07-09 under the same version number, leaving the
+# published crate ~900 lines out of date. Consumers (blueprint-sdk, and every
+# operator built from it) linked selectors that do not exist on-chain, and
+# nothing failed loudly — the live operator only worked because it consumed
+# bindings through a git patch that masked the staleness.
+#
+# A published crate version is IMMUTABLE, so any ABI change must ship under a
+# new version. This gate makes that mechanical: touch the generated bindings,
+# bump the version in the same PR.
+name: Bindings Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: bindings-guard-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-bump-required:
+    name: ABI change requires a bindings version bump
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the merge base to diff the PR against its target.
+          fetch-depth: 0
+
+      - name: Require a version bump when generated bindings change
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          changed() { git diff --name-only "$BASE_SHA"...HEAD -- "$@"; }
+
+          abi_changed="$(changed 'bindings/abi/**' 'bindings/src/bindings/**')"
+          if [ -z "$abi_changed" ]; then
+            echo "No generated-bindings changes in this PR — guard not applicable."
+            exit 0
+          fi
+
+          echo "Generated bindings changed in this PR:"
+          echo "$abi_changed" | sed 's/^/  /'
+
+          # The published identity is bindings/Cargo.toml's `version`. Compare the
+          # literal on both sides rather than just "did the file change", so an
+          # unrelated edit (a dependency line, metadata) cannot satisfy the gate.
+          base_version="$(git show "$BASE_SHA:bindings/Cargo.toml" | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+          head_version="$(sed -n 's/^version = "\(.*\)"/\1/p' bindings/Cargo.toml | head -1)"
+          echo "bindings version: base=${base_version:-<none>} head=${head_version:-<none>}"
+
+          if [ -z "$head_version" ]; then
+            echo "::error file=bindings/Cargo.toml::Could not read a version from bindings/Cargo.toml"
+            exit 1
+          fi
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "::error file=bindings/Cargo.toml::This PR changes the generated bindings (ABI/selectors) but leaves tnt-core-bindings at ${head_version}. A published crate version is immutable, so republishing is impossible — consumers would keep the OLD ABI while the contracts moved, exactly the drift that shipped a stale 0.19.0. Bump the version in bindings/Cargo.toml (and note the ABI change in bindings/CHANGELOG.md)."
+            exit 1
+          fi
+
+          echo "OK: bindings version moved ${base_version} -> ${head_version} alongside the ABI change."


### PR DESCRIPTION
Closes the drift class that shipped a stale published crate and silently broke operators.

## What went wrong (this is not hypothetical)
- `tnt-core-bindings 0.19.0` was published to crates.io **2026-07-07**.
- #209 regenerated the ABI **2026-07-09** — under the **same** version number.
- crates.io versions are immutable, so the published `0.19.0` kept an ABI **~900 lines** out of date from the deployed contract.
- `blueprint-sdk` (and every operator built from it) linked selectors that don't exist on-chain. **Nothing failed loudly** — the live Tempo operator only worked because it consumed bindings through a `[patch.crates-io]` git pin that masked the staleness.
- Fixed after the fact by republishing as `0.19.1` (#212). tnt-core CI had **no** check that would have caught it.

## The gate
Pure git, no build, runs in seconds: if a PR touches `bindings/abi/**` or `bindings/src/bindings/**`, then the `version` literal in `bindings/Cargo.toml` must differ from the base commit's. It compares the *literal* on both sides, so an unrelated edit to that file can't satisfy the gate.

## Validated against real history
| PR | ABI changed? | version bumped? | gate |
|---|---|---|---|
| #209 (payments) | yes | **no** | ❌ **fires** — the actual bug |
| #211 (MSRV only) | no | n/a | N/A — correctly silent |

## Scope
One new workflow file. Deliberately does **not** regenerate bindings in CI to diff them: `gen-bindings` runs a full `forge build`, and per `foundry.yml`'s header the cold via-IR compile OOM-kills a stock runner. This guard is the cheap, precise half; a regeneration-diff job needs a larger runner and is a separate follow-up.
