### PR TITLE
feat(deploy): add Arc Testnet (5042002) and Robinhood Chain Sepolia (46630) as deploy targets

### DIFF
--- a/deploy/config/arc-testnet.json
+++ b/deploy/config/arc-testnet.json
@@ -1,0 +1,98 @@
+{
+  "network": "arc-testnet",
+  "_chainId": 5042002,
+  "_note": "Arc Testnet (Circle), chainId 5042002. Verified live: eth_chainId=0x4cef52, reth v1.11.3, Malachite BFT, ~510ms blocks. Explorer https://testnet.arcscan.app, faucet https://faucet.circle.com (20 USDC per address / 2h, no account). UNLIKE Tempo, Arc PERMITS native value transfers, so EventDriven jobs may settle natively; the per-blueprint ERC20 settlement asset from #209 remains available. HAZARD: USDC is the native gas token AND is exposed as an ERC-20 at 0x3600000000000000000000000000000000000000 backed by the SAME balance (18-dec native view, 6-dec ERC-20 view). address(this).balance and USDC.balanceOf(address(this)) are therefore the same money -- do NOT register that ERC-20 as a stake asset here, and never sum the two views. CONSTRAINT: per-tx gas cap 16,777,216 (2^24), ~44% tighter than Tempo's 30M -- simulate FullDeploy without --broadcast and split any tx over ~16.0M before deploying. src/beacon/* is inoperable (EIP-4788 beacon-roots contract omitted); PREVRANDAO is always 0.",
+  "roles": {
+    "admin": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "treasury": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "timelock": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "multisig": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "revokeBootstrap": true
+  },
+  "core": {
+    "deploy": true,
+    "tangle": "0x0000000000000000000000000000000000000000",
+    "staking": "0x0000000000000000000000000000000000000000",
+    "statusRegistry": "0x0000000000000000000000000000000000000000",
+    "minOperatorStake": 1000000000000000000,
+    "minDelegation": 100000000000000000,
+    "operatorCommissionBps": 1000,
+    "maxBlueprintsPerOperator": 0,
+    "managerHookGasLimit": 2000000
+  },
+  "stakeAssets": [
+    {
+      "symbol": "TNT",
+      "token": "0x0000000000000000000000000000000000000001",
+      "adapter": "0x0000000000000000000000000000000000000000",
+      "minOperatorStake": 1000000000000000000,
+      "minDelegation": 100000000000000000,
+      "depositCap": 250000000000000000000000,
+      "rewardMultiplierBps": 10000
+    }
+  ],
+  "incentives": {
+    "deployMetrics": true,
+    "metrics": "0x0000000000000000000000000000000000000000",
+    "deployRewardVaults": true,
+    "rewardVaults": "0x0000000000000000000000000000000000000000",
+    "deployInflationPool": true,
+    "inflationPool": "0x0000000000000000000000000000000000000000",
+    "tntToken": "0x0000000000000000000000000000000000000000",
+    "vaultOperatorCommissionBps": 1500,
+    "epochLength": 604800,
+    "weights": {
+      "stakingBps": 5500,
+      "operatorsBps": 2500,
+      "customersBps": 1000,
+      "developersBps": 1000,
+      "stakersBps": 0
+    },
+    "vaults": [
+      {
+        "asset": "0x0000000000000000000000000000000000000001",
+        "depositCap": 250000000000000000000000,
+        "active": true
+      }
+    ]
+  },
+  "guards": {
+    "pauseStaking": false,
+    "pauseTangle": false,
+    "requireAdapters": false,
+    "delegatorDelay": 0,
+    "operatorDelay": 0,
+    "bondLessDelay": 0,
+    "maxBlueprintsPerOperator": 0
+  },
+  "manifest": {
+    "path": "deployments/arc-testnet/latest.json",
+    "logSummary": true
+  },
+  "migration": {
+    "deploy": true,
+    "emitArtifacts": true,
+    "useMockVerifier": false,
+    "artifactsPath": "deployments/arc-testnet/migration.json",
+    "merklePath": "packages/migration-claim/merkle-tree.json",
+    "evmClaimsPath": "packages/migration-claim/evm-claims.json",
+    "treasuryCarveoutPath": "packages/migration-claim/treasury-carveout.json",
+    "foundationCarveoutPath": "packages/migration-claim/foundation-carveout.json",
+    "migrationOwner": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "sp1VerifierGateway": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+    "programVKey": "0x000d74444f16d75f72527687a36c1bd4c49e6799816dac4989be3bc175e86fd7",
+    "merkleRoot": "0x54ec5497e0a2f43ec721c1ec5392cb224cf710b1210b579dcaefea002bb51adb",
+    "substrateAllocation": "51244581812207794935986305",
+    "evmAllocation": "1125776519168932451653760",
+    "treasuryAmount": "32588831841878446700145909",
+    "foundationAmount": "15040809826744825912214026",
+    "treasuryRecipient": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "foundationRecipient": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "notes": "arc testnet additive deployment"
+  },
+  "credits": {
+    "deploy": true,
+    "owner": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "credits": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/deploy/config/robinhood-testnet.json
+++ b/deploy/config/robinhood-testnet.json
@@ -1,0 +1,98 @@
+{
+  "network": "robinhood-testnet",
+  "_chainId": 46630,
+  "_note": "Robinhood Chain Sepolia (\"Robinhood Chain Testnet\"), chainId 46630. Verified live: eth_chainId=0xb626, Arbitrum Nitro v3.11.3-rc.8 Rollup (not AnyTrust), ArbOS 61, settles to Ethereum Sepolia, ~242ms blocks. RPC https://rpc.testnet.chain.robinhood.com, explorer https://explorer.testnet.chain.robinhood.com (Blockscout v10.2.6). Permits native value transfers. MORE permissive than Tempo: 32M gas/tx and a 98,304-byte contract-size limit (4x EIP-170), so no facet-splitting is required. CAVEAT: Arbitrum charges the L1 data-posting fee as extra gas INSIDE the tx's own gas limit, so a large deploy consumes well above its raw code-deposit gas. FUNDING: the faucet at https://faucet.testnet.chain.robinhood.com is behind a bot challenge; fund via a Sepolia bridge deposit instead. Public RPC is rate-limited and not production-grade -- use a paid provider for the indexer. Treat any 46630 deployment as disposable (reset policy unpublished); chain owner is a single EOA that can change MaxCodeSize.",
+  "roles": {
+    "admin": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "treasury": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "timelock": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "multisig": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "revokeBootstrap": true
+  },
+  "core": {
+    "deploy": true,
+    "tangle": "0x0000000000000000000000000000000000000000",
+    "staking": "0x0000000000000000000000000000000000000000",
+    "statusRegistry": "0x0000000000000000000000000000000000000000",
+    "minOperatorStake": 1000000000000000000,
+    "minDelegation": 100000000000000000,
+    "operatorCommissionBps": 1000,
+    "maxBlueprintsPerOperator": 0,
+    "managerHookGasLimit": 2000000
+  },
+  "stakeAssets": [
+    {
+      "symbol": "TNT",
+      "token": "0x0000000000000000000000000000000000000001",
+      "adapter": "0x0000000000000000000000000000000000000000",
+      "minOperatorStake": 1000000000000000000,
+      "minDelegation": 100000000000000000,
+      "depositCap": 250000000000000000000000,
+      "rewardMultiplierBps": 10000
+    }
+  ],
+  "incentives": {
+    "deployMetrics": true,
+    "metrics": "0x0000000000000000000000000000000000000000",
+    "deployRewardVaults": true,
+    "rewardVaults": "0x0000000000000000000000000000000000000000",
+    "deployInflationPool": true,
+    "inflationPool": "0x0000000000000000000000000000000000000000",
+    "tntToken": "0x0000000000000000000000000000000000000000",
+    "vaultOperatorCommissionBps": 1500,
+    "epochLength": 604800,
+    "weights": {
+      "stakingBps": 5500,
+      "operatorsBps": 2500,
+      "customersBps": 1000,
+      "developersBps": 1000,
+      "stakersBps": 0
+    },
+    "vaults": [
+      {
+        "asset": "0x0000000000000000000000000000000000000001",
+        "depositCap": 250000000000000000000000,
+        "active": true
+      }
+    ]
+  },
+  "guards": {
+    "pauseStaking": false,
+    "pauseTangle": false,
+    "requireAdapters": false,
+    "delegatorDelay": 0,
+    "operatorDelay": 0,
+    "bondLessDelay": 0,
+    "maxBlueprintsPerOperator": 0
+  },
+  "manifest": {
+    "path": "deployments/robinhood-testnet/latest.json",
+    "logSummary": true
+  },
+  "migration": {
+    "deploy": true,
+    "emitArtifacts": true,
+    "useMockVerifier": false,
+    "artifactsPath": "deployments/robinhood-testnet/migration.json",
+    "merklePath": "packages/migration-claim/merkle-tree.json",
+    "evmClaimsPath": "packages/migration-claim/evm-claims.json",
+    "treasuryCarveoutPath": "packages/migration-claim/treasury-carveout.json",
+    "foundationCarveoutPath": "packages/migration-claim/foundation-carveout.json",
+    "migrationOwner": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "sp1VerifierGateway": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+    "programVKey": "0x000d74444f16d75f72527687a36c1bd4c49e6799816dac4989be3bc175e86fd7",
+    "merkleRoot": "0x54ec5497e0a2f43ec721c1ec5392cb224cf710b1210b579dcaefea002bb51adb",
+    "substrateAllocation": "51244581812207794935986305",
+    "evmAllocation": "1125776519168932451653760",
+    "treasuryAmount": "32588831841878446700145909",
+    "foundationAmount": "15040809826744825912214026",
+    "treasuryRecipient": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "foundationRecipient": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "notes": "robinhood chain sepolia additive deployment"
+  },
+  "credits": {
+    "deploy": true,
+    "owner": "0x2420FFf17c4213A4075cf5f7B6dc33429Aaf22Bb",
+    "credits": "0x0000000000000000000000000000000000000000"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -100,6 +100,10 @@ sepolia = "${SEPOLIA_RPC}"
 holesky = "${HOLESKY_RPC}"
 base = "${BASE_RPC}"
 base-sepolia = "${BASE_SEPOLIA_RPC}"
+# Arc Testnet (Circle) — chainId 5042002, USDC-gas, per-tx cap 16,777,216 gas.
+arc_testnet = "${ARC_TESTNET_RPC:-https://rpc.testnet.arc.io}"
+# Robinhood Chain Sepolia — chainId 46630, Arbitrum Nitro Rollup (ArbOS 61).
+robinhood_testnet = "${ROBINHOOD_TESTNET_RPC:-https://rpc.testnet.chain.robinhood.com}"
 tangle_local = "${TANGLE_LOCAL_RPC}"
 tangle_testnet = "${TANGLE_TESTNET_RPC}"
 tangle_mainnet = "${TANGLE_MAINNET_RPC}"
@@ -113,6 +117,9 @@ base = { key = "${BASE_KEY}" }
 base-sepolia = { key = "${BASE_SEPOLIA_KEY}" }
 tangle_testnet = { key = "${TANGLE_TESTNET_KEY}", url = "https://testnet-explorer.tangle.tools" }
 tangle_mainnet = { key = "${TANGLE_MAINNET_KEY}", url = "https://explorer.tangle.tools" }
+# Both are Blockscout, which accepts an empty API key.
+arc_testnet = { key = "", chain = 5042002, url = "https://testnet.arcscan.app/api/" }
+robinhood_testnet = { key = "", chain = 46630, url = "https://explorer.testnet.chain.robinhood.com/api" }
 
 [dependencies]
 forge-std = "1.9.4"

--- a/indexer/config.arc-testnet.yaml
+++ b/indexer/config.arc-testnet.yaml
@@ -1,0 +1,197 @@
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+# Arc Testnet (Circle, chainId 5042002) configuration.
+# reth execution + Malachite BFT, ~510ms blocks. Plain-RPC (no HyperSync endpoint for 5042002).
+#
+# No `field_selection` workaround (that one is Tempo-specific: its 0x76 txs carry no `input` field).
+# Arc runs stock reth, so the default field set applies.
+#
+# Every `address` is [] and start_block is 0 because NOTHING IS DEPLOYED on this chain yet.
+# Fill both from the FullDeploy manifest before running the indexer.
+# start_block MUST be set to the FullDeploy block from deployments/arc-testnet/latest.json before use.
+name: tangle-indexer-arc-testnet
+# Tempo emits chain-native transactions of type 0x76 that carry NO `input`
+# field. envio's RPC source treats a requested-but-missing tx field as fatal
+# (`input` is not in its nullable-field set), so requesting `input` here aborts
+# the whole indexer at the first block containing a 0x76 tx. Drop it. The only
+# handler that reads `event.transaction?.input` decodes ServiceRequested
+# metadata, and that event does not fire on this deployment; the optional
+# chaining degrades to `undefined` cleanly if it ever does. `hash`/`from` are
+# present on every Tempo tx (0x76 included), so they stay.
+chains:
+  - id: 5042002
+    start_block: 0
+    rpc:
+      - url: https://rpc.testnet.arc.io
+    contracts:
+      - name: Tangle
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: AggregatedResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint256 signerBitmap, bytes output)
+          - event: BlueprintCreated(uint64 indexed blueprintId, address indexed owner, address manager, string metadataUri, bytes32 metadataHash)
+          - event: BlueprintDeactivated(uint64 indexed blueprintId)
+          - event: BlueprintTransferred(uint64 indexed blueprintId, address indexed from, address indexed to)
+          - event: BlueprintTransferProposed(uint64 indexed blueprintId, address indexed from, address indexed pendingOwner)
+          - event: BlueprintTransferCancelled(uint64 indexed blueprintId, address indexed owner)
+          - event: BlueprintSourcesRecorded(uint64 indexed blueprintId, bytes32 indexed sourcesHash, (uint8 kind, (string registry, string image, string tag) container, (uint8 runtime, uint8 fetcher, string artifactUri, string entrypoint) wasm, (uint8 fetcher, string artifactUri, string entrypoint) native, (string cargoPackage, string cargoBin, string basePath) testing, (uint8 arch, uint8 os, string name, bytes32 sha256)[] binaries)[] sources)
+          - event: BlueprintSourcesAcked(uint64 indexed blueprintId, address indexed operator, bytes32 sourcesHash)
+          - event: BlueprintUpdated(uint64 indexed blueprintId, string metadataUri, bytes32 metadataHash)
+          - event: EscrowFunded(uint64 indexed serviceId, address indexed token, uint256 amount)
+          - event: ExitCanceled(uint64 indexed serviceId, address indexed operator)
+          - event: ExitForced(uint64 indexed serviceId, address indexed operator, address indexed forcer)
+          - event: ExitScheduled(uint64 indexed serviceId, address indexed operator, uint64 executeAfter)
+          - event: Initialized(uint64 version)
+          - event: JobCompleted(uint64 indexed serviceId, uint64 indexed callId)
+          - event: JobResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, address indexed operator, bytes output)
+          - event: JobEventRateSet(uint64 indexed blueprintId, uint8 indexed jobIndex, uint256 rate)
+          - event: JobSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, bytes inputs)
+          - event: JobSubmittedFromQuote(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, address[] quotedOperators, uint256 totalPrice, bytes inputs)
+          - event: OperatorJoinedService(uint64 indexed serviceId, address indexed operator, uint16 exposureBps)
+          - event: OperatorLeftService(uint64 indexed serviceId, address indexed operator)
+          - event: OperatorPreRegistered(uint64 indexed blueprintId, address indexed operator)
+          - event: OperatorPreferencesUpdated(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorRegistered(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorUnregistered(uint64 indexed blueprintId, address indexed operator)
+          - event: Paused(address account)
+          - event: PaymentDistributed(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed token, uint256 grossAmount, address developerRecipient, uint256 developerAmount, uint256 protocolAmount, uint256 operatorPoolAmount, uint256 stakerPoolAmount)
+          - event: KeeperRebateAccrued(uint64 indexed serviceId, address indexed keeper, address indexed token, uint256 amount)
+          - event: TntPaymentDiscountApplied(uint64 indexed serviceId, address indexed recipient, address indexed token, uint256 amount)
+          - event: StakerShareRefundedToEscrow(uint64 indexed serviceId, address indexed operator, address indexed token, uint256 amount, bytes reason)
+          - event: SubscriptionBaselineInitialized(uint64 indexed serviceId, uint256 baselineStake, uint256 operatorCount)
+          - event: SubscriptionBillSkippedNoOperators(uint64 indexed serviceId, uint64 period)
+          - event: SubscriptionBillAdjustedByManager(uint64 indexed serviceId, uint256 preAdjustmentAmount, uint256 adjustedAmount, uint16 adjustmentBps)
+          - event: RewardsClaimSkipped(address indexed account, address indexed token)
+          - event: OperatorRewardAccrued(uint64 indexed serviceId, address indexed operator, address indexed token, uint64 blueprintId, uint256 amount)
+          - event: QuoteUsed(address indexed operator, bytes32 indexed quoteHash)
+          - event: RewardsClaimed(address indexed account, address indexed token, uint256 amount)
+          - event: RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+          - event: RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: ServiceActivated(uint64 indexed serviceId, uint64 indexed requestId, uint64 indexed blueprintId, uint8 confidentiality)
+          - event: ServiceApproved(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRejected(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceTerminated(uint64 indexed serviceId)
+          - event: ServiceTerminatedForNonPayment(uint64 indexed serviceId, address indexed triggeredBy, uint64 dueAt, uint64 graceEndsAt, uint256 requiredAmount, uint256 escrowBalance)
+          - event: ServiceExtended(uint64 indexed serviceId, uint64 oldTtl, uint64 newTtl, uint256 payment)
+          - event: SlashCancelled(uint64 indexed slashId, address indexed canceller, string reason)
+          - event: SlashConfigUpdated(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps, uint64 disputeResolutionDeadline, uint256 disputeBond, uint16 maxPendingSlashesPerOperator)
+          - event: DisputeBondCredited(address indexed disputer, uint256 amount)
+          - event: DisputeBondClaimed(address indexed disputer, uint256 amount)
+          - event: SlashDisputed(uint64 indexed slashId, address indexed disputer, string reason)
+          - event: SlashExecuted(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, uint256 actualSlashed)
+          - event: SlashProposed(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, address proposer, uint16 slashBps, uint16 effectiveSlashBps, bytes32 evidence, uint64 executeAfter)
+          - event: SubscriptionBilled(uint64 indexed serviceId, uint256 amount, uint64 period)
+          - event: Unpaused(address account)
+          - event: Upgraded(address indexed implementation)
+      # Not deployed on Tempo (no `mbsm` in latest.json; BlueprintDefinitionRecorded
+      # fires nowhere on-chain). Declared with an empty address so the shared
+      # handler keeps compiling; indexes nothing.
+      - name: MasterBlueprintServiceManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition)
+          - event: BinaryVersionRecorded(uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri)
+          - event: BinaryVersionAttested(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, address indexed attester, uint8 kind, uint8 severityFound, string reportUri)
+          - event: BinaryVersionAttestationRevoked(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri)
+      - name: MultiAssetDelegation
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRegistered(address indexed operator, uint256 stake)
+          - event: OperatorStakeIncreased(address indexed operator, uint256 amount)
+          - event: OperatorUnstakeScheduled(address indexed operator, uint256 amount, uint64 readyRound)
+          - event: OperatorUnstakeExecuted(address indexed operator, uint256 amount)
+          - event: OperatorLeavingScheduled(address indexed operator, uint64 readyRound)
+          - event: OperatorLeft(address indexed operator)
+          - event: OperatorBlueprintAdded(address indexed operator, uint64 indexed blueprintId)
+          - event: OperatorBlueprintRemoved(address indexed operator, uint64 indexed blueprintId)
+          - event: Deposited(address indexed delegator, address indexed token, uint256 amount, uint8 lock)
+          - event: WithdrawScheduled(address indexed delegator, address indexed token, uint256 amount, uint64 readyRound)
+          - event: Withdrawn(address indexed delegator, address indexed token, uint256 amount)
+          - event: Delegated(address indexed delegator, address indexed operator, address indexed token, uint256 amount, uint256 shares, uint8 selectionMode)
+          - event: DelegatorUnstakeScheduled(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 estimatedAmount, uint64 readyRound)
+          - event: DelegatorUnstakeExecuted(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 amount)
+          - event: BlueprintAddedToDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: BlueprintRemovedFromDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: AssetEnabled(address indexed token, uint256 minOperatorStake, uint256 minDelegation)
+          - event: AssetDisabled(address indexed token)
+          - event: RoundAdvanced(uint64 indexed round)
+          - event: Slashed(address indexed operator, uint64 indexed serviceId, uint64 indexed blueprintId, bytes32 assetHash, uint16 slashBps, uint256 operatorSlashed, uint256 delegatorsSlashed, uint256 exchangeRateAfter)
+          - event: SlashRecorded(address indexed operator, uint64 indexed slashId, bytes32 assetHash, uint16 slashBps, uint256 totalSlashed, uint256 exchangeRateBefore, uint256 exchangeRateAfter)
+          - event: OperatorDelegationModeSet(address indexed operator, uint8 mode)
+          - event: OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved)
+          - event: CommissionChangeQueued(uint16 newBps, uint64 executeAfter)
+          - event: CommissionChangeExecuted(uint16 oldBps, uint16 newBps)
+          - event: CommissionChangeCancelled(uint16 cancelledBps)
+          - event: ExpiredLocksHarvested(address indexed delegator, address indexed token, uint256 count, uint256 totalAmount)
+      - name: OperatorStatusRegistry
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: HeartbeatReceived(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed operator, uint8 statusCode, uint256 timestamp)
+          - event: OperatorWentOffline(uint64 indexed serviceId, address indexed operator, uint8 missedBeats)
+          - event: OperatorCameOnline(uint64 indexed serviceId, address indexed operator)
+          - event: StatusChanged(uint64 indexed serviceId, address indexed operator, uint8 oldStatus, uint8 newStatus)
+          - event: HeartbeatConfigUpdated(uint64 indexed serviceId, uint64 interval, uint8 maxMissed)
+          - event: MetricReported(uint64 indexed serviceId, address indexed operator, string metricName, uint256 value)
+          - event: SlashingTriggered(uint64 indexed serviceId, address indexed operator, string reason)
+      # Beacon/liquid contracts are not deployed on Tempo — empty address,
+      # handlers still compile, nothing indexed.
+      - name: ValidatorPodManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: PodCreated(address indexed owner, address indexed pod)
+          - event: Delegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: Undelegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: SharesUpdated(address indexed owner, int256 sharesDelta, uint256 newShares, uint256 totalAssets, uint256 totalSharesPool)
+          - event: BeaconRebase(address indexed owner, int256 assetsDelta, uint256 newTotalAssets, uint256 totalSharesPool)
+          - event: OperatorRegistered(address indexed operator)
+          - event: OperatorDeregistered(address indexed operator)
+          - event: OperatorPoolSlashed(address indexed operator, uint256 slashedAssets, uint256 newTotalAssets, uint256 totalShares)
+          - event: WithdrawalQueued(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+          - event: WithdrawalCompleted(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+      - name: LiquidDelegationFactory
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed vault, address indexed operator, address indexed asset, uint64[] blueprintIds, string name, string symbol)
+      - name: LiquidDelegationVault
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)
+          - event: Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)
+          - event: RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
+          - event: OperatorSet(address indexed controller, address indexed operator, bool approved)
+          - event: Transfer(address indexed from, address indexed to, uint256 value)
+      - name: RewardVaults
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed asset, uint256 depositCap)
+          - event: VaultConfigUpdated(address indexed asset, uint256 depositCap)
+          - event: VaultDeactivated(address indexed asset)
+          - event: StakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount, uint8 lock)
+          - event: UnstakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: RewardsDistributed(address indexed asset, address indexed operator, uint256 poolReward, uint256 commission)
+          - event: DelegatorRewardsClaimed(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: OperatorCommissionClaimed(address indexed asset, address indexed operator, uint256 amount)
+          - event: OperatorCommissionUpdated(uint16 newBps)
+          - event: LockDurationsUpdated(uint256 oneMonth, uint256 twoMonths, uint256 threeMonths, uint256 sixMonths)
+      - name: InflationPool
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRewardClaimed(address indexed operator, uint256 amount)
+          - event: CustomerRewardClaimed(address indexed customer, uint256 amount)
+          - event: DeveloperRewardClaimed(address indexed developer, uint256 amount)
+      - name: Credits
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: CreditsClaimed(address indexed account, uint256 amount, bytes32 offchainAccountId)
+address_format: lowercase

--- a/indexer/config.robinhood-testnet.yaml
+++ b/indexer/config.robinhood-testnet.yaml
@@ -1,0 +1,199 @@
+# yaml-language-server: $schema=./node_modules/envio/evm.schema.json
+# Robinhood Chain Sepolia (chainId 46630) configuration.
+# Arbitrum Nitro Rollup (ArbOS 61) settling to Ethereum Sepolia. Plain-RPC (no HyperSync endpoint for 46630).
+#
+# Unlike the Tempo config there is NO `field_selection` workaround here: Tempo needed it because its
+# chain-native 0x76 transactions carry no `input` field, which envio treats as fatal. Nitro emits standard
+# EVM transactions, so the default field set is correct.
+#
+# Every `address` is [] and start_block is 0 because NOTHING IS DEPLOYED on this chain yet.
+# Fill both from the FullDeploy manifest before running the indexer.
+# start_block MUST be set to the FullDeploy block from deployments/robinhood-testnet/latest.json before use.
+# The public RPC is rate-limited and explicitly not production-grade -- point this at a paid provider.
+name: tangle-indexer-robinhood-testnet
+# Tempo emits chain-native transactions of type 0x76 that carry NO `input`
+# field. envio's RPC source treats a requested-but-missing tx field as fatal
+# (`input` is not in its nullable-field set), so requesting `input` here aborts
+# the whole indexer at the first block containing a 0x76 tx. Drop it. The only
+# handler that reads `event.transaction?.input` decodes ServiceRequested
+# metadata, and that event does not fire on this deployment; the optional
+# chaining degrades to `undefined` cleanly if it ever does. `hash`/`from` are
+# present on every Tempo tx (0x76 included), so they stay.
+chains:
+  - id: 46630
+    start_block: 0
+    rpc:
+      - url: https://rpc.testnet.chain.robinhood.com
+    contracts:
+      - name: Tangle
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: AggregatedResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint256 signerBitmap, bytes output)
+          - event: BlueprintCreated(uint64 indexed blueprintId, address indexed owner, address manager, string metadataUri, bytes32 metadataHash)
+          - event: BlueprintDeactivated(uint64 indexed blueprintId)
+          - event: BlueprintTransferred(uint64 indexed blueprintId, address indexed from, address indexed to)
+          - event: BlueprintTransferProposed(uint64 indexed blueprintId, address indexed from, address indexed pendingOwner)
+          - event: BlueprintTransferCancelled(uint64 indexed blueprintId, address indexed owner)
+          - event: BlueprintSourcesRecorded(uint64 indexed blueprintId, bytes32 indexed sourcesHash, (uint8 kind, (string registry, string image, string tag) container, (uint8 runtime, uint8 fetcher, string artifactUri, string entrypoint) wasm, (uint8 fetcher, string artifactUri, string entrypoint) native, (string cargoPackage, string cargoBin, string basePath) testing, (uint8 arch, uint8 os, string name, bytes32 sha256)[] binaries)[] sources)
+          - event: BlueprintSourcesAcked(uint64 indexed blueprintId, address indexed operator, bytes32 sourcesHash)
+          - event: BlueprintUpdated(uint64 indexed blueprintId, string metadataUri, bytes32 metadataHash)
+          - event: EscrowFunded(uint64 indexed serviceId, address indexed token, uint256 amount)
+          - event: ExitCanceled(uint64 indexed serviceId, address indexed operator)
+          - event: ExitForced(uint64 indexed serviceId, address indexed operator, address indexed forcer)
+          - event: ExitScheduled(uint64 indexed serviceId, address indexed operator, uint64 executeAfter)
+          - event: Initialized(uint64 version)
+          - event: JobCompleted(uint64 indexed serviceId, uint64 indexed callId)
+          - event: JobResultSubmitted(uint64 indexed serviceId, uint64 indexed callId, address indexed operator, bytes output)
+          - event: JobEventRateSet(uint64 indexed blueprintId, uint8 indexed jobIndex, uint256 rate)
+          - event: JobSubmitted(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, bytes inputs)
+          - event: JobSubmittedFromQuote(uint64 indexed serviceId, uint64 indexed callId, uint8 jobIndex, address caller, address[] quotedOperators, uint256 totalPrice, bytes inputs)
+          - event: OperatorJoinedService(uint64 indexed serviceId, address indexed operator, uint16 exposureBps)
+          - event: OperatorLeftService(uint64 indexed serviceId, address indexed operator)
+          - event: OperatorPreRegistered(uint64 indexed blueprintId, address indexed operator)
+          - event: OperatorPreferencesUpdated(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorRegistered(uint64 indexed blueprintId, address indexed operator, bytes ecdsaPublicKey, string rpcAddress)
+          - event: OperatorUnregistered(uint64 indexed blueprintId, address indexed operator)
+          - event: Paused(address account)
+          - event: PaymentDistributed(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed token, uint256 grossAmount, address developerRecipient, uint256 developerAmount, uint256 protocolAmount, uint256 operatorPoolAmount, uint256 stakerPoolAmount)
+          - event: KeeperRebateAccrued(uint64 indexed serviceId, address indexed keeper, address indexed token, uint256 amount)
+          - event: TntPaymentDiscountApplied(uint64 indexed serviceId, address indexed recipient, address indexed token, uint256 amount)
+          - event: StakerShareRefundedToEscrow(uint64 indexed serviceId, address indexed operator, address indexed token, uint256 amount, bytes reason)
+          - event: SubscriptionBaselineInitialized(uint64 indexed serviceId, uint256 baselineStake, uint256 operatorCount)
+          - event: SubscriptionBillSkippedNoOperators(uint64 indexed serviceId, uint64 period)
+          - event: SubscriptionBillAdjustedByManager(uint64 indexed serviceId, uint256 preAdjustmentAmount, uint256 adjustedAmount, uint16 adjustmentBps)
+          - event: RewardsClaimSkipped(address indexed account, address indexed token)
+          - event: OperatorRewardAccrued(uint64 indexed serviceId, address indexed operator, address indexed token, uint64 blueprintId, uint256 amount)
+          - event: QuoteUsed(address indexed operator, bytes32 indexed quoteHash)
+          - event: RewardsClaimed(address indexed account, address indexed token, uint256 amount)
+          - event: RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+          - event: RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+          - event: ServiceActivated(uint64 indexed serviceId, uint64 indexed requestId, uint64 indexed blueprintId, uint8 confidentiality)
+          - event: ServiceApproved(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRejected(uint64 indexed requestId, address indexed operator)
+          - event: ServiceRequested(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceRequestedWithSecurity(uint64 indexed requestId, uint64 indexed blueprintId, address indexed requester, uint8 confidentiality)
+          - event: ServiceTerminated(uint64 indexed serviceId)
+          - event: ServiceTerminatedForNonPayment(uint64 indexed serviceId, address indexed triggeredBy, uint64 dueAt, uint64 graceEndsAt, uint256 requiredAmount, uint256 escrowBalance)
+          - event: ServiceExtended(uint64 indexed serviceId, uint64 oldTtl, uint64 newTtl, uint256 payment)
+          - event: SlashCancelled(uint64 indexed slashId, address indexed canceller, string reason)
+          - event: SlashConfigUpdated(uint64 disputeWindow, bool instantSlashEnabled, uint16 maxSlashBps, uint64 disputeResolutionDeadline, uint256 disputeBond, uint16 maxPendingSlashesPerOperator)
+          - event: DisputeBondCredited(address indexed disputer, uint256 amount)
+          - event: DisputeBondClaimed(address indexed disputer, uint256 amount)
+          - event: SlashDisputed(uint64 indexed slashId, address indexed disputer, string reason)
+          - event: SlashExecuted(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, uint256 actualSlashed)
+          - event: SlashProposed(uint64 indexed slashId, uint64 indexed serviceId, address indexed operator, address proposer, uint16 slashBps, uint16 effectiveSlashBps, bytes32 evidence, uint64 executeAfter)
+          - event: SubscriptionBilled(uint64 indexed serviceId, uint256 amount, uint64 period)
+          - event: Unpaused(address account)
+          - event: Upgraded(address indexed implementation)
+      # Not deployed on Tempo (no `mbsm` in latest.json; BlueprintDefinitionRecorded
+      # fires nowhere on-chain). Declared with an empty address so the shared
+      # handler keeps compiling; indexes nothing.
+      - name: MasterBlueprintServiceManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: BlueprintDefinitionRecorded(uint64 indexed blueprintId, address indexed owner, bytes encodedDefinition)
+          - event: BinaryVersionRecorded(uint64 indexed blueprintId, uint64 indexed versionId, bytes32 sha256Hash, string binaryUri)
+          - event: BinaryVersionAttested(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, address indexed attester, uint8 kind, uint8 severityFound, string reportUri)
+          - event: BinaryVersionAttestationRevoked(uint64 indexed blueprintId, uint64 indexed versionId, uint64 attestationId, string reasonUri)
+      - name: MultiAssetDelegation
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRegistered(address indexed operator, uint256 stake)
+          - event: OperatorStakeIncreased(address indexed operator, uint256 amount)
+          - event: OperatorUnstakeScheduled(address indexed operator, uint256 amount, uint64 readyRound)
+          - event: OperatorUnstakeExecuted(address indexed operator, uint256 amount)
+          - event: OperatorLeavingScheduled(address indexed operator, uint64 readyRound)
+          - event: OperatorLeft(address indexed operator)
+          - event: OperatorBlueprintAdded(address indexed operator, uint64 indexed blueprintId)
+          - event: OperatorBlueprintRemoved(address indexed operator, uint64 indexed blueprintId)
+          - event: Deposited(address indexed delegator, address indexed token, uint256 amount, uint8 lock)
+          - event: WithdrawScheduled(address indexed delegator, address indexed token, uint256 amount, uint64 readyRound)
+          - event: Withdrawn(address indexed delegator, address indexed token, uint256 amount)
+          - event: Delegated(address indexed delegator, address indexed operator, address indexed token, uint256 amount, uint256 shares, uint8 selectionMode)
+          - event: DelegatorUnstakeScheduled(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 estimatedAmount, uint64 readyRound)
+          - event: DelegatorUnstakeExecuted(address indexed delegator, address indexed operator, address indexed token, uint256 shares, uint256 amount)
+          - event: BlueprintAddedToDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: BlueprintRemovedFromDelegation(address indexed delegator, uint256 indexed delegationIndex, uint64 blueprintId)
+          - event: AssetEnabled(address indexed token, uint256 minOperatorStake, uint256 minDelegation)
+          - event: AssetDisabled(address indexed token)
+          - event: RoundAdvanced(uint64 indexed round)
+          - event: Slashed(address indexed operator, uint64 indexed serviceId, uint64 indexed blueprintId, bytes32 assetHash, uint16 slashBps, uint256 operatorSlashed, uint256 delegatorsSlashed, uint256 exchangeRateAfter)
+          - event: SlashRecorded(address indexed operator, uint64 indexed slashId, bytes32 assetHash, uint16 slashBps, uint256 totalSlashed, uint256 exchangeRateBefore, uint256 exchangeRateAfter)
+          - event: OperatorDelegationModeSet(address indexed operator, uint8 mode)
+          - event: OperatorWhitelistUpdated(address indexed operator, address indexed delegator, bool approved)
+          - event: CommissionChangeQueued(uint16 newBps, uint64 executeAfter)
+          - event: CommissionChangeExecuted(uint16 oldBps, uint16 newBps)
+          - event: CommissionChangeCancelled(uint16 cancelledBps)
+          - event: ExpiredLocksHarvested(address indexed delegator, address indexed token, uint256 count, uint256 totalAmount)
+      - name: OperatorStatusRegistry
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: HeartbeatReceived(uint64 indexed serviceId, uint64 indexed blueprintId, address indexed operator, uint8 statusCode, uint256 timestamp)
+          - event: OperatorWentOffline(uint64 indexed serviceId, address indexed operator, uint8 missedBeats)
+          - event: OperatorCameOnline(uint64 indexed serviceId, address indexed operator)
+          - event: StatusChanged(uint64 indexed serviceId, address indexed operator, uint8 oldStatus, uint8 newStatus)
+          - event: HeartbeatConfigUpdated(uint64 indexed serviceId, uint64 interval, uint8 maxMissed)
+          - event: MetricReported(uint64 indexed serviceId, address indexed operator, string metricName, uint256 value)
+          - event: SlashingTriggered(uint64 indexed serviceId, address indexed operator, string reason)
+      # Beacon/liquid contracts are not deployed on Tempo — empty address,
+      # handlers still compile, nothing indexed.
+      - name: ValidatorPodManager
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: PodCreated(address indexed owner, address indexed pod)
+          - event: Delegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: Undelegated(address indexed delegator, address indexed operator, uint256 amount)
+          - event: SharesUpdated(address indexed owner, int256 sharesDelta, uint256 newShares, uint256 totalAssets, uint256 totalSharesPool)
+          - event: BeaconRebase(address indexed owner, int256 assetsDelta, uint256 newTotalAssets, uint256 totalSharesPool)
+          - event: OperatorRegistered(address indexed operator)
+          - event: OperatorDeregistered(address indexed operator)
+          - event: OperatorPoolSlashed(address indexed operator, uint256 slashedAssets, uint256 newTotalAssets, uint256 totalShares)
+          - event: WithdrawalQueued(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+          - event: WithdrawalCompleted(bytes32 indexed withdrawalRoot, address indexed staker, uint256 shares, uint256 assets)
+      - name: LiquidDelegationFactory
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed vault, address indexed operator, address indexed asset, uint64[] blueprintIds, string name, string symbol)
+      - name: LiquidDelegationVault
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)
+          - event: Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)
+          - event: RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
+          - event: OperatorSet(address indexed controller, address indexed operator, bool approved)
+          - event: Transfer(address indexed from, address indexed to, uint256 value)
+      - name: RewardVaults
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: VaultCreated(address indexed asset, uint256 depositCap)
+          - event: VaultConfigUpdated(address indexed asset, uint256 depositCap)
+          - event: VaultDeactivated(address indexed asset)
+          - event: StakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount, uint8 lock)
+          - event: UnstakeRecorded(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: RewardsDistributed(address indexed asset, address indexed operator, uint256 poolReward, uint256 commission)
+          - event: DelegatorRewardsClaimed(address indexed asset, address indexed delegator, address indexed operator, uint256 amount)
+          - event: OperatorCommissionClaimed(address indexed asset, address indexed operator, uint256 amount)
+          - event: OperatorCommissionUpdated(uint16 newBps)
+          - event: LockDurationsUpdated(uint256 oneMonth, uint256 twoMonths, uint256 threeMonths, uint256 sixMonths)
+      - name: InflationPool
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: OperatorRewardClaimed(address indexed operator, uint256 amount)
+          - event: CustomerRewardClaimed(address indexed customer, uint256 amount)
+          - event: DeveloperRewardClaimed(address indexed developer, uint256 amount)
+      - name: Credits
+        address: []
+        handler: src/EventHandlers.ts
+        events:
+          - event: CreditsClaimed(address indexed account, uint256 amount, bytes32 offchainAccountId)
+address_format: lowercase


### PR DESCRIPTION
Adds **Arc Testnet** and **Robinhood Chain Sepolia** as tnt-core deploy targets. No contracts are deployed by this PR — it adds the configuration plus the chain-specific constraints so a deploy can be executed and verified.

Every coordinate below was verified against the **live RPC**, not documentation.

## Arc Testnet (Circle)
| | |
|---|---|
| chainId | **5042002** (`0x4cef52`) — confirmed via `eth_chainId` |
| RPC | `https://rpc.testnet.arc.io` |
| Explorer | `https://testnet.arcscan.app` (Blockscout) |
| Faucet | `https://faucet.circle.com` — 20 USDC per address / 2h, no account |
| Stack | reth v1.11.3 + Malachite BFT, ~510 ms blocks |

**Native value: ALLOWED.** Unlike Tempo, an in-EVM `CALL{value: 1 wei}` succeeds — so EventDriven jobs can settle natively here; the per-blueprint ERC20 settlement asset from #209 remains available but is not required.

**Hazard (encoded in the config `_note`):** USDC is *both* the native gas token *and* an ERC-20 at `0x3600000000000000000000000000000000000000`, backed by the **same balance** — an 18-decimal native view and a 6-decimal ERC-20 view of one asset. So `address(this).balance` and `USDC.balanceOf(address(this))` are the same money. That ERC-20 must **not** be registered as a stake asset, and the two views must never be summed. Also: 6-decimal truncation can make the ERC-20 view read 0 while native dust is held, and USDC's blocklist reverts transfers to/from blocked addresses, which could brick a batched payout or slash loop.

**Constraint:** per-tx gas cap **16,777,216** (2^24) — 44% tighter than Tempo's 30M. Simulate `FullDeploy` without `--broadcast` and split any tx over ~16.0M before deploying. `src/beacon/*` is inoperable (EIP-4788 beacon-roots contract omitted) and `PREVRANDAO` is always 0.

## Robinhood Chain Sepolia
| | |
|---|---|
| chainId | **46630** (`0xb626`) — confirmed via `eth_chainId` and the `CHAINID` opcode |
| RPC | `https://rpc.testnet.chain.robinhood.com` |
| Explorer | `https://explorer.testnet.chain.robinhood.com` (Blockscout v10.2.6) |
| Stack | Arbitrum Nitro v3.11.3 **Rollup** (not AnyTrust), ArbOS 61, settles to Ethereum Sepolia, ~242 ms blocks |

**Native value: ALLOWED.** **More permissive than Tempo**: 32M gas/tx and a **98,304-byte** contract-size limit (4× EIP-170), so none of the facet-splitting Tempo forced is needed here.

**Caveats:** Nitro charges the L1 data-posting fee as *extra gas inside the transaction's own limit*, so a large deploy consumes well above its raw code-deposit gas. The faucet is behind a bot challenge (`x-vercel-mitigated: challenge`) — fund via a Sepolia bridge deposit. The public RPC is rate-limited and explicitly not production-grade, so the indexer needs a paid provider. Treat any 46630 deployment as disposable: the reset policy is unpublished and the chain owner is a single EOA that can change `MaxCodeSize`.

## Files
- `deploy/config/arc-testnet.json`, `deploy/config/robinhood-testnet.json` — copied from `tempo.json`, with the constraints above recorded in `_note`.
- `foundry.toml` — `[rpc_endpoints]` + `[etherscan]` entries (both explorers are Blockscout and accept an empty key).
- `indexer/config.arc-testnet.yaml`, `indexer/config.robinhood-testnet.yaml`.

**Indexer configs ship with every `address: []` and `start_block: 0` on purpose** — nothing is deployed on either chain yet, and inheriting Tempo's addresses would silently index contracts that don't exist there. Both also drop Tempo's `field_selection` workaround, which exists only because Tempo's chain-native `0x76` transactions carry no `input` field; reth and Nitro both emit standard transactions.

## Verification
```bash
curl -s -X POST -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  https://rpc.testnet.arc.io                      # -> 0x4cef52 = 5042002
curl -s -X POST -H 'Content-Type: application/json' \
  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
  https://rpc.testnet.chain.robinhood.com         # -> 0xb626   = 46630
python3 -c "import tomllib;tomllib.load(open('foundry.toml','rb'))"   # valid TOML
```

## Not done here (deliberate)
No deploy was executed. Arc's 16.7M per-tx cap is **unmeasured against tnt-core** — that simulation is the gate before broadcasting, exactly as the 30M Tempo cap was. Robinhood needs bridge funding first.
