### PR TITLE
fix(fixtures): raise the code-size limit so fixture regeneration works again

### DIFF
--- a/script/sh/update-localtestnet-fixtures.sh
+++ b/script/sh/update-localtestnet-fixtures.sh
@@ -8,7 +8,14 @@ BROADCAST_PATH="${BROADCAST_PATH:-$FIXTURES_DIR/localtestnet-broadcast.json}"
 ANVIL_PORT="${ANVIL_PORT:-9545}"
 ANVIL_URL="http://127.0.0.1:${ANVIL_PORT}"
 KEEP_LOGS="${KEEP_FIXTURE_LOGS:-0}"
-export FOUNDRY_CODE_SIZE_LIMIT="${FOUNDRY_CODE_SIZE_LIMIT:-100000}"
+# LocalTestnetSetup deploys the whole protocol from one script, so its INITCODE
+# (not runtime code) is what anvil must accept -- currently ~595 KB and growing
+# with every facet. forge also enforces 2x this value as the initcode ceiling.
+# The previous 100000 default started rejecting the script with
+# "create initcode size limit", breaking fixture regeneration entirely.
+# This is a local test fixture, not a deployable target, so the limit only needs
+# to be comfortably above the script's own size.
+export FOUNDRY_CODE_SIZE_LIMIT="${FOUNDRY_CODE_SIZE_LIMIT:-1000000}"
 
 mkdir -p "$FIXTURES_DIR"
 TMP_STATE="$(mktemp -t anvil-state.XXXXXX.json)"


### PR DESCRIPTION
`script/sh/update-localtestnet-fixtures.sh` **cannot regenerate the Anvil fixtures at all** — it aborts with `create initcode size limit` before deploying anything.

## Cause
`LocalTestnetSetup` deploys the whole protocol from a single script, so what anvil must accept is **that script's initcode**, not any individual contract's runtime code. It's now ~595 KB and grows with every facet added. forge additionally enforces **2× the configured value** as the initcode ceiling, so the hardcoded `100000` default sits below the threshold and the run fails immediately.

## Fix
Default raised `100000` → `1000000`, with the reasoning recorded inline so the next person who hits a size error knows which limit is actually binding. This governs a **local test fixture, not a deployable target** — the value only needs to sit comfortably above the setup script's own size. `FOUNDRY_CODE_SIZE_LIMIT` still overrides it.

## How it surfaced
Regenerating the fixture for blueprint's tnt-core 0.19 migration ([tangle-network/blueprint#1483](https://github.com/tangle-network/blueprint/pull/1483)) required working around this by hand. That PR documents the workaround; the actual fix belongs here.

## Verification
```bash
bash -n script/sh/update-localtestnet-fixtures.sh   # syntax OK
```
One-line default change in a shell script; no contracts, no Solidity, no CI config touched.
